### PR TITLE
refactor: fix 4 code smells from audit

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -357,7 +357,7 @@ function Invoke-SetupCommand {
         Write-Step 'Skipping gentle-ai install (SkipGentleAi flag)'
     }
     else {
-        # IDE without gentle-ai adapter -- manual MCP setup
+        # IDE without gentle-ai adapter -- manual MCP setup (currently only IntelliJ)
         $ideNames = @{ 'intellij' = 'IntelliJ + Copilot' }
         $ideName = if ($ideNames.ContainsKey($Ide.ToLower())) { $ideNames[$Ide.ToLower()] } else { $Ide }
         Write-Step "$ideName`: no gentle-ai adapter available"
@@ -433,15 +433,7 @@ function Invoke-SetupCommand {
     $totalSkipped = $mergeResults.skipped.Count
     Write-Ok "$totalInstalled installed, $totalUpdated updated, $totalSkipped unchanged"
 
-    # 5c. Generate project-level instructions (to be committed to repos)
-    $packRulesPath = Get-PackRulesPath -KitRoot $kitRoot -Role $Role
-    $packRulesContent = ''
-    if ($packRulesPath) {
-        $packRulesContent = Get-Content -Path $packRulesPath -Raw
-    }
-    $skipProtocol = Test-GentleAiSupportsIde -Ide $Ide
-    $instructions = New-CopilotInstructions -Role $Role -PackRulesContent $packRulesContent -SkipEngramProtocol:$skipProtocol
-    Write-Ok "Project instructions generated for role: $Role"
+    # 5c. Project-level instructions are generated during "init", not setup
     Write-Step 'Run "team-ai-kit init" in each project to apply instructions'
 
     # -- Save config -----------------------------------------------------------
@@ -561,10 +553,8 @@ function Invoke-InitCommand {
     # Resolve team repo URL: CLI param > project config > global config
     $effectiveTeamRepo = if ($TeamRepo) { $TeamRepo }
         elseif ($existingConfig -and $existingConfig.teamRepo) { $existingConfig.teamRepo }
-        else {
-            $gc = Get-TeamAiKitConfig
-            if ($gc.teamRepo) { $gc.teamRepo } else { '' }
-        }
+        elseif ($globalConfig.teamRepo) { $globalConfig.teamRepo }
+        else { '' }
 
     # Clone/pull team repo if configured
     $teamRulesContent = ''

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
     Team AI Kit -- Reusable functions for setup and configuration.
 .DESCRIPTION
-    Pure/testable functions used by setup.ps1. No interactive prompts here.
+    Pure/testable functions used by bin/team-ai-kit.ps1. No interactive prompts here.
 #>
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary
- Removed unused `\` generation in setup (only needed during init)
- Clarified IntelliJ-only fallback map with comment
- Fixed outdated comment referencing `setup.ps1` instead of `bin/team-ai-kit.ps1`
- Reused `\` instead of redundant `Get-TeamAiKitConfig` call in init

Closes #98