### PR TITLE
feat(cli): add init-knowledge command to scaffold team knowledge repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ cd team-ai-kit
 ## Usar
 
 ```
-team-ai-kit setup     # Primera configuracion (3 preguntas, 2 minutos)
-team-ai-kit init      # Inicializar en el proyecto actual
-team-ai-kit update    # Pull del team repo + merge sin pisar lo tuyo
-team-ai-kit status    # Ver config actual y skills instalados
-team-ai-kit doctor    # Verificar que todo este bien
+team-ai-kit setup          # Primera configuracion (3 preguntas, 2 minutos)
+team-ai-kit init           # Inicializar en el proyecto actual
+team-ai-kit init-knowledge # Crear estructura de un Team Knowledge Repo
+team-ai-kit update         # Pull del team repo + merge sin pisar lo tuyo
+team-ai-kit status         # Ver config actual y skills instalados
+team-ai-kit doctor         # Verificar que todo este bien
 ```
 
 ### Flujo completo
@@ -241,6 +242,10 @@ team-knowledge/              # Repo mantenido por tech leads
 ```
 
 ```powershell
+# Crear el repo del equipo
+mkdir team-knowledge; cd team-knowledge; git init
+team-ai-kit init-knowledge
+
 # Setup con team repo
 team-ai-kit setup -Ide vscode -Role frontend -TeamRepo https://dev.azure.com/equipo/team-knowledge
 

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -5,9 +5,10 @@
 #   team-ai-kit <command> [options]
 #
 # Commands:
-#   setup    First-time configuration (IDE, role, team repo)
-#   init     Initialize team-ai-kit in the current project
-#   sync     Manually sync engram memories (export + import)
+#   setup          First-time configuration (IDE, role, team repo)
+#   init           Initialize team-ai-kit in the current project
+#   init-knowledge Scaffold a Team Knowledge Repo in the current directory
+#   sync           Manually sync engram memories (export + import)
 #   update   Pull latest team content + merge without overwriting
 #   status   Show current config and installed skills
 #   doctor   Verify prerequisites and installation health
@@ -81,9 +82,10 @@ show_help() {
     echo -e "  ${C_WHITE}Usage: team-ai-kit <command> [options]${C_RESET}"
     echo ""
     echo -e "  ${C_YELLOW}Commands:${C_RESET}"
-    echo "    setup    First-time configuration (IDE, role, team repo)"
-    echo "    init     Initialize team-ai-kit in the current project"
-    echo "    sync     Manually sync engram memories (export + import)"
+    echo "    setup           First-time configuration (IDE, role, team repo)"
+    echo "    init            Initialize team-ai-kit in the current project"
+    echo "    init-knowledge  Scaffold a Team Knowledge Repo in the current directory"
+    echo "    sync            Manually sync engram memories (export + import)"
     echo "    update   Pull latest team content + merge without overwriting"
     echo "    status   Show current config and installed skills"
     echo "    doctor   Verify prerequisites and installation health"
@@ -571,6 +573,51 @@ cmd_init() {
     echo ""
 }
 
+# -- Init Knowledge (scaffold team knowledge repo) ----------------------------
+cmd_init_knowledge() {
+    show_banner
+    local target_dir
+    target_dir=$(pwd)
+
+    echo -e "  ${C_WHITE}Scaffolding Team Knowledge Repo...${C_RESET}"
+    echo ""
+
+    local result_json
+    result_json=$(initialize_knowledge_repo "$target_dir")
+
+    local created_count
+    created_count=$(echo "$result_json" | jq '.created | length')
+
+    if [[ "$created_count" -eq 0 ]]; then
+        warn "All directories already exist. Nothing to create."
+    else
+        local dirs
+        dirs=$(echo "$result_json" | jq -r '.created[]')
+        while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            ok "Created: $dir"
+        done <<< "$dirs"
+    fi
+
+    echo ""
+    ok "Team Knowledge Repo ready!"
+    echo ""
+    echo -e "  ${C_YELLOW}Structure:${C_RESET}"
+    echo "    skills/shared/    Skills for ALL roles"
+    echo "    skills/roles/     Role-specific skills"
+    echo "    rules/            Cross-project rules"
+    echo ""
+    echo -e "  ${C_YELLOW}Next steps:${C_RESET}"
+    echo -e "    ${C_WHITE}1. Add skills to skills/shared/ or skills/roles/<role>/${C_RESET}"
+    echo -e "    ${C_WHITE}2. Add rules to rules/${C_RESET}"
+    echo -e "    ${C_WHITE}3. git init && git add . && git commit && git push${C_RESET}"
+    echo -e "    ${C_WHITE}4. Share the repo URL with your team:${C_RESET}"
+    echo -e "    ${C_DIM}   team-ai-kit setup --team-repo <url>${C_RESET}"
+    echo ""
+    echo -e "  ${C_DIM}Docs: https://github.com/lazarogadiel93/team-ai-kit/blob/master/docs/team-knowledge-repo.md${C_RESET}"
+    echo ""
+}
+
 # -- Sync (manual engram sync) -------------------------------------------------
 cmd_sync() {
     show_banner
@@ -905,9 +952,10 @@ fi
 
 # -- Route subcommand ----------------------------------------------------------
 case "$(_lowercase "$COMMAND")" in
-    setup)  cmd_setup ;;
-    init)   cmd_init ;;
-    sync)   cmd_sync ;;
+    setup)           cmd_setup ;;
+    init)            cmd_init ;;
+    init-knowledge)  cmd_init_knowledge ;;
+    sync)            cmd_sync ;;
     update) cmd_update ;;
     status) cmd_status ;;
     doctor) cmd_doctor ;;

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -8,13 +8,14 @@
     and configuration on top.
 
     Subcommands:
