### PR TITLE
docs: add prerequisite install instructions for Scoop, Homebrew, and jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ gentle-ai es para el dev individual. Team AI Kit agrega lo que falta para equipo
 ### Windows (Scoop)
 
 ```powershell
+# Instalar Scoop (si no lo tenes): https://scoop.sh
+irm get.scoop.sh | iex
+
+# Instalar team-ai-kit
 scoop bucket add team-ai-kit https://github.com/lazarogadiel93/scoop-bucket
 scoop install team-ai-kit
 team-ai-kit setup
@@ -29,7 +33,14 @@ team-ai-kit setup
 ### macOS / Linux
 
 ```bash
-# Requisito: jq (brew install jq / apt install jq)
+# Instalar Homebrew (si no lo tenes): https://brew.sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Instalar jq (requerido)
+brew install jq        # macOS
+# sudo apt install jq  # Debian/Ubuntu
+
+# Instalar team-ai-kit
 git clone https://github.com/lazarogadiel93/team-ai-kit
 cd team-ai-kit
 ./setup.sh

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -32,6 +32,10 @@
 ### Windows (Scoop)
 
 ```powershell
+# Instalar Scoop (si no lo tenes): https://scoop.sh
+irm get.scoop.sh | iex
+
+# Instalar team-ai-kit
 scoop bucket add team-ai-kit https://github.com/lazarogadiel93/scoop-bucket
 scoop install team-ai-kit
 ```
@@ -39,6 +43,14 @@ scoop install team-ai-kit
 ### macOS / Linux (o Windows sin Scoop)
 
 ```bash
+# Instalar Homebrew (si no lo tenes): https://brew.sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Instalar jq (requerido)
+brew install jq        # macOS
+# sudo apt install jq  # Debian/Ubuntu
+
+# Clonar team-ai-kit
 git clone https://github.com/lazarogadiel93/team-ai-kit
 cd team-ai-kit
 ```


### PR DESCRIPTION
Closes #20

## PR Type
- [x] Documentation only

## Summary
- Add Scoop install one-liner for Windows users who don't have it
- Add Homebrew install one-liner for macOS users who don't have it
- Add jq install commands with both brew and apt options
- Updated in both README.md and docs/onboarding.md

## Changes

| File | Change |
|------|--------|
| `README.md` | Added Scoop + Homebrew + jq install commands before tool-specific steps |
| `docs/onboarding.md` | Same prerequisite instructions added to Paso 1 |

## Contributor Checklist
- [x] Linked an approved issue (Closes #20)
- [x] Added exactly one `type:*` label (type:docs)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers