### PR TITLE
chore: release v2.3.0

### DIFF
--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -1501,7 +1501,7 @@ app.<span class="fn">get</span>(<span class="string">'/users/:id'</span>, <span 
         <a href="https://github.com/lazarogadiel93/team-ai-kit" target="_blank" rel="noopener">
           github.com/lazarogadiel93/team-ai-kit
         </a>
-        &nbsp;&middot;&nbsp; MIT License &nbsp;&middot;&nbsp; v2.2.0
+        &nbsp;&middot;&nbsp; MIT License &nbsp;&middot;&nbsp; v2.3.0
       </p>
     </div>
   </footer>

--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -1,11 +1,11 @@
 {
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Team AI Kit - gentle-ai for teams. Standardizes AI usage across development teams with role-based skills, shared memory, and zero-friction onboarding.",
     "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
     "license": "MIT",
-    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.2.0/team-ai-kit-2.2.0.zip",
-    "hash": "502D3753A5CA4AFBE6E2C023355CC66D2D62F4E5DAE3986F64B8EB3B922C0338",
-    "extract_dir": "team-ai-kit-2.2.0",
+    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.3.0/team-ai-kit-2.3.0.zip",
+    "hash": "PLACEHOLDER",
+    "extract_dir": "team-ai-kit-2.3.0",
     "bin": [
         ["bin\\team-ai-kit.ps1", "team-ai-kit"]
     ],


### PR DESCRIPTION
Closes #39

## PR Type
- [x] Maintenance/tooling

## Summary
- Bump version to 2.3.0 in scoop manifest and presentation
- Hash will be updated after release zip is created

## Changes

| File | Change |
|------|--------|
| `scoop/team-ai-kit.json` | Version bump to 2.3.0 |
| `docs/presentation.html` | Version bump footer |