### PR TITLE
fix: correct engram export syntax (positional arg, not flags)

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -195,20 +195,14 @@ function Initialize-SharedEngram {
         $engramBin = Get-EngramBinaryPath
         if ($engramBin) {
             try {
-                $exportArgs = @('export', '--format', 'json', '--output', (Join-Path $engramDir 'observations.json'))
-                if ($ProjectName) {
-                    $exportArgs += @('--project', $ProjectName)
-                }
-                $null = & $engramBin @exportArgs 2>$null
-                if ($LASTEXITCODE -eq 0) {
+                $exportFile = Join-Path $engramDir 'observations.json'
+                $null = & $engramBin export $exportFile 2>$null
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $exportFile)) {
                     $result.exported = $true
                     # Count exported observations
-                    $exportFile = Join-Path $engramDir 'observations.json'
-                    if (Test-Path $exportFile) {
-                        $content = Get-Content $exportFile -Raw | ConvertFrom-Json
-                        if ($content -is [array]) {
-                            $result.count = $content.Count
-                        }
+                    $content = Get-Content $exportFile -Raw | ConvertFrom-Json
+                    if ($content.observations -is [array]) {
+                        $result.count = $content.observations.Count
                     }
                 }
             }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -173,14 +173,10 @@ initialize_shared_engram() {
         engram_bin=$(get_engram_binary_path 2>/dev/null) || true
         if [[ -n "$engram_bin" ]]; then
             local export_file="$engram_dir/observations.json"
-            local export_args=("export" "--format" "json" "--output" "$export_file")
-            if [[ -n "$project_name" ]]; then
-                export_args+=("--project" "$project_name")
-            fi
-            if "$engram_bin" "${export_args[@]}" 2>/dev/null; then
+            if "$engram_bin" export "$export_file" 2>/dev/null; then
                 exported="true"
                 if [[ -f "$export_file" ]]; then
-                    count=$(jq 'if type == "array" then length else 0 end' "$export_file" 2>/dev/null || echo 0)
+                    count=$(jq '.observations | if type == "array" then length else 0 end' "$export_file" 2>/dev/null || echo 0)
                 fi
             fi
         fi


### PR DESCRIPTION
engram export takes a single positional argument (the output file), not --format/--output/--project flags. The wrong syntax caused a file named '--format' to be created in the project root.