### PR TITLE
docs: use full PowerShell cmdlet names for Scoop install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ gentle-ai es para el dev individual. Team AI Kit agrega lo que falta para equipo
 
 ```powershell
 # Instalar Scoop (si no lo tenes): https://scoop.sh
-irm get.scoop.sh | iex
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
 
 # Instalar team-ai-kit
 scoop bucket add team-ai-kit https://github.com/lazarogadiel93/scoop-bucket

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -33,7 +33,8 @@
 
 ```powershell
 # Instalar Scoop (si no lo tenes): https://scoop.sh
-irm get.scoop.sh | iex
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
 
 # Instalar team-ai-kit
 scoop bucket add team-ai-kit https://github.com/lazarogadiel93/scoop-bucket


### PR DESCRIPTION
Closes #20

## PR Type
- [x] Documentation only

## Summary
- Replace `irm get.scoop.sh | iex` with full cmdlet names (`Invoke-RestMethod` / `Invoke-Expression`) so it works even if PS aliases are unavailable
- Add `Set-ExecutionPolicy` step (required for Scoop on fresh Windows installs)

## Changes

| File | Change |
|------|--------|
| `README.md` | Full cmdlet names + execution policy for Scoop install |
| `docs/onboarding.md` | Same |

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label (type:docs)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers