### PR TITLE
chore(scoop): update hash for rebuilt v2.1.0 zip

### DIFF
--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
     "license": "MIT",
     "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.1.0/team-ai-kit-2.1.0.zip",
-    "hash": "A947274D9F0D96C72C7FAA660F538C34F0E928365814F5D643CCDE2BDE9D844B",
+    "hash": "DAAA67F47EB1A13C92337426E65B5AD5512FD2C8D03931B3FB7AECA81352D811",
     "extract_dir": "team-ai-kit-2.1.0",
     "bin": [
         ["bin\\team-ai-kit.ps1", "team-ai-kit"]


### PR DESCRIPTION
Closes #17

## PR Type
- [x] Maintenance/tooling

## Summary
- Update SHA256 hash in scoop manifest after rebuilding v2.1.0 release zip with all judgment day fixes

## Changes

| File | Change |
|------|--------|
| `scoop/team-ai-kit.json` | Updated hash from old zip to new zip containing all fixes |

## Test Plan
- [x] Hash verified against uploaded zip asset

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers