### PR TITLE
fix(version): use single KitVersion variable instead of hardcoded 2.1.0

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -80,6 +80,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# -- Kit version ---------------------------------------------------------------
+# Single source of truth. Bump this on every release.
+$KitVersion = '2.5.1'
+
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root
 $kitRoot = Split-Path $PSScriptRoot -Parent
@@ -444,7 +448,7 @@ function Invoke-SetupCommand {
         teamRepo    = $TeamRepo
         installedAt = $now
         lastUpdate  = $now
-        version     = '2.1.0'
+        version     = $KitVersion
     }
     $configPath = Save-TeamAiKitConfig -Config $config
     Write-Ok "Config saved: $configPath"
@@ -639,7 +643,7 @@ function Invoke-InitCommand {
         teamRepo      = $effectiveTeamRepo
         initializedAt = $now
         lastSync      = $now
-        version       = '2.1.0'
+        version       = $KitVersion
     }
     $null = Save-ProjectConfig -ProjectRoot $projectRoot -Config $projectConfig
     Write-Ok 'Project config saved: .team-ai-kit.json'


### PR DESCRIPTION
## Summary
- Replaces two hardcoded `'2.1.0'` version strings with a single `` variable at the top of `bin/team-ai-kit.ps1`
- `team-ai-kit status` now reports the correct version

Closes #62

| File | Change |
|------|--------|
| `bin/team-ai-kit.ps1` | Added ` = '2.5.1'` variable, replaced both hardcoded references |

### Test Plan
- [x] 201/201 Pester tests pass
- [x] Manually verified `team-ai-kit status` shows correct version