### PR TITLE
chore(scoop): sync local manifest to v2.0.3

### DIFF
--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -1,11 +1,11 @@
 {
-    "version": "2.0.1",
+    "version": "2.0.3",
     "description": "Team AI Kit - gentle-ai for teams. Standardizes AI usage across development teams with role-based skills, shared memory, and zero-friction onboarding.",
     "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
     "license": "MIT",
-    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.0.1/team-ai-kit-2.0.1.zip",
-    "hash": "F3FE6A8711716D1B06E13F2E52B6BC930CE72D00CCDAB0DCAE143ADD32E6E39E",
-    "extract_dir": "team-ai-kit-2.0.1",
+    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.0.3/team-ai-kit-2.0.3.zip",
+    "hash": "E2E4471D97AAD328E473CDC0F829DFC9E42E421135D75FB08D54F7B0D598FC1E",
+    "extract_dir": "team-ai-kit-2.0.3",
     "bin": [
         ["bin\\team-ai-kit.ps1", "team-ai-kit"]
     ],


### PR DESCRIPTION
## Summary
- Sync local `scoop/team-ai-kit.json` manifest from v2.0.1 to v2.0.3 (version, URL, hash, extract_dir)

Closes #10

## PR Type
- [x] Maintenance/tooling

## Changes

| File | Change |
|------|--------|
| `scoop/team-ai-kit.json` | Update version, URL, hash, extract_dir to v2.0.3 |

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added `type:chore` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers