### PR TITLE
feat(scripts): add engram scoop update + version check in doctor

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -202,12 +202,18 @@ function Invoke-SetupCommand {
 
         # -- engram --
         if (Test-EngramInstalled) {
+            if ($Update -and (Test-ScoopInstalled)) {
+                Write-Step 'Updating engram...'
+                try { & scoop update engram }
+                catch { Write-Warn "Failed to update engram: $_" }
+            }
             Write-Ok 'engram available'
         }
         else {
             Write-Step 'Installing engram...'
             if (Test-ScoopInstalled) {
                 try {
+                    & scoop bucket add team-ai-kit https://github.com/lazarogadiel93/scoop-bucket 2>$null
                     & scoop install engram 2>$null
                     Write-Ok 'engram installed via Scoop'
                 }
@@ -997,6 +1003,21 @@ function Invoke-DoctorCommand {
 
     $allGood = $true
 
+    # team-ai-kit version
+    Write-Step 'Checking for updates...'
+    $kitLatest = Get-LatestGithubVersion -Owner 'lazarogadiel93' -Repo 'team-ai-kit'
+    $kitUpdateAvailable = $false
+    if ($kitLatest -and $KitVersion) {
+        try { $kitUpdateAvailable = ([System.Version]$KitVersion) -lt ([System.Version]$kitLatest) }
+        catch { $kitUpdateAvailable = $kitLatest -ne $KitVersion }
+    }
+    if ($kitUpdateAvailable) {
+        Write-Warn "team-ai-kit: v$KitVersion (update available: v$kitLatest) -- run: scoop update team-ai-kit"
+    }
+    else {
+        Write-Ok "team-ai-kit: v$KitVersion"
+    }
+
     # Scoop (optional)
     if (Test-ScoopInstalled) { Write-Ok 'Scoop: installed' }
     else { Write-Warn 'Scoop: NOT found (optional -- direct download available)' }
@@ -1004,14 +1025,28 @@ function Invoke-DoctorCommand {
     # gentle-ai
     if (Test-GentleAiInstalled) {
         $gentlePath = Get-GentleAiBinaryPath
-        Write-Ok "gentle-ai: installed ($gentlePath)"
+        $gentleVer = Get-ToolVersionStatus -Tool 'gentle-ai' -Owner 'Gentleman-Programming' -Repo 'gentle-ai'
+        $verStr = if ($gentleVer.installed) { "v$($gentleVer.installed)" } else { 'unknown' }
+        if ($gentleVer.updateAvailable) {
+            Write-Warn "gentle-ai: $verStr (update available: v$($gentleVer.latest)) -- run: scoop update gentle-ai"
+        }
+        else {
+            Write-Ok "gentle-ai: $verStr ($gentlePath)"
+        }
     }
     else { Write-Err 'gentle-ai: NOT found'; $allGood = $false }
 
     # engram
     if (Test-EngramInstalled) {
         $engramPath = Get-EngramBinaryPath
-        Write-Ok "engram: installed ($engramPath)"
+        $engramVer = Get-ToolVersionStatus -Tool 'engram' -Owner 'Gentleman-Programming' -Repo 'engram'
+        $verStr = if ($engramVer.installed) { "v$($engramVer.installed)" } else { 'unknown' }
+        if ($engramVer.updateAvailable) {
+            Write-Warn "engram: $verStr (update available: v$($engramVer.latest)) -- run: scoop update engram"
+        }
+        else {
+            Write-Ok "engram: $verStr ($engramPath)"
+        }
     }
     else { Write-Err 'engram: NOT found'; $allGood = $false }
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -347,3 +347,31 @@ team-ai-kit update
 1. Verificar que el Copilot plugin esta actualizado
 2. La config MCP se muestra durante el setup -- copiarla a la config de MCP de IntelliJ/Cursor
 3. Verificar engram: `engram --version`
+
+### Scoop no actualiza a la ultima version
+
+Scoop cachea los archivos descargados. Si `scoop update gentle-ai` o `scoop update engram` no instala la version esperada:
+
+```powershell
+# Limpiar cache de Scoop y reintentar
+scoop cache rm gentle-ai
+scoop cache rm engram
+scoop update gentle-ai
+scoop update engram
+```
+
+Si persiste, forzar reinstalacion:
+
+```powershell
+scoop uninstall gentle-ai
+scoop install gentle-ai
+```
+
+### Verificar versiones instaladas
+
+Correr `team-ai-kit doctor` para ver las versiones instaladas y si hay updates disponibles. Tambien se puede verificar manualmente:
+
+```powershell
+gentle-ai version    # version de gentle-ai
+engram version       # version de engram
+```

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -706,7 +706,85 @@ function Get-EngramBinaryPath {
     return $null
 }
 
-# ── gentle-ai Install ────────────────────────────────────────────────────────
+# ── Version Check ─────────────────────────────────────────────────────────────
+
+function Get-InstalledVersion {
+    <#
+    .SYNOPSIS
+        Returns the installed version of a tool (gentle-ai or engram).
+    #>
+    param([Parameter(Mandatory)][string]$Tool)
+    try {
+        $output = & $Tool version 2>$null
+        if ($output -match '(\d+\.\d+\.\d+)') { return $Matches[1] }
+    }
+    catch {}
+    return $null
+}
+
+function Get-LatestGithubVersion {
+    <#
+    .SYNOPSIS
+        Returns the latest release version from a GitHub repo.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Owner,
+        [Parameter(Mandatory)][string]$Repo
+    )
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
+        try {
+            $release = gh release view --repo "$Owner/$Repo" --json tagName 2>$null | ConvertFrom-Json
+            if ($release.tagName -match '(\d+\.\d+\.\d+)') { return $Matches[1] }
+        }
+        catch {
+            Write-Verbose "gh release view failed for ${Owner}/${Repo}: $_"
+        }
+    }
+    else {
+        Write-Verbose 'gh CLI not found -- skipping GitHub API version check'
+    }
+    # Fallback: scoop info
+    if (Test-ScoopInstalled) {
+        try {
+            $info = & scoop info $Repo 2>$null | Out-String
+            if ($info -match 'Version\s*:\s*(\d+\.\d+\.\d+)') { return $Matches[1] }
+        }
+        catch {
+            Write-Verbose "scoop info fallback failed for ${Repo}: $_"
+        }
+    }
+    Write-Verbose "Could not determine latest version for ${Owner}/${Repo}"
+    return $null
+}
+
+function Get-ToolVersionStatus {
+    <#
+    .SYNOPSIS
+        Returns a hashtable with installed, latest, and updateAvailable for a tool.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Tool,
+        [Parameter(Mandatory)][string]$Owner,
+        [Parameter(Mandatory)][string]$Repo
+    )
+    $installed = Get-InstalledVersion -Tool $Tool
+    $latest = Get-LatestGithubVersion -Owner $Owner -Repo $Repo
+    $updateAvailable = $false
+    if ($installed -and $latest) {
+        try {
+            $updateAvailable = ([System.Version]$installed) -lt ([System.Version]$latest)
+        }
+        catch {
+            Write-Verbose "Version comparison failed for $Tool (installed=$installed, latest=$latest): $_"
+            $updateAvailable = $installed -ne $latest
+        }
+    }
+    return @{
+        installed       = $installed
+        latest          = $latest
+        updateAvailable = $updateAvailable
+    }
+}
 
 function Invoke-GentleAiInstall {
     <#

--- a/scoop/engram.json
+++ b/scoop/engram.json
@@ -1,0 +1,35 @@
+{
+    "version": "1.12.0",
+    "description": "Persistent memory for AI coding agents. Agent-agnostic Go binary with SQLite + FTS5.",
+    "homepage": "https://github.com/Gentleman-Programming/engram",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Gentleman-Programming/engram/releases/download/v1.12.0/engram_1.12.0_windows_amd64.zip",
+            "hash": "2c14b300e9195e4b88b9730901f3e973be997cae84c38eaf82cd1c2905b767db",
+            "bin": [
+                "engram.exe"
+            ]
+        },
+        "arm64": {
+            "url": "https://github.com/Gentleman-Programming/engram/releases/download/v1.12.0/engram_1.12.0_windows_arm64.zip",
+            "hash": "2be6efd1ca199c14ef9efc83ee93d33f66cdb18930a1df7d5ae28e9a4f92a60e",
+            "bin": [
+                "engram.exe"
+            ]
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/Gentleman-Programming/engram"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Gentleman-Programming/engram/releases/download/v$version/engram_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Gentleman-Programming/engram/releases/download/v$version/engram_$version_windows_arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #80

## Summary
- Add engram Scoop manifest so it can be updated via `scoop update engram`
- `team-ai-kit update` now also updates engram (same pattern as gentle-ai)
- `team-ai-kit doctor` shows installed versions + available updates for all 3 tools
- Document `scoop cache rm` workaround in troubleshooting

## Changes

| File | Change |
|------|--------|
| `scoop/engram.json` | New Scoop manifest with autoupdate for engram |
| `lib/functions.ps1` | Add Get-InstalledVersion, Get-LatestGithubVersion, Get-ToolVersionStatus |
| `bin/team-ai-kit.ps1` | Engram update in prerequisites + version check in doctor |
| `docs/onboarding.md` | Troubleshooting: scoop cache rm + version verification |
| `scoop/team-ai-kit.json` | Fix suggest bucket references |

## Deployment Note
`scoop/engram.json` must be copied to the `lazarogadiel93/scoop-bucket` repo for `scoop install engram` / `scoop update engram` to work.

## Test Plan
- [x] 222 Pester tests pass
- [x] Judgment Day: 2 rounds, both judges approved
- [x] Shellcheck N/A (PowerShell only)

## Checklist
- [x] Linked an approved issue
- [x] Added type:feature label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers