### PR TITLE
fix: address judgment day findings on v2.6.0

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -855,7 +855,22 @@ cmd_update() {
         fi
     fi
 
-    # Step 4: Update config timestamp
+    # Step 4: Auto-update Engram Memory Protocol in instructions
+    if [[ "$has_project_config" == "true" ]]; then
+        local instructions_path
+        instructions_path=$(get_ide_instructions_path "$config_ide" "$project_root")
+        if [[ -f "$instructions_path" ]]; then
+            local protocol_result
+            protocol_result=$(update_instructions_engram_protocol "$instructions_path")
+            if [[ "$protocol_result" == "changed" ]]; then
+                ok "Engram Memory Protocol updated in project instructions"
+            else
+                step "Engram Memory Protocol unchanged in project instructions"
+            fi
+        fi
+    fi
+
+    # Step 5: Update config timestamp
     local now
     now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     local updated_config

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -242,14 +242,7 @@ function Install-GitHooks {
 
     # -- pre-commit hook -------------------------------------------------------
     $preCommitPath = Join-Path $gitHooksDir 'pre-commit'
-    $preCommitBlock = @"
-
-$marker
-if command -v engram >/dev/null 2>&1; then
-    engram sync $projectFlag 2>/dev/null || true
-    git add .engram/ 2>/dev/null || true
-fi
-"@
+    $preCommitBlock = "`n$marker`nif command -v engram >/dev/null 2>&1; then`n    engram sync $projectFlag 2>/dev/null || true`n    git add .engram/ 2>/dev/null || true`nfi"
 
     if (Test-Path $preCommitPath) {
         $existingContent = Get-Content $preCommitPath -Raw -ErrorAction SilentlyContinue
@@ -257,25 +250,21 @@ fi
             $result.skipped += 'pre-commit'
         }
         else {
-            Add-Content -Path $preCommitPath -Value $preCommitBlock -Encoding ASCII
+            $lfContent = ($existingContent + $preCommitBlock) -replace "`r`n", "`n"
+            [System.IO.File]::WriteAllText($preCommitPath, $lfContent, [System.Text.Encoding]::ASCII)
             $result.installed += 'pre-commit'
         }
     }
     else {
-        $hookContent = "#!/bin/sh" + "`n" + $preCommitBlock
-        Set-Content -Path $preCommitPath -Value $hookContent -Encoding ASCII -NoNewline
+        $hookContent = "#!/bin/sh`n" + $preCommitBlock
+        $lfContent = $hookContent -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($preCommitPath, $lfContent, [System.Text.Encoding]::ASCII)
         $result.installed += 'pre-commit'
     }
 
     # -- post-merge hook -------------------------------------------------------
     $postMergePath = Join-Path $gitHooksDir 'post-merge'
-    $postMergeBlock = @"
-
-$marker
-if command -v engram >/dev/null 2>&1; then
-    engram sync --import 2>/dev/null || true
-fi
-"@
+    $postMergeBlock = "`n$marker`nif command -v engram >/dev/null 2>&1; then`n    engram sync --import 2>/dev/null || true`nfi"
 
     if (Test-Path $postMergePath) {
         $existingContent = Get-Content $postMergePath -Raw -ErrorAction SilentlyContinue
@@ -283,13 +272,15 @@ fi
             $result.skipped += 'post-merge'
         }
         else {
-            Add-Content -Path $postMergePath -Value $postMergeBlock -Encoding ASCII
+            $lfContent = ($existingContent + $postMergeBlock) -replace "`r`n", "`n"
+            [System.IO.File]::WriteAllText($postMergePath, $lfContent, [System.Text.Encoding]::ASCII)
             $result.installed += 'post-merge'
         }
     }
     else {
-        $hookContent = "#!/bin/sh" + "`n" + $postMergeBlock
-        Set-Content -Path $postMergePath -Value $hookContent -Encoding ASCII -NoNewline
+        $hookContent = "#!/bin/sh`n" + $postMergeBlock
+        $lfContent = $hookContent -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($postMergePath, $lfContent, [System.Text.Encoding]::ASCII)
         $result.installed += 'post-merge'
     }
 
