### PR TITLE
docs: add Cursor IDE to all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Explicacion y ejemplos.
 |-----|-----------|-----|-------|
 | **VS Code + Copilot** | Nativo | Via gentle-ai | Full support |
 | **IntelliJ + Copilot** | No | Via template MCP | Config MCP manual |
+| **Cursor** | No | Via template MCP | Config MCP manual |
 | **OpenCode (CLI)** | Nativo | Via gentle-ai | Full support |
 
 ---
@@ -380,7 +381,7 @@ team-ai-kit/
 │   ├── shared/                    5 skills compartidos
 │   └── roles/                     2 skills por rol
 ├── packs/                         Reglas por rol
-├── templates/                     Solo IntelliJ (MCP config)
+├── templates/                     IntelliJ y Cursor (MCP config)
 ├── tests/
 │   ├── functions.Tests.ps1        135 unit tests (Pester)
 │   ├── skills.Tests.ps1           19 validation tests (Pester)

--- a/docs/engram-guide.md
+++ b/docs/engram-guide.md
@@ -179,7 +179,7 @@ Si. Las observaciones con scope `personal` no se exportan al repo. Solo quedan e
 
 ### ¿Esto funciona con cualquier AI/IDE?
 
-engram funciona con cualquier IDE que soporte team-ai-kit: VS Code + Copilot, IntelliJ + Copilot, OpenCode (CLI).
+engram funciona con cualquier IDE que soporte team-ai-kit: VS Code + Copilot, IntelliJ + Copilot, Cursor, OpenCode (CLI).
 
 ---
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -12,7 +12,7 @@
 |-------------|------|
 | **PowerShell 5.1+** | Incluido en Windows |
 | **Git** | `scoop install git` |
-| **Tu IDE** | VS Code, IntelliJ o OpenCode |
+| **Tu IDE** | VS Code, IntelliJ, Cursor o OpenCode |
 
 > Scoop, gentle-ai y engram los instala el setup si faltan.
 
@@ -23,7 +23,7 @@
 | **Bash 4+** | Incluido |
 | **jq** | `brew install jq` / `apt install jq` |
 | **Git** | Incluido o via package manager |
-| **Tu IDE** | VS Code, IntelliJ o OpenCode |
+| **Tu IDE** | VS Code, IntelliJ, Cursor o OpenCode |
 
 ---
 
@@ -74,11 +74,11 @@ team-ai-kit setup
 ./setup.sh
 ```
 
-Te hace **2 preguntas** (VS Code / IntelliJ) o **3** (OpenCode):
+Te hace **2 preguntas** (VS Code / IntelliJ / Cursor) o **3** (OpenCode):
 
-1. **IDE** -- VS Code + Copilot, IntelliJ + Copilot, u OpenCode
+1. **IDE** -- VS Code + Copilot, IntelliJ + Copilot, Cursor, u OpenCode
 2. **Rol** -- Frontend, Backend Node, DevOps, Python
-3. **Provider** -- Solo si elegiste OpenCode (Copilot IDEs auto-detectan `github-copilot`)
+3. **Provider** -- Solo si elegiste OpenCode (Copilot IDEs y Cursor auto-detectan `github-copilot`)
 
 Despues, automaticamente:
 
@@ -115,7 +115,7 @@ team-ai-kit init
 
 Esto genera:
 - `.team-ai-kit.json` -- config del proyecto (rol, IDE, timestamps)
-- `.github/copilot-instructions.md` (VS Code/IntelliJ) o `AGENTS.md` (OpenCode) -- reglas para el AI
+- `.github/copilot-instructions.md` (VS Code/IntelliJ) o `.cursor/rules/team-ai-kit.md` (Cursor) o `AGENTS.md` (OpenCode) -- reglas para el AI
 - `.engram/` -- directorio nativo de engram sync para compartir conocimiento del proyecto con el equipo (via git hooks)
 
 ### Override de rol por proyecto
@@ -162,6 +162,9 @@ team-ai-kit status
 # Windows: VS Code / IntelliJ
 ls "$env:USERPROFILE\.copilot\skills\team-skills"
 
+# Windows: Cursor
+ls "$env:USERPROFILE\.cursor\skills\team-skills"
+
 # Windows: OpenCode
 ls "$env:USERPROFILE\.config\opencode\skills\team-skills"
 ```
@@ -169,6 +172,9 @@ ls "$env:USERPROFILE\.config\opencode\skills\team-skills"
 ```bash
 # macOS/Linux: VS Code / IntelliJ
 ls ~/.copilot/skills/team-skills/
+
+# macOS/Linux: Cursor
+ls ~/.cursor/skills/team-skills/
 
 # macOS/Linux: OpenCode
 ls ~/.config/opencode/skills/team-skills/
@@ -309,8 +315,8 @@ Verificar que la carpeta exista (ver Paso 3 arriba). Si no, correr:
 team-ai-kit update
 ```
 
-### IntelliJ no detecta MCP servers
+### IntelliJ / Cursor no detecta MCP servers
 
 1. Verificar que el Copilot plugin esta actualizado
-2. La config MCP se muestra durante el setup -- copiarla a la config de MCP de IntelliJ
+2. La config MCP se muestra durante el setup -- copiarla a la config de MCP de IntelliJ/Cursor
 3. Verificar engram: `engram --version`

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -1280,7 +1280,7 @@ app.<span class="fn">get</span>(<span class="string">'/users/:id'</span>, <span 
 
       <div class="fade-in" style="max-width: 700px;">
         <p>
-          <strong>gentle-ai</strong> configura tu entorno de AI (VS Code + Copilot, IntelliJ, OpenCode) con:
+          <strong>gentle-ai</strong> configura tu entorno de AI (VS Code + Copilot, IntelliJ, Cursor, OpenCode) con:
         </p>
         <ul style="margin: 1rem 0; padding-left: 24px; display: flex; flex-direction: column; gap: 8px;">
           <li><strong>Skills</strong> &mdash; instrucciones que el AI carga automáticamente según el contexto (ej: cuando detecta un bug, carga el skill de debug)</li>


### PR DESCRIPTION
Closes #32

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add Cursor IDE references to all documentation that was missed in PR #33
- Covers README, onboarding guide, engram guide, and presentation page

## Changes

| File | Change |
|------|--------|
| `README.md` | Added Cursor to IDE support table, updated templates tree description |
| `docs/onboarding.md` | Added Cursor to prerequisites, setup questions, instructions path, skills verification paths, troubleshooting |
| `docs/engram-guide.md` | Added Cursor to supported IDEs list |
| `docs/presentation.html` | Added Cursor to IDE list |

## Test Plan
- [x] Documentation-only change, no code modified
- [x] Verified all IDE mentions now include Cursor

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
