### PR TITLE
docs: update documentation for v2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ Dev A resuelve bug → engram save → git push → Dev B hace pull → AI de De
 
 El AI recuerda decisiones, bugs resueltos, patrones establecidos -- entre sesiones y entre devs. Sin hacer nada manual.
 
+Para que el AI use engram **proactivamente** (guardar sin que le pidas, buscar contexto previo, hacer resumen al cerrar sesion), team-ai-kit inyecta un **Memory Protocol** en las instrucciones del proyecto. Sin este protocolo, el AI tiene las herramientas pero nunca las usa por su cuenta.
+
+El comando `update` mantiene el protocolo actualizado automaticamente.
+
 > 📖 Como funciona, flujo completo, ejemplo real: **[docs/engram-guide.md](docs/engram-guide.md)**
 
 ---
@@ -368,7 +372,7 @@ Explicacion y ejemplos.
 ## Tests
 
 ```powershell
-# Windows: Pester (154 tests)
+# Windows: Pester (222 tests)
 Invoke-Pester tests/ -Output Detailed
 
 # macOS/Linux: E2E bash (9 tests)
@@ -407,7 +411,7 @@ team-ai-kit/
 ├── packs/                         Reglas por rol
 ├── templates/                     IntelliJ y Cursor (MCP config)
 ├── tests/
-│   ├── functions.Tests.ps1        135 unit tests (Pester)
+│   ├── functions.Tests.ps1        203 unit tests (Pester)
 │   ├── skills.Tests.ps1           19 validation tests (Pester)
 │   └── e2e-bash.sh                9 E2E tests (bash)
 ├── docs/

--- a/docs/engram-guide.md
+++ b/docs/engram-guide.md
@@ -127,7 +127,7 @@ El AI de Dev B, al buscar en engram, encuentra la observacion de Dev A:
 engram se configura automaticamente con `team-ai-kit setup`. Para habilitarlo en un proyecto:
 
 ```bash
-# Inicializar en el proyecto (instala git hooks)
+# Inicializar en el proyecto (instala git hooks + Memory Protocol)
 cd mi-proyecto
 team-ai-kit init
 ```
@@ -135,19 +135,33 @@ team-ai-kit init
 Esto:
 1. Crea el directorio `.engram/` en el proyecto
 2. Instala los git hooks (pre-commit + post-merge)
-3. Configura la base local de engram
+3. Inyecta el **Memory Protocol** en las instrucciones del proyecto
+4. Configura la base local de engram
+
+### Memory Protocol
+
+engram provee herramientas (`mem_save`, `mem_search`, `mem_context`, etc.) via MCP. Pero tener las herramientas no es suficiente -- el AI necesita **instrucciones comportamentales** que le digan:
+
+- **Cuando guardar**: despues de decisiones, bugfixes, descubrimientos, patrones establecidos
+- **Cuando buscar**: al inicio de sesion, cuando el usuario menciona algo del pasado, al trabajar en algo que pudo haberse hecho antes
+- **Cuando resumir**: al cerrar sesion, para que la siguiente sesion no arranque ciega
+
+Sin este protocolo, el AI tiene las herramientas pero **nunca las usa proactivamente**. Es como darle un martillo a alguien sin decirle que hay clavos.
+
+`team-ai-kit init` y `team-ai-kit update` inyectan y mantienen este protocolo actualizado automaticamente en las instrucciones del proyecto.
 
 ### Archivos relevantes
 
 ```
 mi-proyecto/
 ├── .engram/
-│   ├── observations.json    # Observaciones exportadas (commiteado)
-│   └── ...
+│   ├── chunks/                  # Observaciones exportadas (commiteado)
+│   │   └── *.jsonl
+│   └── manifest.json            # Metadata del sync
 ├── .git/hooks/
