### PR TITLE
refactor(doctor): only show team repo inside initialized projects

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -1096,12 +1096,17 @@ function Invoke-DoctorCommand {
         }
     }
 
-    # Team repo
-    if ($config.teamRepo) {
-        Write-Ok "Team repo: $($config.teamRepo)"
-    }
-    else {
-        Write-Warn 'Team repo: not configured'
+    # Team repo (only shown inside an initialized project)
+    $projectRoot2 = (Get-Location).Path
+    if (Test-ProjectInitialized -ProjectRoot $projectRoot2) {
+        $pc2 = Get-ProjectConfig -ProjectRoot $projectRoot2
+        $effectiveRepo = if ($pc2.teamRepo) { $pc2.teamRepo } elseif ($config.teamRepo) { $config.teamRepo } else { '' }
+        if ($effectiveRepo) {
+            Write-Ok "Team repo: $effectiveRepo"
+        }
+        else {
+            Write-Step 'Team repo: not configured (use "team-ai-kit init -TeamRepo <url>")'
+        }
     }
 
     Write-Host ''

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -1079,7 +1079,7 @@ function Invoke-DoctorCommand {
         }
     }
 
-    # Project-level skills
+    # Project-level skills & team repo (only inside an initialized project)
     $projectRoot = (Get-Location).Path
     if ($config.ide -and (Test-ProjectInitialized -ProjectRoot $projectRoot)) {
         $pc = Get-ProjectConfig -ProjectRoot $projectRoot
@@ -1094,18 +1094,14 @@ function Invoke-DoctorCommand {
         else {
             Write-Step 'Project skills: not installed (run "team-ai-kit init" with a team repo)'
         }
-    }
 
-    # Team repo (only shown inside an initialized project)
-    $projectRoot2 = (Get-Location).Path
-    if (Test-ProjectInitialized -ProjectRoot $projectRoot2) {
-        $pc2 = Get-ProjectConfig -ProjectRoot $projectRoot2
-        $effectiveRepo = if ($pc2.teamRepo) { $pc2.teamRepo } elseif ($config.teamRepo) { $config.teamRepo } else { '' }
+        # Team repo
+        $effectiveRepo = if ($pc.teamRepo) { $pc.teamRepo } elseif ($config.teamRepo) { $config.teamRepo } else { '' }
         if ($effectiveRepo) {
             Write-Ok "Team repo: $effectiveRepo"
         }
         else {
-            Write-Step 'Team repo: not configured (use "team-ai-kit init -TeamRepo <url>")'
+            Write-Warn 'Team repo: not configured (use "team-ai-kit init -TeamRepo <url>")'
         }
     }
 


### PR DESCRIPTION
## Summary
- Team repo info in `doctor` is now only shown when inside an initialized project
- Outside a project, the team repo line is omitted entirely (it's a project-level concept)
- Inside a project, shows project-level teamRepo or falls back to global default

Closes #90