### PR TITLE
feat(instructions): inject full Engram Memory Protocol into copilot-instructions

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -870,7 +870,21 @@ function Invoke-UpdateCommand {
         }
     }
 
-    # Step 4: Update config timestamp
+    # Step 4: Auto-update engram Memory Protocol in instructions
+    if ($projectConfig) {
+        $instructionsPath = Get-IdeInstructionsPath -Ide $config.ide -ProjectRoot $projectRoot
+        if (Test-Path $instructionsPath) {
+            $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath
+            if ($protocolChanged) {
+                Write-Ok 'Engram Memory Protocol updated in project instructions'
+            }
+            else {
+                Write-Step 'Engram Memory Protocol unchanged in project instructions'
+            }
+        }
+    }
+
+    # Step 5: Update config timestamp
     $config.lastUpdate = Get-Date -Format 'o'
     Save-TeamAiKitConfig -Config $config | Out-Null
     Write-Host ''

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1534,10 +1534,148 @@ function New-CursorMcpConfig {
 
 # ── Instructions Generation ───────────────────────────────────────────────────
 
+function Get-EngramProtocolContent {
+    <#
+    .SYNOPSIS
+        Returns the Engram Memory Protocol markdown content wrapped in markers.
+        Uses single-quoted here-string to prevent accidental variable expansion.
+    #>
+    return @'
+
+<!-- team-ai-kit:engram-protocol -->
+## Engram Persistent Memory -- Protocol
+
+You have access to Engram, a persistent memory system that survives across sessions and compactions.
+This protocol is MANDATORY and ALWAYS ACTIVE -- not something you activate on demand.
+
+### PROACTIVE SAVE TRIGGERS (mandatory -- do NOT wait for user to ask)
+
+Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
+- Architecture or design decision made
+- Team convention documented or established
+- Workflow change agreed upon
+- Tool or library choice made with tradeoffs
+- Bug fix completed (include root cause)
+- Feature implemented with non-obvious approach
+- Configuration change or environment setup done
+- Non-obvious discovery about the codebase
+- Gotcha, edge case, or unexpected behavior found
+- Pattern established (naming, structure, convention)
+- User preference or constraint learned
+
+Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
+
+Format for `mem_save`:
+- **title**: Verb + what -- short, searchable (e.g. "Fixed N+1 query in UserList")
+- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
+- **scope**: `project` (default) | `personal`
+- **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **content**:
+  - **What**: One sentence -- what was done
+  - **Why**: What motivated it (user request, bug, performance, etc.)
+  - **Where**: Files or paths affected
+  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Topic update rules:
+- Different topics MUST NOT overwrite each other
+- Same topic evolving -> use same `topic_key` (upsert)
+- Unsure about key -> call `mem_suggest_topic_key` first
+- Know exact ID to fix -> use `mem_update`
+
+### WHEN TO SEARCH MEMORY
+
+On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "que hicimos", or references to past work:
+1. Call `mem_context` -- checks recent session history (fast, cheap)
+2. If not found, call `mem_search` with relevant keywords
+3. If found, use `mem_get_observation` for full untruncated content
+
+Also search PROACTIVELY when:
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+- User's FIRST message references the project, a feature, or a problem -- call `mem_search` with keywords from their message to check for prior work before responding
+
+### SESSION CLOSE PROTOCOL (mandatory)
+
+Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary` with this structure:
+
+```
+## Goal
+[What we were working on this session]
+
+## Instructions
+[User preferences or constraints discovered -- skip if none]
+
+## Discoveries
+- [Technical findings, gotchas, non-obvious learnings]
+
+## Accomplished
+- [Completed items with key details]
+
+## Next Steps
+- [What remains to be done -- for the next session]
+
+## Relevant Files
+- path/to/file -- [what it does or what changed]
+```
+
+This is NOT optional. If you skip this, the next session starts blind.
+
+### AFTER COMPACTION
+
+If you see a compaction message or "FIRST ACTION REQUIRED":
+1. IMMEDIATELY call `mem_session_summary` with the compacted summary content -- this persists what was done before compaction
+2. Call `mem_context` to recover additional context from previous sessions
+3. Only THEN continue working
+
+Do not skip step 1. Without it, everything done before compaction is lost from memory.
+<!-- /team-ai-kit:engram-protocol -->
+
+'@
+}
+
+function Update-InstructionsEngramProtocol {
+    <#
+    .SYNOPSIS
+        Updates the engram-protocol section in an existing instructions file.
+        If markers exist, replaces content between them.
+        If no markers exist, inserts after the Team Conventions header.
+    .OUTPUTS
+        $true if the file was changed, $false if content is the same.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$FilePath
+    )
+
+    if (-not (Test-Path $FilePath)) { return $false }
+
+    $existing = Get-Content -Path $FilePath -Raw
+    $startMarker = '<!-- team-ai-kit:engram-protocol -->'
+    $endMarker = '<!-- /team-ai-kit:engram-protocol -->'
+
+    $protocolContent = Get-EngramProtocolContent
+    $newSection = $protocolContent.Trim()
+
+    if ($existing -match '(?s)<!-- team-ai-kit:engram-protocol -->.*?<!-- /team-ai-kit:engram-protocol -->') {
+        $updated = $existing -replace '(?s)<!-- team-ai-kit:engram-protocol -->.*?<!-- /team-ai-kit:engram-protocol -->', $newSection
+    }
+    else {
+        # Insert after the header section (before pack rules or team rules)
+        $updated = "$existing`n`n$newSection`n"
+    }
+
+    if ($updated -eq $existing) { return $false }
+
+    [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.Encoding]::UTF8)
+    return $true
+}
+
 function New-CopilotInstructions {
     <#
     .SYNOPSIS
-        Generates the copilot-instructions.md content with team rules injected.
+        Generates the copilot-instructions.md content with engram Memory Protocol
+        and team rules injected. Engram protocol is always included (team-ai-kit
+        requires engram).
     #>
     param(
         [Parameter(Mandatory)]
@@ -1557,13 +1695,13 @@ function New-CopilotInstructions {
 ## Team Conventions
 
 - Follow the team's established patterns and conventions
-- Use engram to save decisions, discoveries, and bug fixes
-- Search engram before starting work to check for prior knowledge
 - Always explain WHY, not just WHAT, when making decisions
 
 "@
 
-    $result = $header
+    $memoryProtocol = Get-EngramProtocolContent
+
+    $result = $header + $memoryProtocol
 
     if ($PackRulesContent) {
         $result += "`n$PackRulesContent`n"

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -392,6 +392,44 @@ Describe 'New-CursorMcpConfig' {
 
 # -- Instructions Generation ---------------------------------------------------
 
+Describe 'Get-EngramProtocolContent' {
+    It 'returns content with opening and closing markers' {
+        $content = Get-EngramProtocolContent
+        $content | Should -BeLike '*<!-- team-ai-kit:engram-protocol -->*'
+        $content | Should -BeLike '*<!-- /team-ai-kit:engram-protocol -->*'
+    }
+
+    It 'includes all mem_* tool references' {
+        $content = Get-EngramProtocolContent
+        $content | Should -BeLike '*mem_save*'
+        $content | Should -BeLike '*mem_search*'
+        $content | Should -BeLike '*mem_context*'
+        $content | Should -BeLike '*mem_session_summary*'
+        $content | Should -BeLike '*mem_get_observation*'
+        $content | Should -BeLike '*mem_suggest_topic_key*'
+        $content | Should -BeLike '*mem_update*'
+    }
+
+    It 'includes all 4 protocol sections' {
+        $content = Get-EngramProtocolContent
+        $content | Should -BeLike '*PROACTIVE SAVE TRIGGERS*'
+        $content | Should -BeLike '*WHEN TO SEARCH MEMORY*'
+        $content | Should -BeLike '*SESSION CLOSE PROTOCOL*'
+        $content | Should -BeLike '*AFTER COMPACTION*'
+    }
+
+    It 'wraps session summary template in code fence' {
+        $content = Get-EngramProtocolContent
+        $content | Should -Match '(?s)```.*## Goal.*## Relevant Files.*```'
+    }
+
+    It 'uses single backticks for inline code (not double)' {
+        $content = Get-EngramProtocolContent
+        $content | Should -Match 'Call `mem_save`'
+        $content | Should -Not -Match '``mem_save``'
+    }
+}
+
 Describe 'New-CopilotInstructions' {
     It 'includes role in header' {
         $instructions = New-CopilotInstructions -Role 'frontend'
@@ -401,6 +439,23 @@ Describe 'New-CopilotInstructions' {
     It 'includes team conventions section' {
         $instructions = New-CopilotInstructions -Role 'backend-node'
         $instructions | Should -BeLike '*Team Conventions*'
+    }
+
+    It 'includes engram Memory Protocol with markers' {
+        $instructions = New-CopilotInstructions -Role 'frontend'
+        $instructions | Should -BeLike '*<!-- team-ai-kit:engram-protocol -->*'
+        $instructions | Should -BeLike '*<!-- /team-ai-kit:engram-protocol -->*'
+        $instructions | Should -BeLike '*mem_save*'
+        $instructions | Should -BeLike '*mem_context*'
+        $instructions | Should -BeLike '*mem_session_summary*'
+        $instructions | Should -BeLike '*AFTER COMPACTION*'
+    }
+
+    It 'places engram-protocol before team-rules in output' {
+        $instructions = New-CopilotInstructions -Role 'frontend' -TeamRulesContent '## Team Rules'
+        $engramIdx = $instructions.IndexOf('<!-- team-ai-kit:engram-protocol -->')
+        $teamIdx = $instructions.IndexOf('<!-- team-ai-kit:team-rules -->')
+        $engramIdx | Should -BeLessThan $teamIdx
     }
 
     It 'appends pack rules when provided' {
@@ -433,9 +488,70 @@ Describe 'New-CopilotInstructions' {
         $instructions | Should -BeLike '*<!-- team-ai-kit:team-rules -->*'
     }
 
-    It 'does not include markers when TeamRulesContent is empty' {
+    It 'does not include team-rules markers when TeamRulesContent is empty' {
         $instructions = New-CopilotInstructions -Role 'frontend'
         $instructions | Should -Not -BeLike '*team-ai-kit:team-rules*'
+    }
+}
+
+Describe 'Update-InstructionsEngramProtocol' {
+    It 'returns $false when file does not exist' {
+        $result = Update-InstructionsEngramProtocol -FilePath 'C:\nonexistent\file.md'
+        $result | Should -BeFalse
+    }
+
+    It 'appends protocol when markers do not exist' {
+        $tempFile = Join-Path $env:TEMP "instructions-$(Get-Random).md"
+        try {
+            Set-Content -Path $tempFile -Value '# Existing content'
+            $result = Update-InstructionsEngramProtocol -FilePath $tempFile
+            $result | Should -BeTrue
+            $content = Get-Content -Path $tempFile -Raw
+            $content | Should -BeLike '*<!-- team-ai-kit:engram-protocol -->*'
+            $content | Should -BeLike '*mem_save*'
+            $content | Should -BeLike '*<!-- /team-ai-kit:engram-protocol -->*'
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'replaces content between existing markers' {
+        $tempFile = Join-Path $env:TEMP "instructions-$(Get-Random).md"
+        try {
+            $initial = @"
+# Header
+<!-- team-ai-kit:engram-protocol -->
+# Old Protocol
+<!-- /team-ai-kit:engram-protocol -->
+# Footer
+"@
+            Set-Content -Path $tempFile -Value $initial
+            $result = Update-InstructionsEngramProtocol -FilePath $tempFile
+            $result | Should -BeTrue
+            $content = Get-Content -Path $tempFile -Raw
+            $content | Should -BeLike '*mem_save*'
+            $content | Should -Not -BeLike '*Old Protocol*'
+            $content | Should -BeLike '*# Header*'
+            $content | Should -BeLike '*# Footer*'
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns $false when content is unchanged' {
+        $tempFile = Join-Path $env:TEMP "instructions-$(Get-Random).md"
+        try {
+            $protocol = Get-EngramProtocolContent
+            $initial = "# Header`n`n$($protocol.Trim())"
+            Set-Content -Path $tempFile -Value $initial
+            $result = Update-InstructionsEngramProtocol -FilePath $tempFile
+            $result | Should -BeFalse
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 


### PR DESCRIPTION
﻿## Summary

- Replace generic 2-line engram hints with the complete Memory Protocol so agents in any IDE know WHEN and HOW to use mem_save, mem_search, mem_session_summary, and post-compaction recovery
- Extract Get-EngramProtocolContent as single-quoted here-string with code-fenced session template
- Add Update-InstructionsEngramProtocol for team-ai-kit update to refresh the protocol section independently
- Integrate protocol update as Step 4 in the update command
- 15 new tests covering protocol content, section ordering, update function, and idempotency

## Why

Agents in IDEs (Copilot Chat, Cursor, etc.) had the engram MCP tools available but NO behavioral guidance on WHEN to use them. Without the Memory Protocol, agents never saved memories proactively -- the MCP server alone is not enough.

## Judgment Day

Round 1: 1 CRITICAL + 4 real WARNINGs found and fixed.
Round 2: APPROVED -- 0 CRITICALs, 0 real WARNINGs. 201 tests passing.
