### PR TITLE
chore(scoop): update v2.4.0 hash after hotfix

### DIFF
--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
     "license": "MIT",
     "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.4.0/team-ai-kit-2.4.0.zip",
-    "hash": "32268a75f7bc30df09affde954c61338ef70b936b82f2c9aad08e35b7748449a",
+    "hash": "02b9ed006d5f5c204b4c33ccab68ab648f24b753c07dff9856e9d8a5b839a8b7",
     "extract_dir": "team-ai-kit-2.4.0",
     "bin": [
         ["bin\\team-ai-kit.ps1", "team-ai-kit"]


### PR DESCRIPTION
Closes #46

## PR Type
- [x] Maintenance/tooling

## Summary
- Update Scoop manifest hash for v2.4.0 after hotfix inclusion
