### PR TITLE
chore(release): bump version to 2.6.3

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.6.2'
+KIT_VERSION='2.6.3'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -82,7 +82,7 @@ $ErrorActionPreference = 'Stop'
 
 # -- Kit version ---------------------------------------------------------------
 # Single source of truth. Bump this on every release.
-$KitVersion = '2.6.2'
+$KitVersion = '2.6.3'
 
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -1518,7 +1518,7 @@ app.<span class="fn">get</span>(<span class="string">'/users/:id'</span>, <span 
         <a href="https://github.com/lazarogadiel93/team-ai-kit" target="_blank" rel="noopener">
           github.com/lazarogadiel93/team-ai-kit
         </a>
-        &nbsp;&middot;&nbsp; MIT License &nbsp;&middot;&nbsp; v2.6.2
+        &nbsp;&middot;&nbsp; MIT License &nbsp;&middot;&nbsp; v2.6.3
       </p>
     </div>
   </footer>

--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.6.2",
+    "version": "2.6.3",
     "description": "Team AI Kit - gentle-ai for teams. Standardizes AI usage across development teams with role-based skills, shared memory, and zero-friction onboarding.",
     "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
     "license": "MIT",
-    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.6.2/team-ai-kit-v2.6.2.zip",
-    "hash": "2e3df8e2e31404a5057648f507c881483778b399873def10d1c6904b55298b3e",
+    "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.6.3/team-ai-kit-v2.6.3.zip",
+    "hash": "",
     "extract_dir": "team-ai-kit",
     "bin": [
         ["bin\\team-ai-kit.ps1", "team-ai-kit"]


### PR DESCRIPTION
﻿## Summary
- Bumps version from 2.6.2 to 2.6.3
- Includes engram scoop update + version check in doctor (PR #81)

## Changes
- bin/team-ai-kit.ps1 - KitVersion bump
- bin/team-ai-kit - KIT_VERSION bump (bash)
- scoop/team-ai-kit.json - version + URL updated (hash pending release asset)
- docs/presentation.html - footer version
