### PR TITLE
feat: add Cursor IDE support

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -14,7 +14,7 @@
 #   help     Show this help message
 #
 # Setup options:
-#   --ide <vscode|intellij|opencode>
+#   --ide <vscode|intellij|opencode|cursor>
 #   --role <frontend|backend-node|devops|python>
 #   --provider <openai|azure-openai|anthropic|github-copilot>
 #   --team-repo <url>         Team content repo URL
@@ -90,7 +90,7 @@ show_help() {
     echo "    help     Show this help message"
     echo ""
     echo -e "  ${C_YELLOW}Setup options:${C_RESET}"
-    echo "    --ide <vscode|intellij|opencode>"
+    echo "    --ide <vscode|intellij|opencode|cursor>"
     echo "    --role <frontend|backend-node|devops|python>"
     echo "    --provider <openai|azure-openai|anthropic|github-copilot>"
     echo "    --team-repo <url>          Team content repo URL"
@@ -211,14 +211,16 @@ cmd_setup() {
         echo "    1) VS Code + Copilot"
         echo "    2) IntelliJ + Copilot"
         echo "    3) OpenCode (CLI)"
+        echo "    4) Cursor"
         echo ""
         while true; do
-            read -rp "  Your IDE (1-3): " ide_choice
+            read -rp "  Your IDE (1-4): " ide_choice
             case "$ide_choice" in
                 1) OPT_IDE="vscode"; break ;;
                 2) OPT_IDE="intellij"; break ;;
                 3) OPT_IDE="opencode"; break ;;
-                *) echo "  Invalid choice. Enter 1, 2, or 3." ;;
+                4) OPT_IDE="cursor"; break ;;
+                *) echo "  Invalid choice. Enter 1, 2, 3, or 4." ;;
             esac
         done
     fi
