### PR TITLE
fix(update): sync config version on update command

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.6.1'
+KIT_VERSION='2.6.2'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -874,7 +874,7 @@ cmd_update() {
     local now
     now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     local updated_config
-    updated_config=$(get_config | jq --arg ts "$now" '.lastUpdate = $ts')
+    updated_config=$(get_config | jq --arg ts "$now" --arg ver "$KIT_VERSION" '.lastUpdate = $ts | .version = $ver')
     save_config "$updated_config" >/dev/null
     echo ""
     ok "Update complete"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -82,7 +82,7 @@ $ErrorActionPreference = 'Stop'
 
 # -- Kit version ---------------------------------------------------------------
 # Single source of truth. Bump this on every release.
-$KitVersion = '2.6.1'
+$KitVersion = '2.6.2'
 
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root
@@ -888,8 +888,9 @@ function Invoke-UpdateCommand {
         }
     }
 
-    # Step 5: Update config timestamp
+    # Step 5: Update config timestamp and version
     $config.lastUpdate = Get-Date -Format 'o'
+    $config.version = $KitVersion
     Save-TeamAiKitConfig -Config $config | Out-Null
     Write-Host ''
     Write-Ok 'Update complete'


### PR DESCRIPTION
Closes #74

The `update` command sets `lastUpdate` but never updates `version` in global config. After `scoop update`, `team-ai-kit status` still shows the old version from initial setup.

Fix: set `config.version = KitVersion` alongside `lastUpdate` in both PS1 and bash CLIs. Also bumps to v2.6.2.