### PR TITLE
chore(scoop): update manifest for v2.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Thumbs.db
 # engram (ignored only in THIS repo -- the tool itself)
 # In project repos, .engram/ MUST be committed (it's the sharing mechanism)
 .engram/
+
+# Release artifacts
+*.zip

--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.5.1",
+    "version": "2.6.0",
     "description": "Team AI Kit - gentle-ai for teams. Standardizes AI usage across development teams with role-based skills, shared memory, and zero-friction onboarding.",
     "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
     "license": "MIT",
-    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.5.1/team-ai-kit-v2.5.1.zip",
-    "hash": "bb4a6647780ef1edee80a55950e8c46ccf3cc21ec70ee40dff52d4c7e51ab986",
+    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.6.0/team-ai-kit-v2.6.0.zip",
+    "hash": "0bf08a49ed6b5fd39215155b843dc29e021cf9334e454b84bb61c2fbe66c3fcb",
     "extract_dir": "team-ai-kit",
     "bin": [
         ["bin\\team-ai-kit.ps1", "team-ai-kit"]


### PR DESCRIPTION
## Summary
- Update scoop manifest version and hash for v2.6.0
- Add `*.zip` to .gitignore to prevent release artifacts from being committed

Closes #66

| File | Change |
|------|--------|
| `scoop/team-ai-kit.json` | Version 2.5.1 -> 2.6.0, updated hash |
| `.gitignore` | Added `*.zip` pattern |