@@ -1656,8 +1647,16 @@ function Update-InstructionsEngramProtocol {
     $protocolContent = Get-EngramProtocolContent
     $newSection = $protocolContent.Trim()
 
-    if ($existing -match '(?s)<!-- team-ai-kit:engram-protocol -->.*?<!-- /team-ai-kit:engram-protocol -->') {
-        $updated = $existing -replace '(?s)<!-- team-ai-kit:engram-protocol -->.*?<!-- /team-ai-kit:engram-protocol -->', $newSection
+    $startIdx = $existing.IndexOf($startMarker)
+    if ($startIdx -ge 0) {
+        $endIdx = $existing.IndexOf($endMarker, $startIdx)
+        if ($endIdx -ge 0) {
+            $endIdx += $endMarker.Length
+            $updated = $existing.Substring(0, $startIdx) + $newSection + $existing.Substring($endIdx)
+        }
+        else {
+            $updated = "$existing`n`n$newSection`n"
+        }
     }
     else {
         # Insert after the header section (before pack rules or team rules)
@@ -1740,8 +1739,16 @@ function Update-InstructionsTeamRules {
 
     $newSection = "$startMarker`n$TeamRulesContent`n$endMarker"
 
-    if ($existing -match '(?s)<!-- team-ai-kit:team-rules -->.*?<!-- /team-ai-kit:team-rules -->') {
-        $updated = $existing -replace '(?s)<!-- team-ai-kit:team-rules -->.*?<!-- /team-ai-kit:team-rules -->', $newSection
+    $startIdx = $existing.IndexOf($startMarker)
+    if ($startIdx -ge 0) {
+        $endIdx = $existing.IndexOf($endMarker, $startIdx)
+        if ($endIdx -ge 0) {
+            $endIdx += $endMarker.Length
+            $updated = $existing.Substring(0, $startIdx) + $newSection + $existing.Substring($endIdx)
+        }
+        else {
+            $updated = "$existing`n`n$newSection`n"
+        }
     }
     else {
         $updated = "$existing`n`n$newSection`n"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1144,6 +1144,153 @@ update_instructions_team_rules() {
     echo "changed"
 }
 
+get_engram_protocol_content() {
+    # Returns the Engram Memory Protocol markdown content wrapped in markers.
+    # Uses single-quoted heredoc delimiter to prevent variable expansion.
+    cat <<'ENGRAM_PROTOCOL_EOF'
+
+<!-- team-ai-kit:engram-protocol -->
+## Engram Persistent Memory -- Protocol
+
+You have access to Engram, a persistent memory system that survives across sessions and compactions.
+This protocol is MANDATORY and ALWAYS ACTIVE -- not something you activate on demand.
+
+### PROACTIVE SAVE TRIGGERS (mandatory -- do NOT wait for user to ask)
+
+Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
+- Architecture or design decision made
+- Team convention documented or established
+- Workflow change agreed upon
+- Tool or library choice made with tradeoffs
+- Bug fix completed (include root cause)
+- Feature implemented with non-obvious approach
+- Configuration change or environment setup done
+- Non-obvious discovery about the codebase
+- Gotcha, edge case, or unexpected behavior found
+- Pattern established (naming, structure, convention)
+- User preference or constraint learned
+
+Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
+
+Format for `mem_save`:
+- **title**: Verb + what -- short, searchable (e.g. "Fixed N+1 query in UserList")
+- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
+- **scope**: `project` (default) | `personal`
+- **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **content**:
+  - **What**: One sentence -- what was done
+  - **Why**: What motivated it (user request, bug, performance, etc.)
+  - **Where**: Files or paths affected
+  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Topic update rules:
+- Different topics MUST NOT overwrite each other
+- Same topic evolving -> use same `topic_key` (upsert)
+- Unsure about key -> call `mem_suggest_topic_key` first
+- Know exact ID to fix -> use `mem_update`
+
+### WHEN TO SEARCH MEMORY
+
+On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "que hicimos", or references to past work:
+1. Call `mem_context` -- checks recent session history (fast, cheap)
+2. If not found, call `mem_search` with relevant keywords
+3. If found, use `mem_get_observation` for full untruncated content
+
+Also search PROACTIVELY when:
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+- User's FIRST message references the project, a feature, or a problem -- call `mem_search` with keywords from their message to check for prior work before responding
+
+### SESSION CLOSE PROTOCOL (mandatory)
+
+Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary` with this structure:
+
+```
+## Goal
+[What we were working on this session]
+
+## Instructions
+[User preferences or constraints discovered -- skip if none]
+
+## Discoveries
+- [Technical findings, gotchas, non-obvious learnings]
+
+## Accomplished
+- [Completed items with key details]
+
+## Next Steps
+- [What remains to be done -- for the next session]
+
+## Relevant Files
+- path/to/file -- [what it does or what changed]
+```
+
+This is NOT optional. If you skip this, the next session starts blind.
+
+### AFTER COMPACTION
+
+If you see a compaction message or "FIRST ACTION REQUIRED":
+1. IMMEDIATELY call `mem_session_summary` with the compacted summary content -- this persists what was done before compaction
+2. Call `mem_context` to recover additional context from previous sessions
+3. Only THEN continue working
+
+Do not skip step 1. Without it, everything done before compaction is lost from memory.
+<!-- /team-ai-kit:engram-protocol -->
+
+ENGRAM_PROTOCOL_EOF
+}
+
+update_instructions_engram_protocol() {
+    # Usage: update_instructions_engram_protocol file_path
+    # Updates only the engram-protocol section in an existing instructions file.
+    # Outputs: "changed" or "unchanged"
+    local file_path="$1"
+
+    [[ -f "$file_path" ]] || { echo "unchanged"; return; }
+
+    local existing
+    existing=$(cat "$file_path")
+
+    local start_marker='<!-- team-ai-kit:engram-protocol -->'
+    local end_marker='<!-- /team-ai-kit:engram-protocol -->'
+    local new_section
+    new_section=$(get_engram_protocol_content)
+    # Trim leading/trailing whitespace
+    new_section=$(echo "$new_section" | sed '/./,$!d' | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
+
+    local updated
+    if echo "$existing" | grep -qF "$start_marker"; then
+        # Replace between markers using temp file to avoid escape issues
+        local tmpfile
+        tmpfile=$(mktemp)
+        trap "rm -f '$tmpfile'" EXIT
+        local in_section=false
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == *"$start_marker"* ]]; then
+                printf '%s\n' "$new_section" >> "$tmpfile"
+                in_section=true
+            elif [[ "$line" == *"$end_marker"* ]]; then
+                in_section=false
+            elif [[ "$in_section" == false ]]; then
+                printf '%s\n' "$line" >> "$tmpfile"
+            fi
+        done <<< "$existing"
+        updated=$(cat "$tmpfile")
+        rm -f "$tmpfile"
+        trap - EXIT
+    else
+        updated=$(printf '%s\n\n%s\n' "$existing" "$new_section")
+    fi
+
+    if [[ "$updated" == "$existing" ]]; then
+        echo "unchanged"
+        return
+    fi
+
+    printf '%s\n' "$updated" > "$file_path"
+    echo "changed"
+}
+
 # -- Template Engine -----------------------------------------------------------
 
 get_template_directory() {

--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -18,7 +18,7 @@
         "github": "https://github.com/lazarogadiel93/team-ai-kit"
     },
     "autoupdate": {
-        "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v$version/team-ai-kit-$version.zip"
+        "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v$version/team-ai-kit-v$version.zip"
     },
     "notes": [
         "Run 'team-ai-kit setup' to configure your IDE, role, and team repo.",

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -1111,6 +1111,60 @@ Describe 'Update-InstructionsTeamRules' {
     }
 }
 
+Describe 'Update-InstructionsTeamRules preserves dollar signs in content' {
+    It 'does not corrupt $1 $2 or $variable in team rules' {
+        $tempFile = Join-Path $env:TEMP "instructions-dollar-$(Get-Random).md"
+        try {
+            $initial = @"
+# Header
+<!-- team-ai-kit:team-rules -->
+# Old Rules
+<!-- /team-ai-kit:team-rules -->
+# Footer
+"@
+            Set-Content -Path $tempFile -Value $initial
+            $rulesWithDollars = 'Use $1 for first arg, $variable for config, and $HOME for home dir'
+            $result = Update-InstructionsTeamRules -FilePath $tempFile -TeamRulesContent $rulesWithDollars
+            $result | Should -BeTrue
+            $content = Get-Content -Path $tempFile -Raw
+            $content | Should -BeLike '*$1*'
+            $content | Should -BeLike '*$variable*'
+            $content | Should -BeLike '*$HOME*'
+            $content | Should -BeLike '*# Footer*'
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Update-InstructionsEngramProtocol preserves dollar signs in content' {
+    It 'does not corrupt content containing dollar signs during replacement' {
+        $tempFile = Join-Path $env:TEMP "instructions-engram-dollar-$(Get-Random).md"
+        try {
+            # Create a file with engram protocol markers containing $-variables
+            $initial = @"
+# Header
+<!-- team-ai-kit:engram-protocol -->
+Old protocol with `$1` and `$variable`
+<!-- /team-ai-kit:engram-protocol -->
+# Footer
+"@
+            Set-Content -Path $tempFile -Value $initial
+            $result = Update-InstructionsEngramProtocol -FilePath $tempFile
+            $result | Should -BeTrue
+            $content = Get-Content -Path $tempFile -Raw
+            # The new protocol content should be there and footer preserved
+            $content | Should -BeLike '*engram-protocol*'
+            $content | Should -BeLike '*mem_save*'
+            $content | Should -BeLike '*# Footer*'
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 Describe 'Get-TeamRepoLocalPath with -RepoUrl' {
     It 'returns different paths for different URLs' {
         $path1 = Get-TeamRepoLocalPath -RepoUrl 'https://github.com/team-a/knowledge'


### PR DESCRIPTION
## Summary
Judgment Day review of v2.6.0 found 5 confirmed real warnings. All fixed.

Closes #68

### Fixes
1. **PS `-replace` with `$` corruption** — Replaced regex `-replace` with IndexOf+Substring in both `Update-InstructionsEngramProtocol` and `Update-InstructionsTeamRules`
2. **PS `Install-GitHooks` CRLF** — Changed from Set-Content/Add-Content to `[System.IO.File]::WriteAllText()` with LF normalization
3. **Bash missing Engram Protocol Step 4** — Added `get_engram_protocol_content()` and `update_instructions_engram_protocol()` to bash CLI
4. **Scoop autoupdate URL** — Fixed missing `v` prefix in `autoupdate.url`
5. **Bash dead code + trailing newline** — Removed no-op line, added `|| [[ -n line ]]` guard and tmpfile trap cleanup

| File | Change |
|------|--------|
| `lib/functions.ps1` | IndexOf+Substring for marker replacement, LF hooks |
| `lib/functions.sh` | New engram protocol functions, dead code removal, newline fix |
| `bin/team-ai-kit` | Step 4 in cmd_update |
| `scoop/team-ai-kit.json` | autoupdate URL v prefix |
| `tests/functions.Tests.ps1` | 2 new tests for `$` round-trip |

### Test Plan
- [x] 222/222 Pester tests pass
- [x] Round 2 Judgment Day: 0 CRITICALs, 0 confirmed real WARNINGs