### PR TITLE
chore(release): bump version to 2.6.1

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.6.0'
+KIT_VERSION='2.6.1'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -82,7 +82,7 @@ $ErrorActionPreference = 'Stop'
 
 # -- Kit version ---------------------------------------------------------------
 # Single source of truth. Bump this on every release.
-$KitVersion = '2.6.0'
+$KitVersion = '2.6.1'
 
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root


### PR DESCRIPTION
Closes #70

Bump both CLIs from 2.6.0 to 2.6.1 after judgment day fixes.

| File | Change |
|------|--------|
| `bin/team-ai-kit.ps1` | KitVersion 2.6.0 -> 2.6.1 |
| `bin/team-ai-kit` | KIT_VERSION 2.6.0 -> 2.6.1 |