-      setup   - First-time configuration (interactive or non-interactive)
-      init    - Initialize team-ai-kit in the current project directory
-      sync    - Manually sync engram memories (export + import)
-      update  - Pull latest team content and merge without overwriting
-      status  - Show current configuration and installed skills
-      doctor  - Verify prerequisites and installation health
-      help    - Show this help message
+      setup          - First-time configuration (interactive or non-interactive)
+      init           - Initialize team-ai-kit in the current project directory
+      init-knowledge - Scaffold a Team Knowledge Repo in the current directory
+      sync           - Manually sync engram memories (export + import)
+      update         - Pull latest team content and merge without overwriting
+      status         - Show current configuration and installed skills
+      doctor         - Verify prerequisites and installation health
+      help           - Show this help message
 .EXAMPLE
     team-ai-kit setup
     Interactive setup -- prompts for IDE and role.
@@ -27,6 +28,9 @@
 .EXAMPLE
     team-ai-kit setup -Ide vscode -Role frontend -TeamRepo https://dev.azure.com/equipo/team-knowledge
     Setup with team content repo (skills and rules shared across projects).
+.EXAMPLE
+    team-ai-kit init-knowledge
+    Scaffold a Team Knowledge Repo in the current directory.
 .EXAMPLE
     team-ai-kit init
     Initialize team-ai-kit in the current project (uses global role).