-│   ├── pre-commit           # Exporta engram antes de commit
-│   └── post-merge           # Importa engram despues de pull
-└── .team-ai-kit.json        # Config del proyecto
+│   ├── pre-commit               # Exporta engram antes de commit
+│   └── post-merge               # Importa engram despues de pull
+└── .team-ai-kit.json            # Config del proyecto
 ```
 
 El directorio `.engram/` se commitea al repo. Asi es como las observaciones viajan entre devs.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -115,7 +115,7 @@ team-ai-kit init
 
 Esto genera:
 - `.team-ai-kit.json` -- config del proyecto (rol, IDE, timestamps)
-- `.github/copilot-instructions.md` (VS Code/IntelliJ) o `.cursor/rules/team-ai-kit.md` (Cursor) o `AGENTS.md` (OpenCode) -- reglas para el AI
+- `.github/copilot-instructions.md` (VS Code/IntelliJ) o `.cursor/rules/team-ai-kit.md` (Cursor) o `AGENTS.md` (OpenCode) -- reglas para el AI, incluyendo el **Memory Protocol** de engram
 - `.engram/` -- directorio nativo de engram sync para compartir conocimiento del proyecto con el equipo (via git hooks)
 
 ### Override de rol por proyecto
@@ -263,7 +263,9 @@ team-ai-kit update
 Esto:
 1. Hace pull del team-knowledge repo (si esta configurado)
 2. Mergea skills nuevos o actualizados
-3. **NUNCA pisa** skills que vos modificaste localmente
+3. Actualiza el **Memory Protocol** de engram en las instrucciones del proyecto
+4. Sincroniza la version en el config
+5. **NUNCA pisa** skills que vos modificaste localmente
 
 ---
 

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -1354,7 +1354,7 @@ app.<span class="fn">get</span>(<span class="string">'/users/:id'</span>, <span 
         <div class="flow-arrow">&rarr;</div>
         <div class="flow-node flow-node--highlight">
           <div class="flow-title">engram save</div>
-          <div class="flow-desc">Guarda automáticamente en .engram/</div>
+          <div class="flow-desc">Guarda en SQLite local (~/.engram/)</div>
         </div>
         <div class="flow-arrow">&rarr;</div>
         <div class="flow-node">
@@ -1384,6 +1384,21 @@ app.<span class="fn">get</span>(<span class="string">'/users/:id'</span>, <span 
           <strong>Semanas después</strong>, Dev B trabaja en otro servicio que usa el mismo patrón de cache.
           Su AI ya sabe del problema anterior y le advierte sobre la race condition
           <strong>antes de que ocurra</strong>.
+        </p>
+      </div>
+
+      <div class="alert alert--warning fade-in" style="max-width: 760px; margin: 1rem auto;">
+        <h4>Memory Protocol &mdash; la pieza clave</h4>
+        <p>
+          engram provee las herramientas (<code>mem_save</code>, <code>mem_search</code>, etc.) via MCP.
+          Pero tener las herramientas no es suficiente &mdash; <strong>el AI necesita instrucciones
+          comportamentales</strong> que le digan <em>cuándo</em> guardar, <em>cuándo</em> buscar,
+          y <em>cuándo</em> hacer un resumen de sesión.
+        </p>
+        <p style="margin-top: 0.75rem;">
+          Team AI Kit inyecta automáticamente un <strong>Memory Protocol</strong> en las instrucciones
+          del proyecto (<code>team-ai-kit init</code> / <code>team-ai-kit update</code>). Sin este
+          protocolo, el AI tiene las herramientas pero <strong>nunca las usa proactivamente</strong>.
         </p>
       </div>
     </div>
@@ -1503,7 +1518,7 @@ app.<span class="fn">get</span>(<span class="string">'/users/:id'</span>, <span 
         <a href="https://github.com/lazarogadiel93/team-ai-kit" target="_blank" rel="noopener">
           github.com/lazarogadiel93/team-ai-kit
         </a>
-        &nbsp;&middot;&nbsp; MIT License &nbsp;&middot;&nbsp; v2.3.0
+        &nbsp;&middot;&nbsp; MIT License &nbsp;&middot;&nbsp; v2.6.2
       </p>
     </div>
   </footer>


### PR DESCRIPTION
Closes #78

## Summary
- Update test counts: 135 -> 203 unit tests, 154 -> 222 total
- Add Memory Protocol documentation across all docs (the key discovery: MCP tools alone aren't enough, AI needs behavioral instructions)
- Fix engram export format: `observations.json` -> `chunks/*.jsonl` + `manifest.json`
- Update presentation version: v2.3.0 -> v2.6.2
- Fix engram flow diagram: save goes to SQLite local, not directly to `.engram/`
- Document that `update` now syncs version and maintains Memory Protocol

| File | Change |
|------|--------|
| `README.md` | Test counts, Memory Protocol mention in engram section |
| `docs/presentation.html` | Version, flow diagram fix, Memory Protocol alert box |
| `docs/engram-guide.md` | Memory Protocol section, correct export format |
| `docs/onboarding.md` | Memory Protocol in init output, update steps |