### PR TITLE
fix: suppress engram export stdout to prevent PS 5.1 pipeline pollution

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -199,7 +199,7 @@ function Initialize-SharedEngram {
                 if ($ProjectName) {
                     $exportArgs += @('--project', $ProjectName)
                 }
-                & $engramBin @exportArgs 2>$null
+                $null = & $engramBin @exportArgs 2>$null
                 if ($LASTEXITCODE -eq 0) {
                     $result.exported = $true
                     # Count exported observations


### PR DESCRIPTION
Fixes PropertyNotFoundException on .exported when running team-ai-kit init with engram installed. Same root cause as the previous Save-SkillManifest fix — PS 5.1 pipeline pollution.