@@ -249,7 +251,7 @@ cmd_setup() {
 
     # Provider: auto-detect for Copilot IDEs, ask only for OpenCode
     if [[ -z "$OPT_PROVIDER" ]]; then
-        if [[ "$OPT_IDE" == "vscode" || "$OPT_IDE" == "intellij" ]]; then
+        if [[ "$OPT_IDE" == "vscode" || "$OPT_IDE" == "intellij" || "$OPT_IDE" == "cursor" ]]; then
             OPT_PROVIDER="github-copilot"
             ok "Provider: $OPT_PROVIDER (auto-detected from IDE)"
         else
@@ -297,8 +299,10 @@ cmd_setup() {
     elif [[ "$SKIP_GENTLE_AI" == "true" ]]; then
         step "Skipping gentle-ai install (--skip-gentle-ai)"
     else
-        # IntelliJ: no gentle-ai adapter
-        step "IntelliJ + Copilot: no gentle-ai adapter available"
+        # IntelliJ/Cursor: no gentle-ai adapter
+        local ide_name
+        if [[ "$OPT_IDE" == "cursor" ]]; then ide_name="Cursor"; else ide_name="IntelliJ + Copilot"; fi
+        step "$ide_name: no gentle-ai adapter available"
         step "Setting up MCP config from template..."
 
         local template_dir=""
@@ -311,12 +315,16 @@ cmd_setup() {
             if [[ -n "$OPT_TARGET_DIR" ]]; then
                 local tpl_target="$OPT_TARGET_DIR/ide-config"
                 install_templates "$template_dir" "$tpl_target" "ENGRAM_BINARY_PATH=$engram_bin"
-                ok "IntelliJ config files generated"
+                ok "$ide_name config files generated"
             else
                 local mcp_json
-                mcp_json=$(new_vscode_mcp_config "$engram_bin")
-                ok "MCP config generated for IntelliJ"
-                step "Add this to your IntelliJ MCP settings:"
+                if [[ "$OPT_IDE" == "cursor" ]]; then
+                    mcp_json=$(new_cursor_mcp_config "$engram_bin")
+                else
+                    mcp_json=$(new_vscode_mcp_config "$engram_bin")
+                fi
+                ok "MCP config generated for $ide_name"
+                step "Add this to your $ide_name MCP settings:"
                 echo ""
                 echo -e "  ${C_DIM}$mcp_json${C_RESET}"
                 echo ""
@@ -402,11 +410,13 @@ cmd_setup() {
         echo -e "    ${C_WHITE}1. Go to your project and run: team-ai-kit init${C_RESET}"
         echo -e "    ${C_DIM}   (configures instructions, engram sync, and git hooks for the project)${C_RESET}"
         echo -e "    ${C_WHITE}2. Open your IDE and start working!${C_RESET}"
-    elif [[ "$OPT_IDE" == "intellij" ]]; then
-        echo -e "    ${C_WHITE}1. Add the MCP config shown above to IntelliJ settings${C_RESET}"
+    elif [[ "$OPT_IDE" == "intellij" || "$OPT_IDE" == "cursor" ]]; then
+        echo -e "    ${C_WHITE}1. Add the MCP config shown above to your IDE settings${C_RESET}"
         echo -e "    ${C_WHITE}2. Go to your project and run: team-ai-kit init${C_RESET}"
         echo -e "    ${C_DIM}   (configures instructions, engram sync, and git hooks for the project)${C_RESET}"
-        echo -e "    ${C_WHITE}3. Open IntelliJ and start working!${C_RESET}"
+        local open_ide_name
+        if [[ "$OPT_IDE" == "cursor" ]]; then open_ide_name="Cursor"; else open_ide_name="IntelliJ"; fi
+        echo -e "    ${C_WHITE}3. Open $open_ide_name and start working!${C_RESET}"
     else
         echo -e "    ${C_WHITE}1. Run gentle-ai to complete agent configuration${C_RESET}"
         echo -e "    ${C_WHITE}2. Go to your project and run: team-ai-kit init${C_RESET}"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -48,7 +48,7 @@ param(
     [Parameter(Position = 0)]
     [string]$Command = 'help',
 
-    [ValidateSet('vscode', 'intellij', 'opencode')]
+    [ValidateSet('vscode', 'intellij', 'opencode', 'cursor')]
     [string]$Ide,
 
     [ValidateSet('frontend', 'backend-node', 'devops', 'python')]
@@ -109,7 +109,7 @@ function Show-Help {
     Write-Host '    help     Show this help message'
     Write-Host ''
     Write-Host '  Setup options:' -ForegroundColor Yellow
-    Write-Host '    -Ide <vscode|intellij|opencode>'
+    Write-Host '    -Ide <vscode|intellij|opencode|cursor>'
     Write-Host '    -Role <frontend|backend-node|devops|python>'
     Write-Host '    -Provider <openai|azure-openai|anthropic|github-copilot>'
     Write-Host '    -TeamRepo <url>          Team content repo URL'
@@ -235,16 +235,18 @@ function Invoke-SetupCommand {
         Write-Host '    1) VS Code + Copilot'
         Write-Host '    2) IntelliJ + Copilot'
         Write-Host '    3) OpenCode (CLI)'
+        Write-Host '    4) Cursor'
         Write-Host ''
 
         do {
-            $ideChoice = Read-Host '  Your IDE (1-3)'
-        } while ($ideChoice -notin @('1', '2', '3'))
+            $ideChoice = Read-Host '  Your IDE (1-4)'
+        } while ($ideChoice -notin @('1', '2', '3', '4'))
 
         $script:Ide = switch ($ideChoice) {
             '1' { 'vscode' }
             '2' { 'intellij' }
             '3' { 'opencode' }
+            '4' { 'cursor' }
         }
     }
 
@@ -277,7 +279,7 @@ function Invoke-SetupCommand {
 
     # Provider: auto-detect for Copilot IDEs, ask only for OpenCode
     if (-not $Provider) {
-        if ($Ide -eq 'vscode' -or $Ide -eq 'intellij') {
+        if ($Ide -eq 'vscode' -or $Ide -eq 'intellij' -or $Ide -eq 'cursor') {
             $script:Provider = 'github-copilot'
             Write-Ok "Provider: $Provider (auto-detected from IDE)"
         }
@@ -337,8 +339,9 @@ function Invoke-SetupCommand {
         Write-Step 'Skipping gentle-ai install (SkipGentleAi flag)'
     }
     else {
-        # IntelliJ: no gentle-ai adapter
-        Write-Step 'IntelliJ + Copilot: no gentle-ai adapter available'
+        # IntelliJ/Cursor: no gentle-ai adapter
+        $ideName = if ($Ide -eq 'cursor') { 'Cursor' } else { 'IntelliJ + Copilot' }
+        Write-Step "$ideName`: no gentle-ai adapter available"
         Write-Step 'Setting up MCP config from template...'
 
         $templateDir = Get-TemplateDirectory -KitRoot $kitRoot -Ide $Ide
@@ -351,14 +354,22 @@ function Invoke-SetupCommand {
             $templateTargetDir = if ($TargetDir) { Join-Path $TargetDir 'ide-config' } else { $null }
             if ($templateTargetDir) {
                 $createdTemplates = @(Install-Templates -TemplateDir $templateDir -TargetDir $templateTargetDir -Variables $templateVars)
-                Write-Ok "$($createdTemplates.Count) IntelliJ config files generated"
+                Write-Ok "$($createdTemplates.Count) $ideName config files generated"
             }
             else {
                 # Show MCP config for manual setup
                 $engramPath = if ($engramBin) { $engramBin } else { '(path-to-engram)' }
-                $mcpJson = New-VsCodeMcpConfig -EngramBinaryPath $engramPath
-                Write-Ok 'MCP config generated for IntelliJ'
-                Write-Step 'Add this to your IntelliJ MCP settings:'
+                if ($Ide -eq 'cursor') {
+                    $mcpJson = New-CursorMcpConfig -EngramBinaryPath $engramPath
+                }
+                elseif ($Ide -eq 'intellij') {
+                    $mcpJson = New-IntelliJMcpConfig -EngramBinaryPath $engramPath
+                }
+                else {
+                    $mcpJson = New-VsCodeMcpConfig -EngramBinaryPath $engramPath
+                }
+                Write-Ok "MCP config generated for $ideName"
+                Write-Step "Add this to your $ideName MCP settings:"
                 Write-Host ''
                 Write-Host $mcpJson -ForegroundColor DarkGray
                 Write-Host ''
@@ -444,11 +455,11 @@ function Invoke-SetupCommand {
         Write-Host '       (configures instructions, engram sync, and git hooks for the project)' -ForegroundColor DarkGray
         Write-Host '    2. Open your IDE and start working!' -ForegroundColor White
     }
-    elseif ($Ide -eq 'intellij') {
-        Write-Host '    1. Add the MCP config shown above to IntelliJ settings' -ForegroundColor White
+    elseif ($Ide -eq 'intellij' -or $Ide -eq 'cursor') {
+        Write-Host '    1. Add the MCP config shown above to your IDE settings' -ForegroundColor White
         Write-Host '    2. Go to your project and run: team-ai-kit init' -ForegroundColor White
         Write-Host '       (configures instructions, engram sync, and git hooks for the project)' -ForegroundColor DarkGray
-        Write-Host '    3. Open IntelliJ and start working!' -ForegroundColor White
+        Write-Host '    3. Open your IDE and start working!' -ForegroundColor White
     }
     else {
         Write-Host '    1. Run gentle-ai to complete agent configuration' -ForegroundColor White

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -10,7 +10,7 @@ Set-StrictMode -Version Latest
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
-$script:VALID_IDES = @('vscode', 'intellij', 'opencode')
+$script:VALID_IDES = @('vscode', 'intellij', 'opencode', 'cursor')
 $script:VALID_ROLES = @('frontend', 'backend-node', 'devops', 'python')
 $script:VALID_PROVIDERS = @('openai', 'azure-openai', 'anthropic', 'github-copilot')
 $script:VALID_COMMANDS = @('setup', 'init', 'sync', 'update', 'status', 'doctor', 'help')
@@ -872,6 +872,10 @@ function Get-IdeSkillsDirectory {
             # OpenCode: gentle-ai installs skills here
             return Join-Path $env:USERPROFILE '.config\opencode\skills'
         }
+        'cursor' {
+            # Cursor: user-level skills directory
+            return Join-Path $env:USERPROFILE '.cursor\skills'
+        }
         default {
             throw "Unsupported IDE: $Ide"
         }
@@ -898,6 +902,9 @@ function Get-IdeInstructionsPath {
         }
         'opencode' {
             return Join-Path $ProjectRoot 'AGENTS.md'
+        }
+        'cursor' {
+            return Join-Path $ProjectRoot '.cursor\rules\team-ai-kit.md'
         }
         default {
             throw "Unsupported IDE: $Ide"
@@ -1318,6 +1325,30 @@ function New-IntelliJMcpConfig {
     return New-VsCodeMcpConfig -EngramBinaryPath $EngramBinaryPath
 }
 
+function New-CursorMcpConfig {
+    <#
+    .SYNOPSIS
+        Generates the MCP config JSON for Cursor (.cursor/mcp.json).
+        Cursor requires mcpServers as the top-level key (not servers).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$EngramBinaryPath
+    )
+    $config = @{
+        mcpServers = @{
+            engram = @{
+                command = $EngramBinaryPath
+                args    = @('mcp', '--tools=agent')
+            }
+            context7 = @{
+                url = 'https://mcp.context7.com/mcp'
+            }
+        }
+    }
+    return $config | ConvertTo-Json -Depth 5
+}
+
 # ── Instructions Generation ───────────────────────────────────────────────────
 
 function New-CopilotInstructions {
@@ -1371,6 +1402,7 @@ function Get-TemplateDirectory {
         'vscode'   = 'vscode-copilot'
         'intellij' = 'intellij-copilot'
         'opencode' = 'opencode'
+        'cursor'   = 'cursor'
     }
     $dirName = $ideDirMap[$Ide.ToLower()]
     if (-not $dirName) { throw "Unsupported IDE: $Ide" }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 # -- Constants -----------------------------------------------------------------
 
-VALID_IDES=("vscode" "intellij" "opencode")
+VALID_IDES=("vscode" "intellij" "opencode" "cursor")
 VALID_ROLES=("frontend" "backend-node" "devops" "python")
 VALID_PROVIDERS=("openai" "azure-openai" "anthropic" "github-copilot")
 VALID_COMMANDS=("setup" "init" "sync" "update" "status" "doctor" "help")
@@ -640,6 +640,7 @@ get_ide_skills_directory() {
         vscode)   echo "$HOME/.copilot/skills" ;;
         intellij) echo "$HOME/.copilot/skills" ;;
         opencode) echo "$HOME/.config/opencode/skills" ;;
+        cursor)   echo "$HOME/.cursor/skills" ;;
         *)        echo "ERROR: Unsupported IDE: $1" >&2; return 1 ;;
     esac
 }
@@ -651,6 +652,7 @@ get_ide_instructions_path() {
         vscode)   echo "$project_root/.github/copilot-instructions.md" ;;
         intellij) echo "$project_root/.github/copilot-instructions.md" ;;
         opencode) echo "$project_root/AGENTS.md" ;;
+        cursor)   echo "$project_root/.cursor/rules/team-ai-kit.md" ;;
         *)        echo "ERROR: Unsupported IDE: $1" >&2; return 1 ;;
     esac
 }
@@ -930,6 +932,21 @@ new_vscode_mcp_config() {
     }'
 }
 
+new_cursor_mcp_config() {
+    local engram_path="$1"
+    jq -n --arg engram "$engram_path" '{
+        mcpServers: {
+            engram: {
+                command: $engram,
+                args: ["mcp", "--tools=agent"]
+            },
+            context7: {
+                url: "https://mcp.context7.com/mcp"
+            }
+        }
+    }'
+}
+
 # -- Instructions Generation ---------------------------------------------------
 
 new_copilot_instructions() {
@@ -968,6 +985,7 @@ get_template_directory() {
         vscode)   dir_name="vscode-copilot" ;;
         intellij) dir_name="intellij-copilot" ;;
         opencode) dir_name="opencode" ;;
+        cursor)   dir_name="cursor" ;;
         *)        echo "ERROR: Unsupported IDE: $2" >&2; return 1 ;;
     esac
     local template_dir="$kit_root/templates/$dir_name"

