### PR TITLE
fix(skills): normalize paths in Install-ProjectSkills to avoid 8.3 short name mismatch on CI

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1093,12 +1093,12 @@ function Get-TeamRepoSkillPaths {
 
     [string[]]$all = @()
 
-    $sharedDir = Join-Path $localPath 'skills\shared'
+    $sharedDir = Join-Path $localPath (Join-Path 'skills' 'shared')
     if (Test-Path $sharedDir) {
         $all += @(Get-ChildItem -Path $sharedDir -Filter 'SKILL.md' -Recurse | Select-Object -ExpandProperty FullName)
     }
 
-    $roleDir = Join-Path $localPath "skills\roles\$Role"
+    $roleDir = Join-Path $localPath (Join-Path 'skills' (Join-Path 'roles' $Role))
     if (Test-Path $roleDir) {
         $all += @(Get-ChildItem -Path $roleDir -Filter 'SKILL.md' -Recurse | Select-Object -ExpandProperty FullName)
     }
@@ -1414,6 +1414,10 @@ function Install-ProjectSkills {
 
     foreach ($skillPath in $teamSkills) {
         $skillPath = [System.IO.Path]::GetFullPath($skillPath)
+        if (-not $skillPath.StartsWith($teamSkillsBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Warning "Skill path '$skillPath' is not under expected base '$teamSkillsBase', skipping."
+            continue
+        }
         $relativePath = $skillPath.Substring($teamSkillsBase.Length).TrimStart('\', '/')
         $destPath = Join-Path $TargetDir (Join-Path 'team-skills' $relativePath)
 

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1414,8 +1414,8 @@ function Install-ProjectSkills {
 
     foreach ($skillPath in $teamSkills) {
         $skillPath = [System.IO.Path]::GetFullPath($skillPath)
-        $relativePath = $skillPath.Replace($teamSkillsBase, '').TrimStart('\', '/')
-        $destPath = Join-Path $TargetDir "team-skills\$relativePath"
+        $relativePath = $skillPath.Substring($teamSkillsBase.Length).TrimStart('\', '/')
+        $destPath = Join-Path $TargetDir (Join-Path 'team-skills' $relativePath)
 
         $destDir = Split-Path $destPath -Parent
         if (-not (Test-Path $destDir)) {

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1394,7 +1394,8 @@ function Install-ProjectSkills {
     }
 
     $teamSkills = Get-TeamRepoSkillPaths -Role $Role -RepoUrl $TeamRepoUrl
-    $teamSkillsBase = Join-Path $teamRepoPath 'skills'
+    # Normalize to long path to avoid 8.3 short name mismatches on CI runners
+    $teamSkillsBase = [System.IO.Path]::GetFullPath((Join-Path $teamRepoPath 'skills'))
 
     # Load project-level manifest for tracking installed hashes
     $teamSkillsDir = Join-Path $TargetDir 'team-skills'
@@ -1412,6 +1413,7 @@ function Install-ProjectSkills {
     }
 
     foreach ($skillPath in $teamSkills) {
+        $skillPath = [System.IO.Path]::GetFullPath($skillPath)
         $relativePath = $skillPath.Replace($teamSkillsBase, '').TrimStart('\', '/')
         $destPath = Join-Path $TargetDir "team-skills\$relativePath"
 


### PR DESCRIPTION
﻿Fixes #57

## Summary
- Normalize paths with `[System.IO.Path]::GetFullPath()` in `Install-ProjectSkills` before `.Replace()` to avoid 8.3 short name mismatch on Windows CI runners

## Changes
| File | Change |
|------|--------|
| `lib/functions.ps1` | Normalize `` and `` with `GetFullPath()` before relative path extraction |

## Test Plan
- [x] 190 tests pass locally
- [x] CI should now pass on Windows runner (the 3 previously failing tests)