@@ -100,9 +104,10 @@ function Show-Help {
     Write-Host '  Usage: team-ai-kit <command> [options]' -ForegroundColor White
     Write-Host ''
     Write-Host '  Commands:' -ForegroundColor Yellow
-    Write-Host '    setup    First-time configuration (IDE, role, team repo)'
-    Write-Host '    init     Initialize team-ai-kit in the current project'
-    Write-Host '    sync     Manually sync engram memories (export + import)'
+    Write-Host '    setup           First-time configuration (IDE, role, team repo)'
+    Write-Host '    init            Initialize team-ai-kit in the current project'
+    Write-Host '    init-knowledge  Scaffold a Team Knowledge Repo in the current directory'
+    Write-Host '    sync            Manually sync engram memories (export + import)'
     Write-Host '    update   Pull latest team content + merge without overwriting'
     Write-Host '    status   Show current config and installed skills'
     Write-Host '    doctor   Verify prerequisites and installation health'
@@ -605,6 +610,44 @@ function Invoke-InitCommand {
     Write-Host ''
 }
 
+# -- Init Knowledge (scaffold team knowledge repo) ----------------------------
+function Invoke-InitKnowledgeCommand {
+    Show-Banner
+    $targetDir = (Get-Location).Path
+
+    Write-Host '  Scaffolding Team Knowledge Repo...' -ForegroundColor White
+    Write-Host ''
+
+    $result = Initialize-KnowledgeRepo -TargetDir $targetDir
+
+    if ($result.created.Count -eq 0) {
+        Write-Warn 'All directories already exist. Nothing to create.'
+    }
+    else {
+        foreach ($dir in $result.created) {
+            Write-Ok "Created: $dir"
+        }
+    }
+
+    Write-Host ''
+    Write-Ok 'Team Knowledge Repo ready!'
+    Write-Host ''
+    Write-Host '  Structure:' -ForegroundColor Yellow
+    Write-Host '    skills/shared/    Skills for ALL roles'
+    Write-Host '    skills/roles/     Role-specific skills'
+    Write-Host '    rules/            Cross-project rules'
+    Write-Host ''
+    Write-Host '  Next steps:' -ForegroundColor Yellow
+    Write-Host '    1. Add skills to skills/shared/ or skills/roles/<role>/' -ForegroundColor White
+    Write-Host '    2. Add rules to rules/' -ForegroundColor White
+    Write-Host '    3. git init && git add . && git commit && git push' -ForegroundColor White
+    Write-Host '    4. Share the repo URL with your team:' -ForegroundColor White
+    Write-Host '       team-ai-kit setup -TeamRepo <url>' -ForegroundColor DarkGray
+    Write-Host ''
+    Write-Host '  Docs: https://github.com/lazarogadiel93/team-ai-kit/blob/master/docs/team-knowledge-repo.md' -ForegroundColor DarkGray
+    Write-Host ''
+}
+
 # -- Sync (manual engram sync) -------------------------------------------------
 function Invoke-SyncCommand {
     Show-Banner
@@ -864,9 +907,10 @@ function Invoke-DoctorCommand {
 
 # -- Route subcommand ----------------------------------------------------------
 switch ($Command.ToLower()) {
-    'setup'  { Invoke-SetupCommand }
-    'init'   { Invoke-InitCommand }
-    'sync'   { Invoke-SyncCommand }
+    'setup'          { Invoke-SetupCommand }
+    'init'           { Invoke-InitCommand }
+    'init-knowledge' { Invoke-InitKnowledgeCommand }
+    'sync'           { Invoke-SyncCommand }
     'update' { Invoke-UpdateCommand }
     'status' { Invoke-StatusCommand }
     'doctor' { Invoke-DoctorCommand }

--- a/docs/team-knowledge-repo.md
+++ b/docs/team-knowledge-repo.md
@@ -45,19 +45,30 @@ team-knowledge/
 
 ## Como funciona
 
-### 1. Tech Lead configura el repo
+### 1. Tech Lead crea el repo
 
-Crea el repo y agrega los skills y reglas que reflejan las convenciones del equipo:
+Crea el repo y usa `init-knowledge` para generar la estructura:
 
 ```bash
 # Crear el repo
 mkdir team-knowledge && cd team-knowledge
 git init
-mkdir -p skills/shared skills/roles rules
 
-# Crear un skill compartido
-mkdir skills/shared/logging
+# Generar la estructura
+team-ai-kit init-knowledge
 ```
+
+Esto crea automaticamente:
+
+```
+team-knowledge/
+├── skills/
+│   ├── shared/
+│   └── roles/
+└── rules/
+```
+
+Ahora agrega el primer skill:
 
 ```markdown
 # skills/shared/logging/SKILL.md

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version Latest
 $script:VALID_IDES = @('vscode', 'intellij', 'opencode', 'cursor')
 $script:VALID_ROLES = @('frontend', 'backend-node', 'devops', 'python')
 $script:VALID_PROVIDERS = @('openai', 'azure-openai', 'anthropic', 'github-copilot')
-$script:VALID_COMMANDS = @('setup', 'init', 'sync', 'update', 'status', 'doctor', 'help')
+$script:VALID_COMMANDS = @('setup', 'init', 'init-knowledge', 'sync', 'update', 'status', 'doctor', 'help')
 
 # ── Config Persistence ───────────────────────────────────────────────────────
 
@@ -1480,6 +1480,44 @@ function Install-Templates {
     }
 
     return $created
+}
+
+# ── Knowledge Repo ────────────────────────────────────────────────────────────
+
+function Initialize-KnowledgeRepo {
+    <#
+    .SYNOPSIS
+        Scaffolds the directory structure for a Team Knowledge Repo.
+    .DESCRIPTION
+        Creates skills/shared, skills/roles, and rules directories
+        in the specified target directory.
+    .OUTPUTS
+        Hashtable with 'created' (array of created dirs) and 'path' (root).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$TargetDir
+    )
+
+    $dirs = @(
+        'skills/shared',
+        'skills/roles',
+        'rules'
+    )
+
+    $created = @()
+    foreach ($dir in $dirs) {
+        $fullPath = Join-Path $TargetDir $dir
+        if (-not (Test-Path $fullPath)) {
+            New-Item -ItemType Directory -Path $fullPath -Force | Out-Null
+            $created += $dir
+        }
+    }
+
+    return @{
+        created = $created
+        path    = $TargetDir
+    }
 }
 
 # ── Summary ───────────────────────────────────────────────────────────────────

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 VALID_IDES=("vscode" "intellij" "opencode" "cursor")
 VALID_ROLES=("frontend" "backend-node" "devops" "python")
 VALID_PROVIDERS=("openai" "azure-openai" "anthropic" "github-copilot")
-VALID_COMMANDS=("setup" "init" "sync" "update" "status" "doctor" "help")
+VALID_COMMANDS=("setup" "init" "init-knowledge" "sync" "update" "status" "doctor" "help")
 
 # -- Helpers -------------------------------------------------------------------
 
@@ -1028,6 +1028,27 @@ install_templates() {
         printf '%s' "$content" > "$dest_path"
         echo "$dest_path"
     done < <(get_template_files "$template_dir")
+}
+
+# -- Knowledge Repo ------------------------------------------------------------
+
+initialize_knowledge_repo() {
+    local target_dir="$1"
+    local dirs=("skills/shared" "skills/roles" "rules")
+    local created=()
+
+    for dir in "${dirs[@]}"; do
+        local full_path="$target_dir/$dir"
+        if [[ ! -d "$full_path" ]]; then
+            mkdir -p "$full_path"
+            created+=("$dir")
+        fi
+    done
+
+    local created_json
+    created_json=$(printf '%s\n' "${created[@]}" | jq -R . | jq -sc '.')
+    jq -n --argjson created "$created_json" --arg path "$target_dir" \
+        '{created: $created, path: $path}'
 }
 
 # -- Summary -------------------------------------------------------------------

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -1568,3 +1568,41 @@ Describe 'Install-SkillsWithMerge' {
         }
     }
 }
+
+# ── Initialize-KnowledgeRepo ─────────────────────────────────────────────────
+
+Describe 'Initialize-KnowledgeRepo' {
+    It 'creates skills/shared, skills/roles, and rules directories' {
+        $tempDir = Join-Path $env:TEMP "team-ai-kit-knowledge-$(Get-Random)"
+        try {
+            New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+            $result = Initialize-KnowledgeRepo -TargetDir $tempDir
+            $result.created.Count | Should -Be 3
+            Test-Path (Join-Path $tempDir 'skills/shared') | Should -BeTrue
+            Test-Path (Join-Path $tempDir 'skills/roles') | Should -BeTrue
+            Test-Path (Join-Path $tempDir 'rules') | Should -BeTrue
+        }
+        finally {
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'is idempotent -- reports nothing created on second run' {
+        $tempDir = Join-Path $env:TEMP "team-ai-kit-knowledge-$(Get-Random)"
+        try {
+            New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+            Initialize-KnowledgeRepo -TargetDir $tempDir | Out-Null
+            $result = Initialize-KnowledgeRepo -TargetDir $tempDir
+            $result.created.Count | Should -Be 0
+        }
+        finally {
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Test-ValidCommand includes init-knowledge' {
+    It 'accepts init-knowledge as valid command' {
+        Test-ValidCommand -Command 'init-knowledge' | Should -BeTrue
+    }
+}


### PR DESCRIPTION
Closes #35

## PR Type
- [x] New feature

## Summary
- Adds `team-ai-kit init-knowledge` command that scaffolds the Team Knowledge Repo directory structure (skills/shared, skills/roles, rules)
- Updates documentation (README + team-knowledge-repo guide) to reference the new command
- Adds 3 new tests (Initialize-KnowledgeRepo + idempotency + valid command)

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | Add `Initialize-KnowledgeRepo` function |
| `lib/functions.sh` | Add `initialize_knowledge_repo` function |
| `bin/team-ai-kit.ps1` | Add `init-knowledge` subcommand + help + route |
| `bin/team-ai-kit` | Add `init-knowledge` subcommand + help + route |
| `docs/team-knowledge-repo.md` | Update creation steps to use `init-knowledge` |
| `README.md` | Add `init-knowledge` to commands list + Team Knowledge section |
| `tests/functions.Tests.ps1` | Add 3 tests for new functionality |

## Test Plan
- [x] All 168 unit tests pass (Pester)
- [x] All 19 skill validation tests pass (Pester)
- [x] New tests: Initialize-KnowledgeRepo creates dirs, is idempotent, valid command check