### PR TITLE
feat(skills): install team-knowledge skills at project level instead of global

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ cd team-ai-kit
 ## Usar
 
 ```
-team-ai-kit setup          # Primera configuracion (3 preguntas, 2 minutos)
-team-ai-kit init           # Inicializar en el proyecto actual
+team-ai-kit setup          # Primera configuracion (skills base a global)
+team-ai-kit init           # Inicializar proyecto (team skills + instructions + hooks)
 team-ai-kit init-knowledge # Crear estructura de un Team Knowledge Repo
-team-ai-kit update         # Pull del team repo + merge sin pisar lo tuyo
-team-ai-kit status         # Ver config actual y skills instalados
+team-ai-kit update         # Pull del team repo + actualizar skills (global + proyecto)
+team-ai-kit status         # Ver config, skills globales y de proyecto
 team-ai-kit doctor         # Verificar que todo este bien
 ```
 
@@ -298,19 +298,21 @@ El AI recuerda decisiones, bugs resueltos, patrones establecidos -- entre sesion
 
 ```
 +-------------------------------------------+
-|  TOOL layer   (team-ai-kit package)       |
-|  CLI + default skills + pack rules        |
+|  GLOBAL layer  (~/.copilot/skills/)       |
+|  Kit base skills (architecture, debug...) |
+|  Installed by: setup / update             |
 +-------------------------------------------+
-|  TEAM layer   (team-knowledge repo)       |
-|  Custom skills + cross-project rules      |
+|  PROJECT layer (.github/skills/)          |
+|  Team-knowledge repo skills               |
+|  Installed by: init / update              |
 +-------------------------------------------+
-|  PROJECT layer (committed to each repo)   |
+|  PROJECT config (committed to each repo)  |
 |  .team-ai-kit.json + instructions +       |
 |  .engram/ + git hooks                     |
 +-------------------------------------------+
 ```
 
