### PR TITLE
fix(setup): handle PowerShell Constrained Language Mode in direct download fallback

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -143,8 +143,7 @@ function Invoke-SetupCommand {
     if (-not $SkipPrerequisites) {
         Write-Host '  [1/5] Checking prerequisites...' -ForegroundColor White
 
-        # Ensure TLS 1.2 for GitHub API (required on PS 5.1)
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Set-TlsProtocol
 
         # -- gentle-ai --
         if (Test-GentleAiInstalled) {

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -447,6 +447,19 @@ function Get-PlatformArchitecture {
     return @{ os = 'windows'; arch = $arch }
 }
 
+function Set-TlsProtocol {
+    <#
+    .SYNOPSIS
+        Ensures TLS 1.2 for .NET HTTP requests (safety net for PS 5.1).
+    .DESCRIPTION
+        Wrapped in try/catch because Constrained Language Mode (CLM) blocks
+        .NET property setting. Modern Windows 10+ already defaults to TLS 1.2,
+        so this is safe to skip in CLM environments.
+    #>
+    try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 }
+    catch { <# CLM blocks .NET property access -- safe to continue on Win10+ #> }
+}
+
 function Get-GithubLatestReleaseAssetUrl {
     <#
     .SYNOPSIS
@@ -462,7 +475,7 @@ function Get-GithubLatestReleaseAssetUrl {
         [Parameter(Mandatory)]
         [string]$AssetPattern
     )
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Set-TlsProtocol
     $apiUrl = "https://api.github.com/repos/$Owner/$Repo/releases/latest"
     $headers = @{ 'User-Agent' = 'team-ai-kit' }
     if ($env:GITHUB_TOKEN) {
@@ -524,7 +537,6 @@ function Install-GithubReleaseBinary {
     $tempExtract = Join-Path $env:TEMP "$Repo-extract-$(Get-Random)"
 
     try {
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         Invoke-WebRequest -Uri $release.url -OutFile $tempZip -UseBasicParsing
 
         if (Test-Path $tempExtract) { Remove-Item -Recurse -Force $tempExtract }
@@ -573,11 +585,23 @@ function Add-ToUserPath {
     }
 
     # Add to persistent user PATH (exact element match, not substring)
-    $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    try {
+        $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    }
+    catch {
+        # CLM blocks .NET static methods -- fall back to registry
+        $userPath = (Get-ItemProperty -Path 'HKCU:\Environment' -Name Path -ErrorAction SilentlyContinue).Path
+    }
     $userElements = if ($userPath) { $userPath -split ';' | Where-Object { $_ -ne '' } } else { @() }
     if (-not $userPath -or $userElements -notcontains $Directory) {
         $newPath = if ($userPath) { "$Directory;$userPath" } else { $Directory }
-        [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+        try {
+            [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+        }
+        catch {
+            # CLM blocks .NET static methods -- fall back to registry (ExpandString = REG_EXPAND_SZ)
+            New-ItemProperty -Path 'HKCU:\Environment' -Name Path -Value $newPath -PropertyType ExpandString -Force | Out-Null
+        }
         return $true
     }
     return $false


### PR DESCRIPTION
## Summary
- Fixes Issue #28: direct download fallback crashes on corporate PCs with PowerShell Constrained Language Mode (CLM)
- Extracts `Set-TlsProtocol` helper (DRY) with try/catch for CLM compatibility
- Wraps `[Environment]::` calls in `Add-ToUserPath` with registry cmdlet fallback (`HKCU:\Environment`, REG_EXPAND_SZ)
- Removes redundant TLS set in `Install-GithubReleaseBinary`

## Judgment Day
- Round 1: 1 CRITICAL (`[Environment]::` blocked by CLM) + DRY → fixed
- Round 2: 1 WARNING real (REG_SZ vs REG_EXPAND_SZ) → fixed inline
- APPROVED after Round 2. 169 tests green.

Closes #28