### PR TITLE
feat: enable Cursor delegation to gentle-ai and deduplicate Engram Protocol

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -357,8 +357,9 @@ function Invoke-SetupCommand {
         Write-Step 'Skipping gentle-ai install (SkipGentleAi flag)'
     }
     else {
-        # IntelliJ/Cursor: no gentle-ai adapter
-        $ideName = if ($Ide -eq 'cursor') { 'Cursor' } else { 'IntelliJ + Copilot' }
+        # IDE without gentle-ai adapter -- manual MCP setup
+        $ideNames = @{ 'intellij' = 'IntelliJ + Copilot' }
+        $ideName = if ($ideNames.ContainsKey($Ide.ToLower())) { $ideNames[$Ide.ToLower()] } else { $Ide }
         Write-Step "$ideName`: no gentle-ai adapter available"
         Write-Step 'Setting up MCP config from template...'
 
@@ -377,10 +378,7 @@ function Invoke-SetupCommand {
             else {
                 # Show MCP config for manual setup
                 $engramPath = if ($engramBin) { $engramBin } else { '(path-to-engram)' }
-                if ($Ide -eq 'cursor') {
-                    $mcpJson = New-CursorMcpConfig -EngramBinaryPath $engramPath
-                }
-                elseif ($Ide -eq 'intellij') {
+                if ($Ide -eq 'intellij') {
                     $mcpJson = New-IntelliJMcpConfig -EngramBinaryPath $engramPath
                 }
                 else {
@@ -441,7 +439,8 @@ function Invoke-SetupCommand {
     if ($packRulesPath) {
         $packRulesContent = Get-Content -Path $packRulesPath -Raw
     }
-    $instructions = New-CopilotInstructions -Role $Role -PackRulesContent $packRulesContent
+    $skipProtocol = Test-GentleAiSupportsIde -Ide $Ide
+    $instructions = New-CopilotInstructions -Role $Role -PackRulesContent $packRulesContent -SkipEngramProtocol:$skipProtocol
     Write-Ok "Project instructions generated for role: $Role"
     Write-Step 'Run "team-ai-kit init" in each project to apply instructions'
 
@@ -472,7 +471,7 @@ function Invoke-SetupCommand {
         Write-Host '       (configures instructions, team skills, engram sync, and git hooks)' -ForegroundColor DarkGray
         Write-Host '    2. Open your IDE and start working!' -ForegroundColor White
     }
-    elseif ($Ide -eq 'intellij' -or $Ide -eq 'cursor') {
+    elseif (-not (Test-GentleAiSupportsIde -Ide $Ide)) {
         Write-Host '    1. Add the MCP config shown above to your IDE settings' -ForegroundColor White
         Write-Host '    2. Go to your project and run: team-ai-kit init' -ForegroundColor White
         Write-Host '       (configures instructions, team skills, engram sync, and git hooks)' -ForegroundColor DarkGray
@@ -587,7 +586,8 @@ function Invoke-InitCommand {
         }
     }
 
-    $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent
+    $skipProtocol = Test-GentleAiSupportsIde -Ide $effectiveIde
+    $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent -SkipEngramProtocol:$skipProtocol
     [System.IO.File]::WriteAllText($instructionsPath, $instructions, [System.Text.Encoding]::UTF8)
     $relInstructionsPath = $instructionsPath.Replace($projectRoot, '').TrimStart('\', '/')
     Write-Ok "Created: $relInstructionsPath"
@@ -881,12 +881,19 @@ function Invoke-UpdateCommand {
     }
 
     # Step 4: Auto-update engram Memory Protocol in instructions
+    # Skip for IDEs where gentle-ai handles the protocol globally
     if ($projectConfig) {
         $instructionsPath = Get-IdeInstructionsPath -Ide $config.ide -ProjectRoot $projectRoot
         if (Test-Path $instructionsPath) {
-            $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath
+            $skipProtocol = Test-GentleAiSupportsIde -Ide $config.ide
+            $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath -SkipEngramProtocol:$skipProtocol
             if ($protocolChanged) {
-                Write-Ok 'Engram Memory Protocol updated in project instructions'
+                if ($skipProtocol) {
+                    Write-Ok 'Engram Memory Protocol removed from project instructions (gentle-ai handles it)'
+                }
+                else {
+                    Write-Ok 'Engram Memory Protocol updated in project instructions'
+                }
             }
             else {
                 Write-Step 'Engram Memory Protocol unchanged in project instructions'

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -396,6 +396,7 @@ function Get-GentleAiAgentId {
     $map = @{
         'vscode'   = 'vscode-copilot'
         'opencode' = 'opencode'
+        'cursor'   = 'cursor'
     }
     return $map[$Ide.ToLower()]
 }
@@ -1706,14 +1707,16 @@ function Update-InstructionsEngramProtocol {
     <#
     .SYNOPSIS
         Updates the engram-protocol section in an existing instructions file.
+        If SkipEngramProtocol is set, removes existing markers instead of updating.
         If markers exist, replaces content between them.
-        If no markers exist, inserts after the Team Conventions header.
+        If no markers exist and not skipping, inserts after the Team Conventions header.
     .OUTPUTS
         $true if the file was changed, $false if content is the same.
     #>
     param(
         [Parameter(Mandatory)]
-        [string]$FilePath
+        [string]$FilePath,
+        [switch]$SkipEngramProtocol
     )
 
     if (-not (Test-Path $FilePath)) { return $false }
@@ -1722,10 +1725,27 @@ function Update-InstructionsEngramProtocol {
     $startMarker = '<!-- team-ai-kit:engram-protocol -->'
     $endMarker = '<!-- /team-ai-kit:engram-protocol -->'
 
+    $startIdx = $existing.IndexOf($startMarker)
+
+    if ($SkipEngramProtocol) {
+        # Remove existing engram protocol block if present
+        if ($startIdx -ge 0) {
+            $endIdx = $existing.IndexOf($endMarker, $startIdx)
+            if ($endIdx -ge 0) {
+                $endIdx += $endMarker.Length
+                $updated = $existing.Substring(0, $startIdx) + $existing.Substring($endIdx)
+                $updated = $updated -replace '(\r?\n){3,}', "`r`n`r`n"
+                $updated = $updated.TrimEnd() + "`r`n"
+                if ($updated -eq $existing) { return $false }
+                [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.Encoding]::UTF8)
+                return $true
+            }
+        }
+        return $false
+    }
+
     $protocolContent = Get-EngramProtocolContent
     $newSection = $protocolContent.Trim()
-
-    $startIdx = $existing.IndexOf($startMarker)
     if ($startIdx -ge 0) {
         $endIdx = $existing.IndexOf($endMarker, $startIdx)
         if ($endIdx -ge 0) {
@@ -1750,15 +1770,17 @@ function Update-InstructionsEngramProtocol {
 function New-CopilotInstructions {
     <#
     .SYNOPSIS
-        Generates the copilot-instructions.md content with engram Memory Protocol
-        and team rules injected. Engram protocol is always included (team-ai-kit
-        requires engram).
+        Generates the copilot-instructions.md content with team rules injected.
+        Engram protocol is only included for IDEs where gentle-ai does NOT handle it
+        (e.g. IntelliJ). For gentle-ai-supported IDEs, gentle-ai injects the protocol
+        globally and team-ai-kit skips it to avoid duplication.
     #>
     param(
         [Parameter(Mandatory)]
         [string]$Role,
         [string]$PackRulesContent = '',
-        [string]$TeamRulesContent = ''
+        [string]$TeamRulesContent = '',
+        [switch]$SkipEngramProtocol
     )
 
     $header = @"
@@ -1776,9 +1798,12 @@ function New-CopilotInstructions {
 
 "@
 
-    $memoryProtocol = Get-EngramProtocolContent
+    $result = $header
 
-    $result = $header + $memoryProtocol
+    if (-not $SkipEngramProtocol) {
+        $memoryProtocol = Get-EngramProtocolContent
+        $result += $memoryProtocol
+    }
 
     if ($PackRulesContent) {
         $result += "`n$PackRulesContent`n"

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -28,8 +28,8 @@ Describe 'Get-GentleAiAgentId' {
         Get-GentleAiAgentId -Ide 'intellij' | Should -BeNullOrEmpty
     }
 
-    It 'returns $null for cursor (no gentle-ai adapter)' {
-        Get-GentleAiAgentId -Ide 'cursor' | Should -BeNullOrEmpty
+    It 'maps cursor to cursor' {
+        Get-GentleAiAgentId -Ide 'cursor' | Should -Be 'cursor'
     }
 
     It 'returns $null for unknown IDEs' {
@@ -39,6 +39,7 @@ Describe 'Get-GentleAiAgentId' {
     It 'is case-insensitive' {
         Get-GentleAiAgentId -Ide 'VSCode' | Should -Be 'vscode-copilot'
         Get-GentleAiAgentId -Ide 'OPENCODE' | Should -Be 'opencode'
+        Get-GentleAiAgentId -Ide 'CURSOR' | Should -Be 'cursor'
     }
 }
 
@@ -55,8 +56,8 @@ Describe 'Test-GentleAiSupportsIde' {
         Test-GentleAiSupportsIde -Ide 'intellij' | Should -BeFalse
     }
 
-    It 'returns $false for cursor' {
-        Test-GentleAiSupportsIde -Ide 'cursor' | Should -BeFalse
+    It 'returns $true for cursor' {
+        Test-GentleAiSupportsIde -Ide 'cursor' | Should -BeTrue
     }
 
     It 'returns $false for unknown IDEs' {
@@ -492,6 +493,26 @@ Describe 'New-CopilotInstructions' {
         $instructions = New-CopilotInstructions -Role 'frontend'
         $instructions | Should -Not -BeLike '*team-ai-kit:team-rules*'
     }
+
+    It 'skips engram protocol when SkipEngramProtocol is set' {
+        $instructions = New-CopilotInstructions -Role 'frontend' -SkipEngramProtocol
+        $instructions | Should -Not -BeLike '*team-ai-kit:engram-protocol*'
+        $instructions | Should -Not -BeLike '*mem_save*'
+        $instructions | Should -BeLike '*Team Conventions*'
+    }
+
+    It 'includes engram protocol when SkipEngramProtocol is not set' {
+        $instructions = New-CopilotInstructions -Role 'frontend'
+        $instructions | Should -BeLike '*team-ai-kit:engram-protocol*'
+        $instructions | Should -BeLike '*mem_save*'
+    }
+
+    It 'skips engram protocol but keeps team rules when both flags used' {
+        $instructions = New-CopilotInstructions -Role 'frontend' -TeamRulesContent '## Team Rules' -SkipEngramProtocol
+        $instructions | Should -Not -BeLike '*team-ai-kit:engram-protocol*'
+        $instructions | Should -BeLike '*<!-- team-ai-kit:team-rules -->*'
+        $instructions | Should -BeLike '*Team Rules*'
+    }
 }
 
 Describe 'Update-InstructionsEngramProtocol' {
@@ -547,6 +568,41 @@ Describe 'Update-InstructionsEngramProtocol' {
             $initial = "# Header`n`n$($protocol.Trim())"
             Set-Content -Path $tempFile -Value $initial
             $result = Update-InstructionsEngramProtocol -FilePath $tempFile
+            $result | Should -BeFalse
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'removes existing protocol when SkipEngramProtocol is set' {
+        $tempFile = Join-Path $env:TEMP "instructions-$(Get-Random).md"
+        try {
+            $initial = @"
+# Header
+<!-- team-ai-kit:engram-protocol -->
+## Old Protocol
+<!-- /team-ai-kit:engram-protocol -->
+# Footer
+"@
+            Set-Content -Path $tempFile -Value $initial
+            $result = Update-InstructionsEngramProtocol -FilePath $tempFile -SkipEngramProtocol
+            $result | Should -BeTrue
+            $content = Get-Content -Path $tempFile -Raw
+            $content | Should -Not -BeLike '*engram-protocol*'
+            $content | Should -BeLike '*# Header*'
+            $content | Should -BeLike '*# Footer*'
+        }
+        finally {
+            Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns $false when SkipEngramProtocol is set and no markers exist' {
+        $tempFile = Join-Path $env:TEMP "instructions-$(Get-Random).md"
+        try {
+            Set-Content -Path $tempFile -Value '# No protocol here'
+            $result = Update-InstructionsEngramProtocol -FilePath $tempFile -SkipEngramProtocol
             $result | Should -BeFalse
         }
         finally {


### PR DESCRIPTION
## Summary
- Enable Cursor as a gentle-ai delegated IDE (`Get-GentleAiAgentId` now maps `cursor` to `cursor`) since gentle-ai v1.20.0 supports it with native subagents
- Skip Engram Protocol injection in project instructions for IDEs where gentle-ai handles it globally (vscode, opencode, cursor), avoiding duplicate protocol blocks that waste context tokens
- On `update`, remove existing `team-ai-kit:engram-protocol` markers from instructions for gentle-ai-supported IDEs
- IntelliJ retains its own Engram Protocol injection since gentle-ai does not support it

## Changes
- `lib/functions.ps1`: Added `cursor` to agent map, `SkipEngramProtocol` switch on `New-CopilotInstructions` and `Update-InstructionsEngramProtocol`, CRLF-aware regex for block removal
- `bin/team-ai-kit.ps1`: setup/init/update pass `SkipEngramProtocol` based on `Test-GentleAiSupportsIde`, dynamic IDE name in else branch, dead cursor condition removed from next-steps
- `tests/functions.Tests.ps1`: Updated cursor mapping tests, added SkipEngramProtocol tests (alone + with TeamRulesContent)

## Judgment Day
Round 1: 2 confirmed real WARNINGs + 1 confirmed SUGGESTION - fixed
Round 2: Both judges CLEAN - **APPROVED**

Closes #85, closes #86
