### PR TITLE
fix(init): replace -Ide with -TeamRepo in re-init guard

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -512,7 +512,7 @@ function Invoke-InitCommand {
         if ($Force) {
             Write-Warn "Already initialized (Role=$($existingConfig.role)). Re-initializing (--Force)."
         }
-        elseif (-not $Role -and -not $Ide) {
+        elseif (-not $Role -and -not $TeamRepo) {
             # Interactive mode: show config and ask
             Write-Warn 'This project is already initialized:'
             Write-Host "    Role:        $($existingConfig.role)" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary
- Fixed re-init guard in `init` command that incorrectly checked `-Ide` param
- Replaced with `-TeamRepo` which is actually meaningful for init
- `-Ide` is a setup-level param; checking it caused `init -Ide vscode` to bypass the interactive prompt and hit an error exit

Closes #92