### PR TITLE
fix(engram): extend project filter to sessions and prompts

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -201,9 +201,17 @@ function Initialize-SharedEngram {
                     $result.exported = $true
                     $content = Get-Content $exportFile -Raw | ConvertFrom-Json
 
-                    # Filter observations by project name if provided
-                    if ($ProjectName -and $content.observations -is [array]) {
-                        $content.observations = @($content.observations | Where-Object { $_.project -eq $ProjectName })
+                    # Filter all sections by project name if provided
+                    if ($ProjectName) {
+                        if ($content.observations -is [array]) {
+                            $content.observations = @($content.observations | Where-Object { $_.project -eq $ProjectName })
+                        }
+                        if ($content.sessions -is [array]) {
+                            $content.sessions = @($content.sessions | Where-Object { $_.project -eq $ProjectName })
+                        }
+                        if ($content.prompts -is [array]) {
+                            $content.prompts = @($content.prompts | Where-Object { $_.project -eq $ProjectName })
+                        }
                         $content | ConvertTo-Json -Depth 10 | Set-Content $exportFile -Encoding UTF8
                     }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -176,9 +176,13 @@ initialize_shared_engram() {
             if "$engram_bin" export "$export_file" 2>/dev/null; then
                 exported="true"
                 if [[ -f "$export_file" ]]; then
-                    # Filter observations by project name if provided
+                    # Filter all sections by project name if provided
                     if [[ -n "$project_name" ]]; then
-                        jq --arg proj "$project_name" '.observations = [.observations[]? | select(.project == $proj)]' "$export_file" > "${export_file}.tmp" 2>/dev/null \
+                        jq --arg proj "$project_name" '
+                            .observations = [.observations[]? | select(.project == $proj)] |
+                            .sessions = [.sessions[]? | select(.project == $proj)] |
+                            .prompts = [.prompts[]? | select(.project == $proj)]
+                        ' "$export_file" > "${export_file}.tmp" 2>/dev/null \
                             && mv "${export_file}.tmp" "$export_file"
                     fi
                     count=$(jq '.observations | if type == "array" then length else 0 end' "$export_file" 2>/dev/null || echo 0)

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -897,7 +897,7 @@ Describe 'Initialize-SharedEngram' {
             $script:filterTestDir = Join-Path $TestDrive 'engram-filter-project'
             New-Item -ItemType Directory -Path $script:filterTestDir -Force | Out-Null
 
-            # Create fake engram script that exports multi-project observations
+            # Create fake engram script that exports multi-project data
             $script:fakeEngram = Join-Path $TestDrive 'fake-engram.ps1'
             @'
 param($Command, $OutputFile)
@@ -908,7 +908,15 @@ if ($Command -eq 'export') {
             @{ project = 'other-project'; title = 'obs2'; content = 'data2' }
             @{ project = 'my-project'; title = 'obs3'; content = 'data3' }
         )
-        sessions = @()
+        sessions = @(
+            @{ project = 'my-project'; id = 'ses-1' }
+            @{ project = 'other-project'; id = 'ses-2' }
+        )
+        prompts = @(
+            @{ project = 'my-project'; content = 'prompt1' }
+            @{ project = 'other-project'; content = 'prompt2' }
+            @{ project = 'my-project'; content = 'prompt3' }
+        )
     } | ConvertTo-Json -Depth 5 | Set-Content -Path $OutputFile
 }
 '@ | Set-Content $script:fakeEngram
@@ -926,6 +934,15 @@ if ($Command -eq 'export') {
             $content = Get-Content $exportFile -Raw | ConvertFrom-Json
             $content.observations.Count | Should -Be 2
             $content.observations | ForEach-Object { $_.project | Should -Be 'my-project' }
+        }
+
+        It 'filters sessions and prompts by project too' {
+            $exportFile = Join-Path $script:filterTestDir 'shared-engram\observations.json'
+            $content = Get-Content $exportFile -Raw | ConvertFrom-Json
+            $content.sessions.Count | Should -Be 1
+            $content.sessions[0].project | Should -Be 'my-project'
+            $content.prompts.Count | Should -Be 2
+            $content.prompts | ForEach-Object { $_.project | Should -Be 'my-project' }
         }
 
         It 'exports all observations when no ProjectName is provided' {


### PR DESCRIPTION
## Summary
- Extend engram export project filter to also cover `.sessions` and `.prompts` (v2.0.3 only filtered `.observations`)

Closes #11

## PR Type
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | Filter `.sessions` and `.prompts` by ProjectName alongside observations |
| `lib/functions.sh` | Same filter via jq for sessions and prompts |
| `tests/functions.Tests.ps1` | Add multi-project sessions/prompts to fake engram + new test asserting they get filtered |

## Test Plan
- [x] 124 Pester tests pass, 0 failed, 0 NotRun
- [x] New test verifies sessions and prompts are filtered by project

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added `type:bug` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers