### PR TITLE
fix(engram): filter exported observations by project name

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -199,8 +199,14 @@ function Initialize-SharedEngram {
                 $null = & $engramBin export $exportFile 2>$null
                 if ($LASTEXITCODE -eq 0 -and (Test-Path $exportFile)) {
                     $result.exported = $true
-                    # Count exported observations
                     $content = Get-Content $exportFile -Raw | ConvertFrom-Json
+
+                    # Filter observations by project name if provided
+                    if ($ProjectName -and $content.observations -is [array]) {
+                        $content.observations = @($content.observations | Where-Object { $_.project -eq $ProjectName })
+                        $content | ConvertTo-Json -Depth 10 | Set-Content $exportFile -Encoding UTF8
+                    }
+
                     if ($content.observations -is [array]) {
                         $result.count = $content.observations.Count
                     }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -176,6 +176,11 @@ initialize_shared_engram() {
             if "$engram_bin" export "$export_file" 2>/dev/null; then
                 exported="true"
                 if [[ -f "$export_file" ]]; then
+                    # Filter observations by project name if provided
+                    if [[ -n "$project_name" ]]; then
+                        jq --arg proj "$project_name" '.observations = [.observations[]? | select(.project == $proj)]' "$export_file" > "${export_file}.tmp" 2>/dev/null \
+                            && mv "${export_file}.tmp" "$export_file"
+                    fi
                     count=$(jq '.observations | if type == "array" then length else 0 end' "$export_file" 2>/dev/null || echo 0)
                 fi
             fi

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -786,6 +786,28 @@ Describe 'Save-SkillManifest' {
                         hash        = 'ABC123'
                         source      = 'default'
                         installedAt = '2026-04-14T00:00:00'
+                    }
+                }
+            }
+            $path = Save-SkillManifest -Manifest $manifest
+            Test-Path $path | Should -BeTrue
+        }
+        finally {
+            $env:USERPROFILE = $originalProfile
+        }
+    }
+
+    It 'manifest roundtrips through Save + Get' {
+        $originalProfile = $env:USERPROFILE
+        $env:USERPROFILE = $script:manifestTestDir
+        try {
+            $readBack = Get-SkillManifest
+            $readBack.files.Count | Should -Be 1
+            $readBack.files['team-skills\shared\architecture\SKILL.md'].hash | Should -Be 'ABC123'
+            $readBack.files['team-skills\shared\architecture\SKILL.md'].source | Should -Be 'default'
+        }
+        finally {
+            $env:USERPROFILE = $originalProfile
         }
     }
 }
@@ -869,6 +891,61 @@ Describe 'Initialize-SharedEngram' {
         $result.path | Should -Not -BeNullOrEmpty
         Test-Path $result.path | Should -BeTrue
     }
+
+    Context 'project filtering' {
+        BeforeAll {
+            $script:filterTestDir = Join-Path $TestDrive 'engram-filter-project'
+            New-Item -ItemType Directory -Path $script:filterTestDir -Force | Out-Null
+
+            # Create fake engram script that exports multi-project observations
+            $script:fakeEngram = Join-Path $TestDrive 'fake-engram.ps1'
+            @'
+param($Command, $OutputFile)
+if ($Command -eq 'export') {
+    @{
+        observations = @(
+            @{ project = 'my-project'; title = 'obs1'; content = 'data1' }
+            @{ project = 'other-project'; title = 'obs2'; content = 'data2' }
+            @{ project = 'my-project'; title = 'obs3'; content = 'data3' }
+        )
+        sessions = @()
+    } | ConvertTo-Json -Depth 5 | Set-Content -Path $OutputFile
+}
+'@ | Set-Content $script:fakeEngram
+
+            Mock Test-EngramInstalled { return $true }
+            Mock Get-EngramBinaryPath { return $script:fakeEngram }
+        }
+
+        It 'filters observations to matching project only' {
+            $result = Initialize-SharedEngram -ProjectRoot $script:filterTestDir -ProjectName 'my-project'
+            $result.exported | Should -BeTrue
+            $result.count | Should -Be 2
+
+            $exportFile = Join-Path $script:filterTestDir 'shared-engram\observations.json'
+            $content = Get-Content $exportFile -Raw | ConvertFrom-Json
+            $content.observations.Count | Should -Be 2
+            $content.observations | ForEach-Object { $_.project | Should -Be 'my-project' }
+        }
+
+        It 'exports all observations when no ProjectName is provided' {
+            $noFilterDir = Join-Path $TestDrive 'engram-no-filter'
+            New-Item -ItemType Directory -Path $noFilterDir -Force | Out-Null
+
+            $result = Initialize-SharedEngram -ProjectRoot $noFilterDir
+            $result.exported | Should -BeTrue
+            $result.count | Should -Be 3
+        }
+
+        It 'returns count 0 when no observations match project' {
+            $noMatchDir = Join-Path $TestDrive 'engram-no-match'
+            New-Item -ItemType Directory -Path $noMatchDir -Force | Out-Null
+
+            $result = Initialize-SharedEngram -ProjectRoot $noMatchDir -ProjectName 'nonexistent-project'
+            $result.exported | Should -BeTrue
+            $result.count | Should -Be 0
+        }
+    }
 }
 
 Describe 'New-InitSummary' {
@@ -898,28 +975,6 @@ Describe 'Test-ValidCommand includes init' {
         Test-ValidCommand -Command 'status' | Should -BeTrue
         Test-ValidCommand -Command 'doctor' | Should -BeTrue
         Test-ValidCommand -Command 'help' | Should -BeTrue
-    }
-}
-            $path = Save-SkillManifest -Manifest $manifest
-            Test-Path $path | Should -BeTrue
-        }
-        finally {
-            $env:USERPROFILE = $originalProfile
-        }
-    }
-
-    It 'manifest roundtrips through Save + Get' {
-        $originalProfile = $env:USERPROFILE
-        $env:USERPROFILE = $script:manifestTestDir
-        try {
-            $readBack = Get-SkillManifest
-            $readBack.files.Count | Should -Be 1
-            $readBack.files['team-skills\shared\architecture\SKILL.md'].hash | Should -Be 'ABC123'
-            $readBack.files['team-skills\shared\architecture\SKILL.md'].source | Should -Be 'default'
-        }
-        finally {
-            $env:USERPROFILE = $originalProfile
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Filter engram export observations by project name to prevent cross-project knowledge leakage
- Fix pre-existing `Save-SkillManifest` test with broken brace structure that silently skipped 15 tests

Closes #7

## PR Type
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | After engram export, filter `.observations` by `` and rewrite JSON |
| `lib/functions.sh` | Same filter using `jq select(.project == )` |
| `tests/functions.Tests.ps1` | Add 3 project filtering tests + fix Save-SkillManifest broken braces (15 tests unblocked) |

## Test Plan
- [x] 123 Pester tests pass (was 107 passed + 15 NotRun)
- [x] Project filtering: filters to matching project, exports all when no name, returns 0 on no match
- [x] Save-SkillManifest tests now run and pass (previously blocked by broken braces)

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added `type:bug` label
- [x] Scripts tested
- [x] Conventional commit format
- [x] No Co-Authored-By trailers