### PR TITLE
fix(init): crash on new projects due to unset existingConfig

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -500,6 +500,7 @@ function Invoke-InitCommand {
     Write-Host ''
     Write-Host '  [2/4] Checking project state...' -ForegroundColor White
 
+    $existingConfig = $null
     if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
         $existingConfig = Get-ProjectConfig -ProjectRoot $projectRoot
 


### PR DESCRIPTION
Closes #46

## PR Type
- [x] Bug fix

## Summary
- Initialize `$existingConfig = $null` before the project-initialized check in `Invoke-InitCommand`
- Fixes crash on `team-ai-kit init` for new (never initialized) projects caused by `Set-StrictMode -Version Latest`

## Test Plan
- [x] 181 Pester tests passing
- [x] Manually verified: `team-ai-kit init` on new project no longer crashes