-El tracking de merge se hace con SHA256 hashes en `~/.team-ai-kit/manifest.json`.
+Cada proyecto tiene sus propios team skills (diferentes equipos, diferentes stacks). Los skills base son globales y compartidos por todos los proyectos.
 
 ---
 

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -352,7 +352,7 @@ cmd_setup() {
         fi
     fi
 
-    # 5b. Install skills with 3-layer merge
+    # 5b. Install kit base skills to global (team-repo skills go to project via init)
     local target_skills_dir
     if [[ -n "$OPT_TARGET_DIR" ]]; then
         target_skills_dir="$OPT_TARGET_DIR"
@@ -360,10 +360,10 @@ cmd_setup() {
         target_skills_dir=$(get_ide_skills_directory "$OPT_IDE")
     fi
 
-    step "Skills target: $target_skills_dir"
+    step "Global skills target: $target_skills_dir"
 
     local merge_json
-    merge_json=$(install_skills_with_merge "$KIT_ROOT" "$OPT_ROLE" "$target_skills_dir" "$has_team_repo" "$OPT_TEAM_REPO")
+    merge_json=$(install_skills_with_merge "$KIT_ROOT" "$OPT_ROLE" "$target_skills_dir" "false" "")
     local total_installed total_updated total_skipped
     total_installed=$(echo "$merge_json" | jq -r '.installed')
     total_updated=$(echo "$merge_json" | jq -r '.updated')
@@ -412,19 +412,19 @@ cmd_setup() {
     echo -e "  ${C_YELLOW}Next steps:${C_RESET}"
     if [[ -n "$agent_id" && "$SKIP_GENTLE_AI" == "false" ]]; then
         echo -e "    ${C_WHITE}1. Go to your project and run: team-ai-kit init${C_RESET}"
-        echo -e "    ${C_DIM}   (configures instructions, engram sync, and git hooks for the project)${C_RESET}"
+        echo -e "    ${C_DIM}   (configures instructions, team skills, engram sync, and git hooks)${C_RESET}"
         echo -e "    ${C_WHITE}2. Open your IDE and start working!${C_RESET}"
     elif [[ "$OPT_IDE" == "intellij" || "$OPT_IDE" == "cursor" ]]; then
         echo -e "    ${C_WHITE}1. Add the MCP config shown above to your IDE settings${C_RESET}"
         echo -e "    ${C_WHITE}2. Go to your project and run: team-ai-kit init${C_RESET}"
-        echo -e "    ${C_DIM}   (configures instructions, engram sync, and git hooks for the project)${C_RESET}"
+        echo -e "    ${C_DIM}   (configures instructions, team skills, engram sync, and git hooks)${C_RESET}"
         local open_ide_name
         if [[ "$OPT_IDE" == "cursor" ]]; then open_ide_name="Cursor"; else open_ide_name="IntelliJ"; fi
         echo -e "    ${C_WHITE}3. Open $open_ide_name and start working!${C_RESET}"
     else
         echo -e "    ${C_WHITE}1. Run gentle-ai to complete agent configuration${C_RESET}"
         echo -e "    ${C_WHITE}2. Go to your project and run: team-ai-kit init${C_RESET}"
-        echo -e "    ${C_DIM}   (configures instructions, engram sync, and git hooks for the project)${C_RESET}"
+        echo -e "    ${C_DIM}   (configures instructions, team skills, engram sync, and git hooks)${C_RESET}"
         echo -e "    ${C_WHITE}3. Open your IDE and start working!${C_RESET}"
     fi
     echo ""
@@ -546,6 +546,25 @@ cmd_init() {
     local rel_instructions_path="${instructions_path#$project_root/}"
     ok "Created: $rel_instructions_path"
 
+    # 3b. Install team-repo skills to project-level directory
+    if [[ -n "$effective_team_repo" ]] && test_team_repo_cloned "$effective_team_repo"; then
+        local project_skills_dir
+        project_skills_dir=$(get_ide_project_skills_directory "$effective_ide" "$project_root")
+        local rel_skills_dir="${project_skills_dir#$project_root/}"
+        step "Installing team skills to project: $rel_skills_dir"
+
+        local ps_json ps_installed ps_updated
+        ps_json=$(install_project_skills "$effective_role" "$effective_team_repo" "$project_skills_dir")
+        ps_installed=$(echo "$ps_json" | jq -r '.installed')
+        ps_updated=$(echo "$ps_json" | jq -r '.updated')
+        local ps_total=$((ps_installed + ps_updated))
+        if [[ "$ps_total" -gt 0 ]]; then
+            ok "$ps_installed installed, $ps_updated updated team skills"
+        else
+            step "No team skills to install (repo has no skills for this role)"
+        fi
+    fi
+
     # -- Step 4: Setup engram sync + git hooks --------------------------------
     echo ""
     echo -e "  ${C_WHITE}[4/4] Setting up engram sync and git hooks...${C_RESET}"
@@ -605,8 +624,17 @@ cmd_init() {
     echo ""
     echo -e "  ${C_YELLOW}Next steps:${C_RESET}"
     echo -e "    ${C_WHITE}1. Commit .team-ai-kit.json and $rel_instructions_path to your repo${C_RESET}"
-    echo -e "    ${C_WHITE}2. Commit .engram/ to share knowledge with your team${C_RESET}"
-    echo -e "    ${C_WHITE}3. Start working -- git hooks will sync engram automatically!${C_RESET}"
+    if [[ -n "$effective_team_repo" ]]; then
+        local rel_skills_dir
+        rel_skills_dir="$(get_ide_project_skills_directory "$effective_ide" "$project_root")"
+        rel_skills_dir="${rel_skills_dir#$project_root/}"
+        echo -e "    ${C_WHITE}2. Commit $rel_skills_dir/ (team skills for this project)${C_RESET}"
+        echo -e "    ${C_WHITE}3. Commit .engram/ to share knowledge with your team${C_RESET}"
+        echo -e "    ${C_WHITE}4. Start working -- git hooks will sync engram automatically!${C_RESET}"
+    else
+        echo -e "    ${C_WHITE}2. Commit .engram/ to share knowledge with your team${C_RESET}"
+        echo -e "    ${C_WHITE}3. Start working -- git hooks will sync engram automatically!${C_RESET}"
+    fi
     echo -e "    ${C_DIM}   (manual sync: team-ai-kit sync)${C_RESET}"
     echo ""
 }
@@ -752,11 +780,15 @@ cmd_update() {
                 warn "Failed to clone team repo -- continuing with defaults only"
             fi
         fi
+        # Safety net: if a cached clone exists from a previous run, use it
+        if [[ "$has_team_repo" == "false" ]] && test_team_repo_cloned "$effective_team_repo"; then
+            has_team_repo="true"
+        fi
     else
         step 'No team repo configured (use "team-ai-kit setup --team-repo <url>" to add one)'
     fi
 
-    # Step 2: Merge skills with no-overwrite
+    # Step 2: Merge kit base skills to global (no team-repo layer)
     local target_skills_dir
     if [[ -n "$OPT_TARGET_DIR" ]]; then
         target_skills_dir="$OPT_TARGET_DIR"
@@ -764,10 +796,10 @@ cmd_update() {
         target_skills_dir=$(get_ide_skills_directory "$config_ide")
     fi
 
-    step "Merging skills to: $target_skills_dir"
+    step "Merging kit base skills to global: $target_skills_dir"
 
     local merge_json
-    merge_json=$(install_skills_with_merge "$KIT_ROOT" "$config_role" "$target_skills_dir" "$has_team_repo" "$effective_team_repo")
+    merge_json=$(install_skills_with_merge "$KIT_ROOT" "$config_role" "$target_skills_dir" "false" "")
     local m_installed m_updated m_skipped
     m_installed=$(echo "$merge_json" | jq -r '.installed')
     m_updated=$(echo "$merge_json" | jq -r '.updated')
@@ -777,6 +809,29 @@ cmd_update() {
     ok "Installed: $m_installed new skills"
     [[ "$m_updated" -gt 0 ]] && ok "Updated:   $m_updated skills (source changed, yours untouched)"
     [[ "$m_skipped" -gt 0 ]] && step "Unchanged: $m_skipped skills (already up to date or user-modified)"
+
+    # Step 2b: Install team-repo skills to project-level directory
+    if [[ "$has_team_repo" == "true" && "$has_project_config" == "true" ]]; then
+        local effective_ide effective_role_proj project_skills_dir
+        effective_ide=$(get_project_config_value "$project_root" "ide" 2>/dev/null) || true
+        [[ -z "$effective_ide" ]] && effective_ide="$config_ide"
+        effective_role_proj=$(get_project_config_value "$project_root" "role" 2>/dev/null) || true
+        [[ -z "$effective_role_proj" ]] && effective_role_proj="$config_role"
+        project_skills_dir=$(get_ide_project_skills_directory "$effective_ide" "$project_root")
+
+        echo ""
+        local rel_dir="${project_skills_dir#$project_root/}"
+        step "Merging team skills to project: $rel_dir"
+
+        local ps_json ps_installed ps_updated ps_skipped
+        ps_json=$(install_project_skills "$effective_role_proj" "$effective_team_repo" "$project_skills_dir")
+        ps_installed=$(echo "$ps_json" | jq -r '.installed')
+        ps_updated=$(echo "$ps_json" | jq -r '.updated')
+        ps_skipped=$(echo "$ps_json" | jq -r '.skipped')
+        [[ "$ps_installed" -gt 0 ]] && ok "Installed: $ps_installed new team skills"
+        [[ "$ps_updated" -gt 0 ]] && ok "Updated:   $ps_updated team skills"
+        [[ "$ps_skipped" -gt 0 ]] && step "Unchanged: $ps_skipped team skills"
+    fi
 
     # Step 3: Auto-update team rules in instructions if project is initialized
     if [[ "$has_team_repo" == "true" && "$has_project_config" == "true" ]]; then
@@ -855,7 +910,7 @@ cmd_status() {
         local default_count team_count
         default_count=$(echo "$manifest_json" | jq '[.files[] | select(.source == "default")] | length')
         team_count=$(echo "$manifest_json" | jq '[.files[] | select(.source == "team")] | length')
-        echo -e "  ${C_WHITE}Tracked Skills: $file_count total ($default_count default, $team_count team)${C_RESET}"
+        echo -e "  ${C_WHITE}Global Skills: $file_count tracked ($default_count default, $team_count team)${C_RESET}"
 
         # Check for user modifications
         local skills_dir modified_count=0
@@ -882,7 +937,24 @@ cmd_status() {
             skill_count=$(find "$team_skills_dir" -name 'SKILL.md' -type f | wc -l | tr -d ' ')
             echo -e "  ${C_WHITE}Installed Skills: $skill_count (no manifest -- run update to track)${C_RESET}"
         else
-            warn "Skills directory not found: $team_skills_dir"
+            warn "Global skills directory not found: $team_skills_dir"
+        fi
+    fi
+
+    # Show project-level skills
+    if test_project_initialized "$project_root"; then
+        local project_ide project_skills_dir project_team_dir
+        project_ide=$(get_project_config_value "$project_root" "ide" 2>/dev/null) || true
+        [[ -z "$project_ide" ]] && project_ide="$config_ide"
+        project_skills_dir=$(get_ide_project_skills_directory "$project_ide" "$project_root")
+        project_team_dir="$project_skills_dir/team-skills"
+        if [[ -d "$project_team_dir" ]]; then
+            local p_count
+            p_count=$(find "$project_team_dir" -name 'SKILL.md' -type f | wc -l | tr -d ' ')
+            local rel_dir="${project_skills_dir#$project_root/}"
+            echo -e "  ${C_WHITE}Project Skills: $p_count in $rel_dir/${C_RESET}"
+        else
+            step 'Project skills: none (run "team-ai-kit init" with a team repo)'
         fi
     fi
 
@@ -939,7 +1011,7 @@ cmd_doctor() {
         warn 'Config: not configured (run "team-ai-kit setup")'
     fi
 
-    # Skills directory
+    # Global skills directory
     if [[ -n "$config_ide" ]]; then
         local skills_dir team_skills_dir
         skills_dir=$(get_ide_skills_directory "$config_ide")
@@ -947,9 +1019,28 @@ cmd_doctor() {
         if [[ -d "$team_skills_dir" ]]; then
             local count
             count=$(find "$team_skills_dir" -name 'SKILL.md' -type f | wc -l | tr -d ' ')
-            ok "Team skills: $count files in $team_skills_dir"
+            ok "Global skills: $count files in $team_skills_dir"
         else
-            warn "Team skills: directory not found ($team_skills_dir)"
+            warn "Global skills: directory not found ($team_skills_dir)"
+        fi
+    fi
+
+    # Project-level skills
+    local project_root
+    project_root=$(pwd)
+    if [[ -n "$config_ide" ]] && test_project_initialized "$project_root"; then
+        local project_ide project_skills_dir project_team_dir
+        project_ide=$(get_project_config_value "$project_root" "ide" 2>/dev/null) || true
+        [[ -z "$project_ide" ]] && project_ide="$config_ide"
+        project_skills_dir=$(get_ide_project_skills_directory "$project_ide" "$project_root")
+        project_team_dir="$project_skills_dir/team-skills"
+        if [[ -d "$project_team_dir" ]]; then
+            local p_count
+            p_count=$(find "$project_team_dir" -name 'SKILL.md' -type f | wc -l | tr -d ' ')
+            local rel_dir="${project_skills_dir#$project_root/}"
+            ok "Project skills: $p_count files in $rel_dir/"
+        else
+            step 'Project skills: not installed (run "team-ai-kit init" with a team repo)'
         fi
     fi
 

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -403,7 +403,7 @@ function Invoke-SetupCommand {
         }
     }
 
-    # 5b. Install skills with 3-layer merge
+    # 5b. Install kit base skills to global (team-repo skills go to project via init)
     if ($TargetDir) {
         $targetSkillsDir = $TargetDir
     }
@@ -411,16 +411,12 @@ function Invoke-SetupCommand {
         $targetSkillsDir = Get-IdeSkillsDirectory -Ide $Ide
     }
 
-    Write-Step "Skills target: $targetSkillsDir"
+    Write-Step "Global skills target: $targetSkillsDir"
 
     $mergeParams = @{
         KitRoot   = $kitRoot
         Role      = $Role
         TargetDir = $targetSkillsDir
-    }
-    if ($hasTeamRepo) {
-        $mergeParams.IncludeTeamRepo = $true
-        $mergeParams.TeamRepoUrl = $TeamRepo
     }
 
     $mergeResults = Install-SkillsWithMerge @mergeParams
@@ -463,19 +459,19 @@ function Invoke-SetupCommand {
     Write-Host '  Next steps:' -ForegroundColor Yellow
     if ($gentleAiAgentId -and -not $SkipGentleAi) {
         Write-Host '    1. Go to your project and run: team-ai-kit init' -ForegroundColor White
-        Write-Host '       (configures instructions, engram sync, and git hooks for the project)' -ForegroundColor DarkGray
+        Write-Host '       (configures instructions, team skills, engram sync, and git hooks)' -ForegroundColor DarkGray
         Write-Host '    2. Open your IDE and start working!' -ForegroundColor White
     }
     elseif ($Ide -eq 'intellij' -or $Ide -eq 'cursor') {
         Write-Host '    1. Add the MCP config shown above to your IDE settings' -ForegroundColor White
         Write-Host '    2. Go to your project and run: team-ai-kit init' -ForegroundColor White
-        Write-Host '       (configures instructions, engram sync, and git hooks for the project)' -ForegroundColor DarkGray
+        Write-Host '       (configures instructions, team skills, engram sync, and git hooks)' -ForegroundColor DarkGray
         Write-Host '    3. Open your IDE and start working!' -ForegroundColor White
     }
     else {
         Write-Host '    1. Run gentle-ai to complete agent configuration' -ForegroundColor White
         Write-Host '    2. Go to your project and run: team-ai-kit init' -ForegroundColor White
-        Write-Host '       (configures instructions, engram sync, and git hooks for the project)' -ForegroundColor DarkGray
+        Write-Host '       (configures instructions, team skills, engram sync, and git hooks)' -ForegroundColor DarkGray
         Write-Host '    3. Open your IDE and start working!' -ForegroundColor White
     }
     Write-Host ''
@@ -586,6 +582,21 @@ function Invoke-InitCommand {
     $relInstructionsPath = $instructionsPath.Replace($projectRoot, '').TrimStart('\', '/')
     Write-Ok "Created: $relInstructionsPath"
 
+    # 3b. Install team-repo skills to project-level directory
+    if ($effectiveTeamRepo -and (Test-TeamRepoCloned -RepoUrl $effectiveTeamRepo)) {
+        $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot
+        Write-Step "Installing team skills to project: $($projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/'))"
+
+        $projectSkillResults = Install-ProjectSkills -Role $effectiveRole -TeamRepoUrl $effectiveTeamRepo -TargetDir $projectSkillsDir
+        $pTotal = $projectSkillResults.installed + $projectSkillResults.updated
+        if ($pTotal -gt 0) {
+            Write-Ok "$($projectSkillResults.installed) installed, $($projectSkillResults.updated) updated team skills"
+        }
+        else {
+            Write-Step 'No team skills to install (repo has no skills for this role)'
+        }
+    }
+
     # -- Step 4: Setup engram sync + git hooks --------------------------------
     Write-Host ''
     Write-Host '  [4/4] Setting up engram sync and git hooks...' -ForegroundColor White
@@ -641,8 +652,16 @@ function Invoke-InitCommand {
     Write-Host ''
     Write-Host '  Next steps:' -ForegroundColor Yellow
     Write-Host "    1. Commit .team-ai-kit.json and $relInstructionsPath to your repo" -ForegroundColor White
-    Write-Host '    2. Commit .engram/ to share knowledge with your team' -ForegroundColor White
-    Write-Host '    3. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+    if ($effectiveTeamRepo) {
+        $relSkillsDir = (Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot).Replace($projectRoot, '').TrimStart('\', '/')
+        Write-Host "    2. Commit $relSkillsDir/ (team skills for this project)" -ForegroundColor White
+        Write-Host '    3. Commit .engram/ to share knowledge with your team' -ForegroundColor White
+        Write-Host '    4. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+    }
+    else {
+        Write-Host '    2. Commit .engram/ to share knowledge with your team' -ForegroundColor White
+        Write-Host '    3. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+    }
     Write-Host '       (manual sync: team-ai-kit sync)' -ForegroundColor DarkGray
     Write-Host ''
 }
@@ -777,12 +796,16 @@ function Invoke-UpdateCommand {
                 Write-Warn 'Failed to clone team repo -- continuing with defaults only'
             }
         }
+        # Safety net: if a cached clone exists from a previous run, use it
+        if (-not $hasTeamRepo -and (Test-TeamRepoCloned -RepoUrl $effectiveTeamRepo)) {
+            $hasTeamRepo = $true
+        }
     }
     else {
         Write-Step 'No team repo configured (use "team-ai-kit setup -TeamRepo <url>" to add one)'
     }
 
-    # Step 2: Merge skills with no-overwrite
+    # Step 2: Merge kit base skills to global (no team-repo layer)
     if ($TargetDir) {
         $targetSkillsDir = $TargetDir
     }
@@ -790,16 +813,12 @@ function Invoke-UpdateCommand {
         $targetSkillsDir = Get-IdeSkillsDirectory -Ide $config.ide
     }
 
-    Write-Step "Merging skills to: $targetSkillsDir"
+    Write-Step "Merging kit base skills to global: $targetSkillsDir"
 
     $mergeParams = @{
         KitRoot   = $kitRoot
         Role      = $config.role
         TargetDir = $targetSkillsDir
-    }
-    if ($hasTeamRepo) {
-        $mergeParams.IncludeTeamRepo = $true
-        $mergeParams.TeamRepoUrl = $effectiveTeamRepo
     }
 
     $mergeResults = Install-SkillsWithMerge @mergeParams
@@ -811,6 +830,27 @@ function Invoke-UpdateCommand {
     }
     if ($mergeResults.skipped.Count -gt 0) {
         Write-Step "Unchanged: $($mergeResults.skipped.Count) skills (already up to date or user-modified)"
+    }
+
+    # Step 2b: Install team-repo skills to project-level directory
+    if ($hasTeamRepo -and $projectConfig) {
+        $effectiveIde = if ($projectConfig.ide) { $projectConfig.ide } else { $config.ide }
+        $effectiveRole = if ($projectConfig.role) { $projectConfig.role } else { $config.role }
+        $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot
+
+        Write-Host ''
+        Write-Step "Merging team skills to project: $($projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/'))"
+
+        $projectSkillResults = Install-ProjectSkills -Role $effectiveRole -TeamRepoUrl $effectiveTeamRepo -TargetDir $projectSkillsDir
+        if ($projectSkillResults.installed -gt 0) {
+            Write-Ok "Installed: $($projectSkillResults.installed) new team skills"
+        }
+        if ($projectSkillResults.updated -gt 0) {
+            Write-Ok "Updated:   $($projectSkillResults.updated) team skills"
+        }
+        if ($projectSkillResults.skipped -gt 0) {
+            Write-Step "Unchanged: $($projectSkillResults.skipped) team skills"
+        }
     }
 
     # Step 3: Auto-update team rules in instructions if project is initialized
@@ -873,7 +913,7 @@ function Invoke-StatusCommand {
     if ($fileCount -gt 0) {
         $defaultCount = @($manifest.files.Values | Where-Object { $_.source -eq 'default' }).Count
         $teamCount = @($manifest.files.Values | Where-Object { $_.source -eq 'team' }).Count
-        Write-Host "  Tracked Skills: $fileCount total ($defaultCount default, $teamCount team)" -ForegroundColor White
+        Write-Host "  Global Skills: $fileCount tracked ($defaultCount default, $teamCount team)" -ForegroundColor White
 
         # Check for user modifications
         $skillsDir = Get-IdeSkillsDirectory -Ide $config.ide
@@ -894,10 +934,26 @@ function Invoke-StatusCommand {
         $teamSkillsDir = Join-Path $skillsDir 'team-skills'
         if (Test-Path $teamSkillsDir) {
             $skillFiles = @(Get-ChildItem -Path $teamSkillsDir -Filter 'SKILL.md' -Recurse)
-            Write-Host "  Installed Skills: $($skillFiles.Count) (no manifest -- run update to track)" -ForegroundColor White
+            Write-Host "  Global Skills: $($skillFiles.Count) (no manifest -- run update to track)" -ForegroundColor White
         }
         else {
-            Write-Warn "  Skills directory not found: $teamSkillsDir"
+            Write-Warn "  Global skills directory not found: $teamSkillsDir"
+        }
+    }
+
+    # Show project-level skills
+    if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
+        $pc = Get-ProjectConfig -ProjectRoot $projectRoot
+        $projectIde = if ($pc.ide) { $pc.ide } else { $config.ide }
+        $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $projectIde -ProjectRoot $projectRoot
+        $projectTeamDir = Join-Path $projectSkillsDir 'team-skills'
+        if (Test-Path $projectTeamDir) {
+            $projectSkillFiles = @(Get-ChildItem -Path $projectTeamDir -Filter 'SKILL.md' -Recurse)
+            $relDir = $projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/')
+            Write-Host "  Project Skills: $($projectSkillFiles.Count) in $relDir/" -ForegroundColor White
+        }
+        else {
+            Write-Step 'Project skills: none (run "team-ai-kit init" with a team repo)'
         }
     }
 
@@ -949,16 +1005,33 @@ function Invoke-DoctorCommand {
         Write-Warn 'Config: not configured (run "team-ai-kit setup")'
     }
 
-    # Skills directory
+    # Global skills directory
     if ($config.ide) {
         $skillsDir = Get-IdeSkillsDirectory -Ide $config.ide
         $teamSkillsDir = Join-Path $skillsDir 'team-skills'
         if (Test-Path $teamSkillsDir) {
             $count = @(Get-ChildItem -Path $teamSkillsDir -Filter 'SKILL.md' -Recurse).Count
-            Write-Ok "Team skills: $count files in $teamSkillsDir"
+            Write-Ok "Global skills: $count files in $teamSkillsDir"
         }
         else {
-            Write-Warn "Team skills: directory not found ($teamSkillsDir)"
+            Write-Warn "Global skills: directory not found ($teamSkillsDir)"
+        }
+    }
+
+    # Project-level skills
+    $projectRoot = (Get-Location).Path
+    if ($config.ide -and (Test-ProjectInitialized -ProjectRoot $projectRoot)) {
+        $pc = Get-ProjectConfig -ProjectRoot $projectRoot
+        $projectIde = if ($pc.ide) { $pc.ide } else { $config.ide }
+        $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $projectIde -ProjectRoot $projectRoot
+        $projectTeamDir = Join-Path $projectSkillsDir 'team-skills'
+        if (Test-Path $projectTeamDir) {
+            $pCount = @(Get-ChildItem -Path $projectTeamDir -Filter 'SKILL.md' -Recurse).Count
+            $relDir = $projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/')
+            Write-Ok "Project skills: $pCount files in $relDir/"
+        }
+        else {
+            Write-Step 'Project skills: not installed (run "team-ai-kit init" with a team repo)'
         }
     }
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -158,7 +158,7 @@ Si corres `init` en un proyecto ya inicializado:
 team-ai-kit doctor
 ```
 
-Esto verifica: gentle-ai, engram, jq (Unix), config, skills instalados y team repo.
+Esto verifica: gentle-ai, engram, jq (Unix), config, skills instalados (global + proyecto) y team repo.
 
 Si queres ver tu config actual:
 
@@ -167,6 +167,8 @@ team-ai-kit status
 ```
 
 ### Verificar skills manualmente
+
+**Skills base (globales):**
 
 ```powershell
 # Windows: VS Code / IntelliJ
@@ -188,6 +190,19 @@ ls ~/.cursor/skills/team-skills/
 
 # macOS/Linux: OpenCode
 ls ~/.config/opencode/skills/team-skills/
+```
+
+**Skills del team repo (en el proyecto):**
+
+```powershell
+# VS Code / IntelliJ
+ls .github\skills\team-skills
+
+# Cursor
+ls .cursor\skills\team-skills
+
+# OpenCode
+ls .agents\skills\team-skills
 ```
 
 ---

--- a/docs/team-knowledge-repo.md
+++ b/docs/team-knowledge-repo.md
@@ -144,10 +144,10 @@ team-ai-kit init --team-repo https://github.com/otro-equipo/knowledge
 ```
 
 Los skills y reglas del team repo se descargan e inyectan. El dev recibe:
-- Skills compartidos del team repo (logging, error-handling, etc.)
+- Skills compartidos del team repo (logging, error-handling, etc.) **instalados en el proyecto** (`.github/skills/`)
 - Skills de su rol especifico (design-system para frontend)
 - Reglas cross-proyecto inyectadas en las instrucciones del AI
-- Todo esto **ademas** de los skills base de team-ai-kit
+- Todo esto **ademas** de los skills base de team-ai-kit (que estan a nivel global)
 
 **Nota:** Cada URL de team repo se clona en una ubicacion unica (`~/.team-ai-kit/team-content/<hash>/`), asi que diferentes proyectos con diferentes team repos no se pisan.
 
@@ -162,7 +162,7 @@ team-ai-kit update
 El update:
 1. Hace pull del team repo
 2. Detecta skills nuevos o actualizados
-3. Los instala respetando las customizaciones locales del dev
+3. Actualiza skills base (global) y team skills (en el proyecto)
 4. **Actualiza automaticamente las reglas** en las instrucciones del proyecto (si el proyecto esta inicializado)
 
 ### 4. Nuevo integrante = 2 minutos
@@ -180,24 +180,25 @@ En 2 minutos tiene toda la configuracion del equipo sin leer documentacion, sin 
 
 ---
 
-## Prioridad de merge
+## Donde se instalan los skills
 
-Cuando corres `team-ai-kit update`, las capas se resuelven asi:
+Los skills se instalan en **dos niveles**:
 
 ```
 ┌─────────────────────────────────────────────┐
-│  🟢  Customizaciones locales del dev        │  ← NUNCA se pisa
-│      Skills o reglas que el dev modifico     │
+│  📁  GLOBAL (~/.copilot/skills/)            │  ← Skills base de team-ai-kit
+│      architecture, code-quality, debug, etc. │    Instalados por: setup / update
 ├─────────────────────────────────────────────┤
-│  🔵  Team Knowledge Repo                    │  ← Se agregan si son nuevos,
-│      Skills y reglas del Tech Lead          │    se actualizan si no fueron modificados
-├─────────────────────────────────────────────┤
-│  ⚪  Defaults del package                   │  ← Base, menor prioridad
-│      Skills base incluidos en team-ai-kit   │
+│  📂  PROYECTO (.github/skills/)             │  ← Skills del team-knowledge repo
+│      logging, error-handling, design-system  │    Instalados por: init / update
 └─────────────────────────────────────────────┘
 ```
 
-**Como funciona el tracking:**
+**Por que dos niveles?** Porque diferentes proyectos pueden usar stacks diferentes (Next.js+Supabase vs Angular+Firebase). Los skills del equipo son **por proyecto**, los skills base son universales.
+
+El IDE (VSCode, Cursor, OpenCode) detecta ambos niveles automaticamente. Los skills de proyecto tienen prioridad si hay un nombre duplicado.
+
+### Tracking de cambios
 
 - Cada archivo tiene un hash SHA256 guardado en `~/.team-ai-kit/manifest.json`
 - Si el hash actual del archivo coincide con el hash del ultimo update → el dev no lo toco → se puede actualizar

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -852,7 +852,7 @@ function Get-PackRulesPath {
 function Get-IdeSkillsDirectory {
     <#
     .SYNOPSIS
-        Returns the target directory where skills should be copied for the given IDE.
+        Returns the GLOBAL (user-level) directory where kit base skills are installed.
         Uses gentle-ai's native paths for supported IDEs.
     #>
     param(
@@ -875,6 +875,37 @@ function Get-IdeSkillsDirectory {
         'cursor' {
             # Cursor: user-level skills directory
             return Join-Path $env:USERPROFILE '.cursor\skills'
+        }
+        default {
+            throw "Unsupported IDE: $Ide"
+        }
+    }
+}
+
+function Get-IdeProjectSkillsDirectory {
+    <#
+    .SYNOPSIS
+        Returns the PROJECT-LEVEL directory where team-knowledge repo skills are installed.
+        These are committed to the repo so each project has its own team skills.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Ide,
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+    switch ($Ide.ToLower()) {
+        'vscode' {
+            return Join-Path $ProjectRoot '.github\skills'
+        }
+        'intellij' {
+            return Join-Path $ProjectRoot '.github\skills'
+        }
+        'opencode' {
+            return Join-Path $ProjectRoot '.agents\skills'
+        }
+        'cursor' {
+            return Join-Path $ProjectRoot '.cursor\skills'
         }
         default {
             throw "Unsupported IDE: $Ide"
@@ -1329,6 +1360,105 @@ function Install-SkillsWithMerge {
 
     # Persist manifest (suppress return value to avoid pipeline pollution)
     $null = Save-SkillManifest -Manifest $manifest
+
+    return $results
+}
+
+function Install-ProjectSkills {
+    <#
+    .SYNOPSIS
+        Installs team-knowledge repo skills into the PROJECT-LEVEL skills directory.
+        These are committed to the repo. Tracks last-installed hashes via a local
+        manifest so user modifications are not overwritten.
+    .OUTPUTS
+        Hashtable with keys: installed (int), updated (int), skipped (int).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Role,
+        [Parameter(Mandatory)]
+        [string]$TeamRepoUrl,
+        [Parameter(Mandatory)]
+        [string]$TargetDir
+    )
+
+    $results = @{
+        installed = 0
+        updated   = 0
+        skipped   = 0
+    }
+
+    $teamRepoPath = Get-TeamRepoLocalPath -RepoUrl $TeamRepoUrl
+    if (-not (Test-Path $teamRepoPath)) {
+        return $results
+    }
+
+    $teamSkills = Get-TeamRepoSkillPaths -Role $Role -RepoUrl $TeamRepoUrl
+    $teamSkillsBase = Join-Path $teamRepoPath 'skills'
+
+    # Load project-level manifest for tracking installed hashes
+    $teamSkillsDir = Join-Path $TargetDir 'team-skills'
+    $manifestPath = Join-Path $teamSkillsDir '.team-ai-kit-skills-manifest.json'
+    $manifest = @{ files = @{} }
+    if (Test-Path $manifestPath) {
+        $raw = Get-Content $manifestPath -Raw | ConvertFrom-Json
+        if ($raw.files) {
+            $raw.files.PSObject.Properties | ForEach-Object {
+                $manifest.files[$_.Name] = @{
+                    hash = $_.Value.hash
+                }
+            }
+        }
+    }
+
+    foreach ($skillPath in $teamSkills) {
+        $relativePath = $skillPath.Replace($teamSkillsBase, '').TrimStart('\', '/')
+        $destPath = Join-Path $TargetDir "team-skills\$relativePath"
+
+        $destDir = Split-Path $destPath -Parent
+        if (-not (Test-Path $destDir)) {
+            New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+        }
+
+        $sourceHash = Get-FileContentHash -FilePath $skillPath
+
+        if (-not (Test-Path $destPath)) {
+            Copy-Item -Path $skillPath -Destination $destPath -Force
+            $manifest.files[$relativePath] = @{ hash = $sourceHash }
+            $results.installed++
+        }
+        else {
+            $destHash = Get-FileContentHash -FilePath $destPath
+            if ($sourceHash -eq $destHash) {
+                $manifest.files[$relativePath] = @{ hash = $sourceHash }
+                $results.skipped++
+            }
+            else {
+                # Source and dest differ -- check if user modified it
+                $lastInstalledHash = $null
+                if ($manifest.files.ContainsKey($relativePath)) {
+                    $lastInstalledHash = $manifest.files[$relativePath].hash
+                }
+                if ($lastInstalledHash -and $destHash -ne $lastInstalledHash) {
+                    # User modified the file -- skip to preserve their changes
+                    $results.skipped++
+                }
+                else {
+                    # File matches last-installed hash or no record -- safe to update
+                    Copy-Item -Path $skillPath -Destination $destPath -Force
+                    $manifest.files[$relativePath] = @{ hash = $sourceHash }
+                    $results.updated++
+                }
+            }
+        }
+    }
+
+    # Save updated manifest
+    if (-not (Test-Path $teamSkillsDir)) {
+        New-Item -ItemType Directory -Path $teamSkillsDir -Force | Out-Null
+    }
+    $json = $manifest | ConvertTo-Json -Depth 5
+    $json | Set-Content -Path $manifestPath -Encoding UTF8
 
     return $results
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -645,6 +645,20 @@ get_ide_skills_directory() {
     esac
 }
 
+get_ide_project_skills_directory() {
+    # Returns the project-level skills directory for the given IDE.
+    # Usage: get_ide_project_skills_directory ide project_root
+    local ide project_root="$2"
+    ide=$(_lowercase "$1")
+    case "$ide" in
+        vscode)   echo "$project_root/.github/skills" ;;
+        intellij) echo "$project_root/.github/skills" ;;
+        opencode) echo "$project_root/.agents/skills" ;;
+        cursor)   echo "$project_root/.cursor/skills" ;;
+        *)        echo "ERROR: Unsupported IDE: $1" >&2; return 1 ;;
+    esac
+}
+
 get_ide_instructions_path() {
     local ide project_root="$2"
     ide=$(_lowercase "$1")
@@ -937,6 +951,78 @@ install_skills_with_merge() {
             done < <(get_team_repo_skill_paths "$role" "$team_repo_url")
         fi
     fi
+
+    echo "{\"installed\":$installed,\"updated\":$updated,\"skipped\":$skipped}"
+}
+
+install_project_skills() {
+    # Installs team-knowledge repo skills into project-level directory.
+    # Tracks last-installed hashes via a local manifest so user modifications
+    # are not overwritten.
+    # Usage: install_project_skills role team_repo_url target_dir
+    # Outputs: JSON with installed/updated/skipped counts
+    local role="$1" team_repo_url="$2" target_dir="$3"
+
+    local installed=0 updated=0 skipped=0
+
+    local team_repo_path
+    team_repo_path=$(get_team_repo_local_path "$team_repo_url")
+    if [[ ! -d "$team_repo_path" ]]; then
+        echo "{\"installed\":0,\"updated\":0,\"skipped\":0}"
+        return
+    fi
+
+    local team_skills_base="$team_repo_path/skills"
+    local team_skills_dir="$target_dir/team-skills"
+    local manifest_path="$team_skills_dir/.team-ai-kit-skills-manifest.json"
+
+    # Load existing manifest
+    local manifest_json='{"files":{}}'
+    if [[ -f "$manifest_path" ]]; then
+        manifest_json=$(cat "$manifest_path")
+    fi
+
+    while IFS= read -r skill_path; do
+        [[ -z "$skill_path" ]] && continue
+        local relative_path="${skill_path#"$team_skills_base"/}"
+        local dest_path="$target_dir/team-skills/$relative_path"
+        local dest_dir
+        dest_dir=$(dirname "$dest_path")
+        [[ -d "$dest_dir" ]] || mkdir -p "$dest_dir"
+
+        local source_hash
+        source_hash=$(get_file_content_hash "$skill_path") || continue
+
+        if [[ ! -f "$dest_path" ]]; then
+            cp "$skill_path" "$dest_path"
+            manifest_json=$(echo "$manifest_json" | jq --arg key "$relative_path" --arg hash "$source_hash" '.files[$key] = {hash: $hash}')
+            installed=$((installed + 1))
+        else
+            local dest_hash
+            dest_hash=$(get_file_content_hash "$dest_path")
+            if [[ "$source_hash" == "$dest_hash" ]]; then
+                manifest_json=$(echo "$manifest_json" | jq --arg key "$relative_path" --arg hash "$source_hash" '.files[$key] = {hash: $hash}')
+                skipped=$((skipped + 1))
+            else
+                # Source and dest differ -- check if user modified it
+                local last_installed_hash
+                last_installed_hash=$(echo "$manifest_json" | jq -r ".files[\"$relative_path\"].hash // empty" 2>/dev/null)
+                if [[ -n "$last_installed_hash" && "$dest_hash" != "$last_installed_hash" ]]; then
+                    # User modified the file -- skip to preserve their changes
+                    skipped=$((skipped + 1))
+                else
+                    # File matches last-installed hash or no record -- safe to update
+                    cp "$skill_path" "$dest_path"
+                    manifest_json=$(echo "$manifest_json" | jq --arg key "$relative_path" --arg hash "$source_hash" '.files[$key] = {hash: $hash}')
+                    updated=$((updated + 1))
+                fi
+            fi
+        fi
+    done < <(get_team_repo_skill_paths "$role" "$team_repo_url")
+
+    # Save updated manifest
+    [[ -d "$team_skills_dir" ]] || mkdir -p "$team_skills_dir"
+    echo "$manifest_json" | jq '.' > "$manifest_path"
 
     echo "{\"installed\":$installed,\"updated\":$updated,\"skipped\":$skipped}"
 }

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -288,6 +288,32 @@ Describe 'Get-IdeSkillsDirectory' {
     }
 }
 
+Describe 'Get-IdeProjectSkillsDirectory' {
+    It 'returns .github/skills for vscode' {
+        $path = Get-IdeProjectSkillsDirectory -Ide 'vscode' -ProjectRoot 'C:\project'
+        $path | Should -BeLike '*\.github?skills'
+    }
+
+    It 'returns .github/skills for intellij' {
+        $path = Get-IdeProjectSkillsDirectory -Ide 'intellij' -ProjectRoot 'C:\project'
+        $path | Should -BeLike '*\.github?skills'
+    }
+
+    It 'returns .agents/skills for opencode' {
+        $path = Get-IdeProjectSkillsDirectory -Ide 'opencode' -ProjectRoot 'C:\project'
+        $path | Should -BeLike '*\.agents?skills'
+    }
+
+    It 'returns .cursor/skills for cursor' {
+        $path = Get-IdeProjectSkillsDirectory -Ide 'cursor' -ProjectRoot 'C:\project'
+        $path | Should -BeLike '*\.cursor?skills'
+    }
+
+    It 'throws for unsupported IDE' {
+        { Get-IdeProjectSkillsDirectory -Ide 'vim' -ProjectRoot 'C:\project' } | Should -Throw '*Unsupported IDE*'
+    }
+}
+
 Describe 'Get-IdeInstructionsPath' {
     It 'returns copilot-instructions.md for vscode' {
         $path = Get-IdeInstructionsPath -Ide 'vscode' -ProjectRoot 'C:\project'
@@ -1722,6 +1748,59 @@ Describe 'Install-SkillsWithMerge' {
         finally {
             $env:USERPROFILE = $originalProfile
         }
+    }
+}
+
+# -- Install-ProjectSkills ----------------------------------------------------
+
+Describe 'Install-ProjectSkills' {
+    BeforeAll {
+        $script:projectSkillsDir = Join-Path $env:TEMP "team-ai-kit-proj-skills-$(Get-Random)"
+        # Create a fake team repo with skills
+        $script:fakeTeamRepo = Join-Path $env:TEMP "team-ai-kit-fake-team-$(Get-Random)"
+        $fakeSkillDir = Join-Path $script:fakeTeamRepo 'skills\shared\test-skill'
+        New-Item -ItemType Directory -Path $fakeSkillDir -Force | Out-Null
+        Set-Content -Path (Join-Path $fakeSkillDir 'SKILL.md') -Value '# Test Skill'
+
+        $fakeRoleDir = Join-Path $script:fakeTeamRepo 'skills\roles\frontend\react-skill'
+        New-Item -ItemType Directory -Path $fakeRoleDir -Force | Out-Null
+        Set-Content -Path (Join-Path $fakeRoleDir 'SKILL.md') -Value '# React Skill'
+    }
+
+    AfterAll {
+        if (Test-Path $script:projectSkillsDir) { Remove-Item -Recurse -Force $script:projectSkillsDir }
+        if (Test-Path $script:fakeTeamRepo) { Remove-Item -Recurse -Force $script:fakeTeamRepo }
+    }
+
+    It 'returns zero counts when team repo does not exist' {
+        $results = Install-ProjectSkills -Role 'frontend' -TeamRepoUrl 'https://example.com/nonexistent.git' -TargetDir $script:projectSkillsDir
+        $results.installed | Should -Be 0
+        $results.updated | Should -Be 0
+        $results.skipped | Should -Be 0
+    }
+
+    It 'installs team repo skills to project directory' {
+        # Mock the team repo path to point to our fake
+        Mock Get-TeamRepoLocalPath { return $script:fakeTeamRepo }
+        $results = Install-ProjectSkills -Role 'frontend' -TeamRepoUrl 'https://example.com/fake.git' -TargetDir $script:projectSkillsDir
+        $results.installed | Should -Be 2  # 1 shared + 1 frontend role
+        $results.updated | Should -Be 0
+    }
+
+    It 'skips unchanged skills on second run' {
+        Mock Get-TeamRepoLocalPath { return $script:fakeTeamRepo }
+        $results = Install-ProjectSkills -Role 'frontend' -TeamRepoUrl 'https://example.com/fake.git' -TargetDir $script:projectSkillsDir
+        $results.installed | Should -Be 0
+        $results.skipped | Should -Be 2
+    }
+
+    It 'detects updated skills when source changes' {
+        Mock Get-TeamRepoLocalPath { return $script:fakeTeamRepo }
+        # Modify source
+        Set-Content -Path (Join-Path $script:fakeTeamRepo 'skills\shared\test-skill\SKILL.md') -Value '# Test Skill v2'
+        $results = Install-ProjectSkills -Role 'frontend' -TeamRepoUrl 'https://example.com/fake.git' -TargetDir $script:projectSkillsDir
+        $results.updated | Should -Be 1
+        $results.skipped | Should -Be 1
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #54

- **`setup`** now only installs kit base skills to global (`~/.copilot/skills/`). Team-repo skills are no longer mixed into global.
- **`init`** installs team-knowledge repo skills into the **project** at `.github/skills/` (vscode/intellij), `.agents/skills/` (opencode), or `.cursor/skills/` (cursor).
- **`update`** splits: kit base skills to global, team-repo skills to project directory.
- **`status`** and **`doctor`** now report both global and project-level skills separately.

### Why

Different projects may use different stacks and need different team skills. Installing all team skills globally meant every project shared the same set -- wrong for multi-team devs.

### Changes

| File | What changed |
|------|-------------|
| `lib/functions.ps1` | New `Get-IdeProjectSkillsDirectory` + `Install-ProjectSkills` functions |
| `lib/functions.sh` | Bash equivalents of above |
| `bin/team-ai-kit.ps1` | setup/init/update/status/doctor commands updated |
| `bin/team-ai-kit` | Bash CLI equivalents |
| `tests/functions.Tests.ps1` | 9 new tests (190 total, 0 failures) |
| `README.md` | Updated architecture diagram + command descriptions |
| `docs/team-knowledge-repo.md` | Two-layer skills architecture documented |
| `docs/onboarding.md` | Added project-level skills verification |