--- a/setup.ps1
+++ b/setup.ps1
@@ -16,7 +16,7 @@
 #>
 
 param(
-    [ValidateSet('vscode', 'intellij', 'opencode')]
+    [ValidateSet('vscode', 'intellij', 'opencode', 'cursor')]
     [string]$Ide,
 
     [ValidateSet('frontend', 'backend-node', 'devops', 'python')]

--- a/templates/cursor/mcp.json.template
+++ b/templates/cursor/mcp.json.template
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "engram": {
+      "command": "{{ENGRAM_BINARY_PATH}}",
+      "args": ["mcp", "--tools=agent"]
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -28,6 +28,10 @@ Describe 'Get-GentleAiAgentId' {
         Get-GentleAiAgentId -Ide 'intellij' | Should -BeNullOrEmpty
     }
 
+    It 'returns $null for cursor (no gentle-ai adapter)' {
+        Get-GentleAiAgentId -Ide 'cursor' | Should -BeNullOrEmpty
+    }
+
     It 'returns $null for unknown IDEs' {
         Get-GentleAiAgentId -Ide 'vim' | Should -BeNullOrEmpty
     }
@@ -51,6 +55,10 @@ Describe 'Test-GentleAiSupportsIde' {
         Test-GentleAiSupportsIde -Ide 'intellij' | Should -BeFalse
     }
 
+    It 'returns $false for cursor' {
+        Test-GentleAiSupportsIde -Ide 'cursor' | Should -BeFalse
+    }
+
     It 'returns $false for unknown IDEs' {
         Test-GentleAiSupportsIde -Ide 'vim' | Should -BeFalse
     }
@@ -63,6 +71,7 @@ Describe 'Test-ValidIde' {
         Test-ValidIde -Ide 'vscode' | Should -BeTrue
         Test-ValidIde -Ide 'intellij' | Should -BeTrue
         Test-ValidIde -Ide 'opencode' | Should -BeTrue
+        Test-ValidIde -Ide 'cursor' | Should -BeTrue
     }
 
     It 'is case-insensitive' {
@@ -269,6 +278,11 @@ Describe 'Get-IdeSkillsDirectory' {
         $path | Should -BeLike '*opencode*skills*'
     }
 
+    It 'returns .cursor/skills path for cursor' {
+        $path = Get-IdeSkillsDirectory -Ide 'cursor'
+        $path | Should -BeLike '*.cursor?skills*'
+    }
+
     It 'throws for unsupported IDE' {
         { Get-IdeSkillsDirectory -Ide 'vim' } | Should -Throw '*Unsupported IDE*'
     }
@@ -288,6 +302,11 @@ Describe 'Get-IdeInstructionsPath' {
     It 'returns AGENTS.md for opencode' {
         $path = Get-IdeInstructionsPath -Ide 'opencode' -ProjectRoot 'C:\project'
         $path | Should -BeLike '*AGENTS.md'
+    }
+
+    It 'returns .cursor/rules/team-ai-kit.md for cursor' {
+        $path = Get-IdeInstructionsPath -Ide 'cursor' -ProjectRoot 'C:\project'
+        $path | Should -BeLike '*.cursor?rules?team-ai-kit.md'
     }
 
     It 'throws for unsupported IDE' {
@@ -315,6 +334,33 @@ Describe 'New-VsCodeMcpConfig' {
         $config = $json | ConvertFrom-Json
         $config.servers.context7 | Should -Not -BeNullOrEmpty
         $config.servers.context7.url | Should -BeLike '*context7*'
+    }
+}
+
+Describe 'New-CursorMcpConfig' {
+    It 'generates valid JSON' {
+        $json = New-CursorMcpConfig -EngramBinaryPath 'C:\engram.exe'
+        { $json | ConvertFrom-Json } | Should -Not -Throw
+    }
+
+    It 'includes engram server config under mcpServers' {
+        $json = New-CursorMcpConfig -EngramBinaryPath 'C:\engram.exe'
+        $config = $json | ConvertFrom-Json
+        $config.mcpServers.engram | Should -Not -BeNullOrEmpty
+        $config.mcpServers.engram.command | Should -Be 'C:\engram.exe'
+    }
+
+    It 'includes context7 server config under mcpServers' {
+        $json = New-CursorMcpConfig -EngramBinaryPath 'C:\engram.exe'
+        $config = $json | ConvertFrom-Json
+        $config.mcpServers.context7 | Should -Not -BeNullOrEmpty
+        $config.mcpServers.context7.url | Should -BeLike '*context7*'
+    }
+
+    It 'does not have servers key' {
+        $json = New-CursorMcpConfig -EngramBinaryPath 'C:\engram.exe'
+        $config = $json | ConvertFrom-Json
+        ($config.PSObject.Properties.Name -contains 'servers') | Should -Be $false
     }
 }
 
@@ -364,6 +410,12 @@ Describe 'Get-TemplateDirectory' {
         $dir | Should -BeNullOrEmpty
     }
 
+    It 'returns cursor dir for cursor' {
+        $dir = Get-TemplateDirectory -KitRoot $script:kitRoot -Ide 'cursor'
+        $dir | Should -BeLike '*cursor*'
+        Test-Path $dir | Should -BeTrue
+    }
+
     It 'throws for unsupported IDE' {
         { Get-TemplateDirectory -KitRoot $script:kitRoot -Ide 'vim' } | Should -Throw '*Unsupported IDE*'
     }
@@ -372,6 +424,13 @@ Describe 'Get-TemplateDirectory' {
 Describe 'Get-TemplateFiles' {
     It 'finds .template files for intellij' {
         $dir = Get-TemplateDirectory -KitRoot $script:kitRoot -Ide 'intellij'
+        $files = Get-TemplateFiles -TemplateDir $dir
+        $files | Should -Not -BeNullOrEmpty
+        $files | ForEach-Object { $_.Name | Should -BeLike '*.template' }
+    }
+
+    It 'finds .template files for cursor' {
+        $dir = Get-TemplateDirectory -KitRoot $script:kitRoot -Ide 'cursor'
         $files = Get-TemplateFiles -TemplateDir $dir
         $files | Should -Not -BeNullOrEmpty
         $files | ForEach-Object { $_.Name | Should -BeLike '*.template' }
@@ -437,6 +496,57 @@ Describe 'Install-Templates' {
             $content = Get-Content $mcpFile -Raw
             $content | Should -BeLike '*engram.exe*'
             $content | Should -Not -BeLike '*{{ENGRAM_BINARY_PATH}}*'
+        }
+    }
+}
+
+Describe 'Install-Templates (Cursor)' {
+    BeforeAll {
+        $script:cursorTplTempDir = Join-Path $env:TEMP "team-ai-kit-cursor-tpl-test-$(Get-Random)"
+    }
+
+    AfterAll {
+        if (Test-Path $script:cursorTplTempDir) {
+            Remove-Item -Path $script:cursorTplTempDir -Recurse -Force
+        }
+    }
+
+    It 'expands and copies Cursor templates to target dir' {
+        $tplDir = Get-TemplateDirectory -KitRoot $script:kitRoot -Ide 'cursor'
+        $vars = @{
+            ENGRAM_BINARY_PATH = 'C:/tools/engram.exe'
+        }
+        $created = Install-Templates -TemplateDir $tplDir -TargetDir $script:cursorTplTempDir -Variables $vars
+        $created | Should -Not -BeNullOrEmpty
+    }
+
+    It 'creates files without .template extension' {
+        $created = Get-ChildItem -Path $script:cursorTplTempDir -Recurse -File
+        $created | ForEach-Object { $_.Name | Should -Not -BeLike '*.template' }
+    }
+
+    It 'replaces placeholders in Cursor MCP config' {
+        $mcpFile = Join-Path $script:cursorTplTempDir 'mcp.json'
+        if (Test-Path $mcpFile) {
+            $content = Get-Content $mcpFile -Raw
+            $content | Should -BeLike '*engram.exe*'
+            $content | Should -Not -BeLike '*{{ENGRAM_BINARY_PATH}}*'
+        }
+    }
+
+    It 'generates valid JSON for Cursor MCP config' {
+        $mcpFile = Join-Path $script:cursorTplTempDir 'mcp.json'
+        if (Test-Path $mcpFile) {
+            $content = Get-Content $mcpFile -Raw
+            { $content | ConvertFrom-Json } | Should -Not -Throw
+        }
+    }
+
+    It 'Cursor MCP config uses mcpServers key (Cursor format)' {
+        $mcpFile = Join-Path $script:cursorTplTempDir 'mcp.json'
+        if (Test-Path $mcpFile) {
+            $config = Get-Content $mcpFile -Raw | ConvertFrom-Json
+            $config.mcpServers | Should -Not -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
Closes #32

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add Cursor as 4th supported IDE alongside vscode, intellij, and opencode
- Cursor MCP config uses `mcpServers` key format (different from VS Code's `servers`)
- Full parity between PowerShell and Bash implementations

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | Added `cursor` to VALID_IDES, IDE mapping functions, new `New-CursorMcpConfig` with `mcpServers` key |
| `lib/functions.sh` | Added `cursor` to VALID_IDES, IDE mapping functions, new `new_cursor_mcp_config` with `mcpServers` key |
| `setup.ps1` | Added `cursor` to ValidateSet |
| `bin/team-ai-kit.ps1` | Interactive menu (4 options), provider auto-detect, Step 4 cursor branching, next steps |
| `bin/team-ai-kit` | Interactive menu (4 options), provider auto-detect, Step 4 cursor branching, next steps |
| `tests/functions.Tests.ps1` | 15 new Cursor-specific Pester tests (165 total) |
| `templates/cursor/mcp.json.template` | New Cursor MCP config template with `mcpServers` format |

## Test Plan
- [x] 165 Pester tests passing (15 new Cursor-specific)
- [x] Judgment Day adversarial review: APPROVED (2 rounds, 2 CRITICALs + 3 WARNINGs found and fixed in Round 1, Round 2 clean)
- [x] Conventional commit format

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
