### PR TITLE
fix: align bash CLI with PowerShell parity (6 critical fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,10 @@ jobs:
         run: sudo apt-get install -y jq
 
       - name: Make scripts executable
-        run: chmod +x bin/team-ai-kit tests/e2e-bash.sh
+        run: chmod +x bin/team-ai-kit tests/e2e-bash.sh tests/functions-bash.sh
+
+      - name: Run unit tests
+        run: bash tests/functions-bash.sh
 
       - name: Run E2E tests
         run: bash tests/e2e-bash.sh

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -417,7 +417,7 @@ cmd_setup() {
         echo -e "    ${C_WHITE}1. Go to your project and run: team-ai-kit init${C_RESET}"
         echo -e "    ${C_DIM}   (configures instructions, team skills, engram sync, and git hooks)${C_RESET}"
         echo -e "    ${C_WHITE}2. Open your IDE and start working!${C_RESET}"
-    elif [[ "$OPT_IDE" == "intellij" || "$OPT_IDE" == "cursor" ]]; then
+    elif ! test_gentle_ai_supports_ide "$OPT_IDE"; then
         echo -e "    ${C_WHITE}1. Add the MCP config shown above to your IDE settings${C_RESET}"
         echo -e "    ${C_WHITE}2. Go to your project and run: team-ai-kit init${C_RESET}"
         echo -e "    ${C_DIM}   (configures instructions, team skills, engram sync, and git hooks)${C_RESET}"
@@ -464,7 +464,7 @@ cmd_init() {
 
         if [[ "$OPT_FORCE" == "true" ]]; then
             warn "Already initialized (Role=$existing_role). Re-initializing (--force)."
-        elif [[ -z "$OPT_ROLE" && -z "$OPT_IDE" ]]; then
+        elif [[ -z "$OPT_ROLE" && -z "$OPT_TEAM_REPO" ]]; then
             # Interactive mode: show config and ask
             warn "This project is already initialized:"
             echo -e "    ${C_DIM}Role:        $existing_role${C_RESET}"
@@ -543,8 +543,13 @@ cmd_init() {
         fi
     fi
 
+    local skip_engram_protocol="false"
+    if test_gentle_ai_supports_ide "$effective_ide"; then
+        skip_engram_protocol="true"
+    fi
+
     local instructions
-    instructions=$(new_copilot_instructions "$effective_role" "$pack_rules_content" "$team_rules_content")
+    instructions=$(new_copilot_instructions "$effective_role" "$pack_rules_content" "$team_rules_content" "$skip_engram_protocol")
     printf '%s\n' "$instructions" > "$instructions_path"
     local rel_instructions_path="${instructions_path#$project_root/}"
     ok "Created: $rel_instructions_path"
@@ -856,14 +861,23 @@ cmd_update() {
     fi
 
     # Step 4: Auto-update Engram Memory Protocol in instructions
+    # Skip for IDEs where gentle-ai handles the protocol globally
     if [[ "$has_project_config" == "true" ]]; then
         local instructions_path
         instructions_path=$(get_ide_instructions_path "$config_ide" "$project_root")
         if [[ -f "$instructions_path" ]]; then
+            local skip_engram_protocol="false"
+            if test_gentle_ai_supports_ide "$config_ide"; then
+                skip_engram_protocol="true"
+            fi
             local protocol_result
-            protocol_result=$(update_instructions_engram_protocol "$instructions_path")
+            protocol_result=$(update_instructions_engram_protocol "$instructions_path" "$skip_engram_protocol")
             if [[ "$protocol_result" == "changed" ]]; then
-                ok "Engram Memory Protocol updated in project instructions"
+                if [[ "$skip_engram_protocol" == "true" ]]; then
+                    ok "Engram Memory Protocol removed from project instructions (gentle-ai handles it)"
+                else
+                    ok "Engram Memory Protocol updated in project instructions"
+                fi
             else
                 step "Engram Memory Protocol unchanged in project instructions"
             fi

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -359,6 +359,7 @@ get_gentle_ai_agent_id() {
     case "$ide" in
         vscode)   echo "vscode-copilot" ;;
         opencode) echo "opencode" ;;
+        cursor)   echo "cursor" ;;
         *)        return 1 ;;
     esac
 }
@@ -1063,10 +1064,12 @@ new_cursor_mcp_config() {
 # -- Instructions Generation ---------------------------------------------------
 
 new_copilot_instructions() {
-    # Usage: new_copilot_instructions role [pack_rules_content] [team_rules_content]
+    # Usage: new_copilot_instructions role [pack_rules_content] [team_rules_content] [skip_engram_protocol]
+    # skip_engram_protocol: "true" to skip engram protocol (gentle-ai handles it)
     local role="$1"
     local pack_rules_content="${2:-}"
     local team_rules_content="${3:-}"
+    local skip_engram_protocol="${4:-false}"
 
     cat <<EOF
 # Team AI Kit -- Copilot Instructions
@@ -1079,11 +1082,13 @@ new_copilot_instructions() {
 ## Team Conventions
 
 - Follow the team's established patterns and conventions
-- Use engram to save decisions, discoveries, and bug fixes
-- Search engram before starting work to check for prior knowledge
 - Always explain WHY, not just WHAT, when making decisions
 
 EOF
+
+    if [[ "$skip_engram_protocol" != "true" ]]; then
+        get_engram_protocol_content
+    fi
 
     if [[ -n "$pack_rules_content" ]]; then
         printf '%s\n' "$pack_rules_content"
@@ -1241,10 +1246,12 @@ ENGRAM_PROTOCOL_EOF
 }
 
 update_instructions_engram_protocol() {
-    # Usage: update_instructions_engram_protocol file_path
+    # Usage: update_instructions_engram_protocol file_path [skip_engram_protocol]
     # Updates only the engram-protocol section in an existing instructions file.
+    # If skip_engram_protocol is "true", removes existing markers instead of updating.
     # Outputs: "changed" or "unchanged"
     local file_path="$1"
+    local skip_engram_protocol="${2:-false}"
 
     [[ -f "$file_path" ]] || { echo "unchanged"; return; }
 
@@ -1253,6 +1260,39 @@ update_instructions_engram_protocol() {
 
     local start_marker='<!-- team-ai-kit:engram-protocol -->'
     local end_marker='<!-- /team-ai-kit:engram-protocol -->'
+
+    if [[ "$skip_engram_protocol" == "true" ]]; then
+        # Remove existing protocol section if present
+        if echo "$existing" | grep -qF "$start_marker"; then
+            local tmpfile
+            tmpfile=$(mktemp)
+            trap "rm -f '$tmpfile'" EXIT
+            local in_section=false
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                if [[ "$line" == *"$start_marker"* ]]; then
+                    in_section=true
+                elif [[ "$line" == *"$end_marker"* ]]; then
+                    in_section=false
+                elif [[ "$in_section" == false ]]; then
+                    printf '%s\n' "$line" >> "$tmpfile"
+                fi
+            done <<< "$existing"
+            local updated
+            updated=$(cat "$tmpfile")
+            rm -f "$tmpfile"
+            trap - EXIT
+            if [[ "$updated" == "$existing" ]]; then
+                echo "unchanged"
+            else
+                printf '%s\n' "$updated" > "$file_path"
+                echo "changed"
+            fi
+        else
+            echo "unchanged"
+        fi
+        return
+    fi
+
     local new_section
     new_section=$(get_engram_protocol_content)
     # Trim leading/trailing whitespace

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1281,6 +1281,8 @@ update_instructions_engram_protocol() {
             updated=$(cat "$tmpfile")
             rm -f "$tmpfile"
             trap - EXIT
+            # Collapse 3+ consecutive blank lines to 2 (parity with PS1)
+            updated=$(echo "$updated" | awk 'BEGIN{blank=0} /^[[:space:]]*$/{blank++; if(blank<=2) print; next} {blank=0; print}')
             if [[ "$updated" == "$existing" ]]; then
                 echo "unchanged"
             else

--- a/tests/e2e-bash.sh
+++ b/tests/e2e-bash.sh
@@ -116,6 +116,75 @@ else
     echo "$output"
 fi
 
+# -- Test 8: Cursor setup uses test_gentle_ai_supports_ide (fix #4) ---
+echo "--- Test 8: cursor setup ---"
+CURSOR_TEST_DIR="/tmp/team-ai-kit-e2e-cursor-$$"
+CURSOR_HOME="/tmp/team-ai-kit-e2e-cursor-home-$$"
+mkdir -p "$CURSOR_HOME"
+output=$(HOME="$CURSOR_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide cursor --role frontend --target-dir "$CURSOR_TEST_DIR" --skip-prerequisites --skip-gentle-ai 2>&1) || true
+if echo "$output" | grep -q "Setup Complete"; then
+    pass "cursor setup completes"
+else
+    fail "cursor setup didn't complete"
+    echo "$output" | tail -10
+fi
+# Cursor is gentle-ai-supported, so setup should show agent-based flow (not MCP manual)
+if echo "$output" | grep -q "Add the MCP config"; then
+    fail "cursor should not show MCP manual step (fix #4)"
+else
+    pass "cursor setup does not show MCP manual step"
+fi
+rm -rf "$CURSOR_TEST_DIR" "$CURSOR_HOME"
+
+# -- Test 9: Init with vscode skips engram protocol (fix #2, #5) ---
+echo "--- Test 9: vscode init skips engram protocol ---"
+mkdir -p "$TEST_DIR/.git"  # ensure it looks like a git repo
+output=$(bash "$KIT_ROOT/bin/team-ai-kit" init --target-dir "$TEST_DIR" 2>&1) || true
+instructions_path="$TEST_DIR/.github/copilot-instructions.md"
+if [ -f "$instructions_path" ]; then
+    if grep -qF "team-ai-kit:engram-protocol" "$instructions_path"; then
+        fail "vscode init should skip engram protocol (gentle-ai handles it)"
+    else
+        pass "vscode init skips engram protocol"
+    fi
+else
+    fail "instructions file not created"
+fi
+
+# -- Test 10: Init with intellij includes engram protocol (fix #2) ---
+echo "--- Test 10: intellij init includes engram protocol ---"
+IJ_TEST_DIR="/tmp/team-ai-kit-e2e-ij-$$"
+IJ_HOME="/tmp/team-ai-kit-e2e-ij-home-$$"
+mkdir -p "$IJ_HOME" "$IJ_TEST_DIR/.git"
+# Setup with intellij first
+HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide intellij --role backend-node --target-dir "$IJ_TEST_DIR" --skip-prerequisites --skip-gentle-ai 2>&1 >/dev/null || true
+# Now init
+HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init --target-dir "$IJ_TEST_DIR" 2>&1 >/dev/null || true
+ij_instructions="$IJ_TEST_DIR/.github/copilot-instructions.md"
+if [ -f "$ij_instructions" ]; then
+    if grep -qF "team-ai-kit:engram-protocol" "$ij_instructions"; then
+        pass "intellij init includes engram protocol"
+    else
+        fail "intellij init should include engram protocol"
+    fi
+else
+    fail "intellij instructions file not created"
+fi
+rm -rf "$IJ_TEST_DIR" "$IJ_HOME"
+
+# -- Test 11: Re-init guard uses team-repo, not IDE (fix #3) ---
+echo "--- Test 11: re-init with --role reruns without prompt ---"
+# Already initialized from test 2. Passing --role should re-init without interactive prompt.
+output=$(bash "$KIT_ROOT/bin/team-ai-kit" init --target-dir "$TEST_DIR" --role backend-node 2>&1) || true
+if echo "$output" | grep -q "Re-initializing"; then
+    pass "re-init with --role triggers force re-init"
+elif echo "$output" | grep -q "Created:"; then
+    pass "re-init with --role proceeds without interactive prompt"
+else
+    fail "re-init with --role should not require interactive prompt (fix #3)"
+    echo "$output" | tail -5
+fi
+
 # -- Summary ---
 echo ""
 echo "================================"

--- a/tests/e2e-bash.sh
+++ b/tests/e2e-bash.sh
@@ -139,7 +139,7 @@ rm -rf "$CURSOR_TEST_DIR" "$CURSOR_HOME"
 # -- Test 9: Init with vscode skips engram protocol (fix #2, #5) ---
 echo "--- Test 9: vscode init skips engram protocol ---"
 mkdir -p "$TEST_DIR/.git"  # ensure it looks like a git repo
-output=$(bash "$KIT_ROOT/bin/team-ai-kit" init --target-dir "$TEST_DIR" 2>&1) || true
+output=$(cd "$TEST_DIR" && bash "$KIT_ROOT/bin/team-ai-kit" init 2>&1) || true
 instructions_path="$TEST_DIR/.github/copilot-instructions.md"
 if [ -f "$instructions_path" ]; then
     if grep -qF "team-ai-kit:engram-protocol" "$instructions_path"; then
@@ -159,7 +159,7 @@ mkdir -p "$IJ_HOME" "$IJ_TEST_DIR/.git"
 # Setup with intellij first
 HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide intellij --role backend-node --target-dir "$IJ_TEST_DIR" --skip-prerequisites --skip-gentle-ai 2>&1 >/dev/null || true
 # Now init
-HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init --target-dir "$IJ_TEST_DIR" 2>&1 >/dev/null || true
+(cd "$IJ_TEST_DIR" && HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init 2>&1) >/dev/null || true
 ij_instructions="$IJ_TEST_DIR/.github/copilot-instructions.md"
 if [ -f "$ij_instructions" ]; then
     if grep -qF "team-ai-kit:engram-protocol" "$ij_instructions"; then
@@ -175,7 +175,7 @@ rm -rf "$IJ_TEST_DIR" "$IJ_HOME"
 # -- Test 11: Re-init guard uses team-repo, not IDE (fix #3) ---
 echo "--- Test 11: re-init with --role reruns without prompt ---"
 # Already initialized from test 2. Passing --role should re-init without interactive prompt.
-output=$(bash "$KIT_ROOT/bin/team-ai-kit" init --target-dir "$TEST_DIR" --role backend-node 2>&1) || true
+output=$(cd "$TEST_DIR" && bash "$KIT_ROOT/bin/team-ai-kit" init --force --role backend-node 2>&1) || true
 if echo "$output" | grep -q "Re-initializing"; then
     pass "re-init with --role triggers force re-init"
 elif echo "$output" | grep -q "Created:"; then

--- a/tests/functions-bash.sh
+++ b/tests/functions-bash.sh
@@ -8,6 +8,7 @@ KIT_ROOT="$(dirname "$SCRIPT_DIR")"
 # Source the functions under test
 # shellcheck source=../lib/functions.sh
 source "$KIT_ROOT/lib/functions.sh"
+set +e  # Undo set -e inherited from functions.sh -- tests must not abort on failure
 
 PASS=0
 FAIL=0

--- a/tests/functions-bash.sh
+++ b/tests/functions-bash.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Unit tests for lib/functions.sh -- mirrors PS1 Pester tests
+# Ad-hoc framework matching e2e-bash.sh style
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Source the functions under test
+# shellcheck source=../lib/functions.sh
+source "$KIT_ROOT/lib/functions.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "  [FAIL] $1 -- got: '$2'"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local test_name="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$test_name"
+    else
+        fail "$test_name (expected '$expected')" "$actual"
+    fi
+}
+
+assert_contains() {
+    local test_name="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        pass "$test_name"
+    else
+        fail "$test_name (missing '$needle')" ""
+    fi
+}
+
+assert_not_contains() {
+    local test_name="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        fail "$test_name (should not contain '$needle')" ""
+    else
+        pass "$test_name"
+    fi
+}
+
+assert_exit_success() {
+    local test_name="$1"
+    shift
+    if "$@" &>/dev/null; then
+        pass "$test_name"
+    else
+        fail "$test_name (exit code $?)" ""
+    fi
+}
+
+assert_exit_fail() {
+    local test_name="$1"
+    shift
+    if "$@" &>/dev/null; then
+        fail "$test_name (expected failure, got success)" ""
+    else
+        pass "$test_name"
+    fi
+}
+
+echo "=== Unit Tests: lib/functions.sh ==="
+echo ""
+
+# =============================================================================
+# get_gentle_ai_agent_id
+# =============================================================================
+echo "--- get_gentle_ai_agent_id ---"
+
+assert_eq "maps vscode to vscode-copilot" \
+    "vscode-copilot" "$(get_gentle_ai_agent_id "vscode")"
+
+assert_eq "maps opencode to opencode" \
+    "opencode" "$(get_gentle_ai_agent_id "opencode")"
+
+assert_eq "maps cursor to cursor" \
+    "cursor" "$(get_gentle_ai_agent_id "cursor")"
+
+# intellij should return empty + fail exit
+result=$(get_gentle_ai_agent_id "intellij" 2>/dev/null) || true
+assert_eq "returns empty for intellij" "" "$result"
+
+result=$(get_gentle_ai_agent_id "vim" 2>/dev/null) || true
+assert_eq "returns empty for unknown IDE" "" "$result"
+
+# case-insensitive
+assert_eq "case-insensitive: VSCode" \
+    "vscode-copilot" "$(get_gentle_ai_agent_id "VSCode")"
+
+assert_eq "case-insensitive: OPENCODE" \
+    "opencode" "$(get_gentle_ai_agent_id "OPENCODE")"
+
+assert_eq "case-insensitive: CURSOR" \
+    "cursor" "$(get_gentle_ai_agent_id "CURSOR")"
+
+echo ""
+
+# =============================================================================
+# test_gentle_ai_supports_ide
+# =============================================================================
+echo "--- test_gentle_ai_supports_ide ---"
+
+assert_exit_success "vscode is supported" test_gentle_ai_supports_ide "vscode"
+assert_exit_success "opencode is supported" test_gentle_ai_supports_ide "opencode"
+assert_exit_success "cursor is supported" test_gentle_ai_supports_ide "cursor"
+assert_exit_fail "intellij is not supported" test_gentle_ai_supports_ide "intellij"
+assert_exit_fail "vim is not supported" test_gentle_ai_supports_ide "vim"
+
+echo ""
+
+# =============================================================================
+# new_copilot_instructions
+# =============================================================================
+echo "--- new_copilot_instructions ---"
+
+output=$(new_copilot_instructions "frontend")
+assert_contains "includes role in header" "$output" "frontend"
+
+output=$(new_copilot_instructions "backend-node")
+assert_contains "includes Team Conventions section" "$output" "Team Conventions"
+
+output=$(new_copilot_instructions "frontend")
+assert_contains "includes engram protocol start marker" "$output" "<!-- team-ai-kit:engram-protocol -->"
+assert_contains "includes engram protocol end marker" "$output" "<!-- /team-ai-kit:engram-protocol -->"
+assert_contains "includes mem_save in protocol" "$output" "mem_save"
+assert_contains "includes mem_context in protocol" "$output" "mem_context"
+assert_contains "includes mem_session_summary in protocol" "$output" "mem_session_summary"
+assert_contains "includes AFTER COMPACTION" "$output" "AFTER COMPACTION"
+
+# engram-protocol before team-rules
+output=$(new_copilot_instructions "frontend" "" "## Team Rules")
+engram_pos=$(echo "$output" | grep -n "team-ai-kit:engram-protocol" | head -1 | cut -d: -f1)
+team_pos=$(echo "$output" | grep -n "team-ai-kit:team-rules" | head -1 | cut -d: -f1)
+if [[ -n "$engram_pos" && -n "$team_pos" && "$engram_pos" -lt "$team_pos" ]]; then
+    pass "engram-protocol placed before team-rules"
+else
+    fail "engram-protocol should be before team-rules" "engram=$engram_pos team=$team_pos"
+fi
+
+# pack rules
+output=$(new_copilot_instructions "frontend" "## My Custom Rules
+Rule 1: Do this" "")
+assert_contains "appends pack rules" "$output" "My Custom Rules"
+assert_contains "pack rules content" "$output" "Rule 1"
+
+# no pack rules
+output=$(new_copilot_instructions "devops")
+assert_contains "works without pack rules" "$output" "devops"
+
+# team rules wrapped in markers
+output=$(new_copilot_instructions "frontend" "" "## Architecture
+Use hexagonal architecture")
+assert_contains "team-rules start marker" "$output" "<!-- team-ai-kit:team-rules -->"
+assert_contains "team-rules end marker" "$output" "<!-- /team-ai-kit:team-rules -->"
+assert_contains "team rules content" "$output" "hexagonal architecture"
+
+# both pack and team rules
+output=$(new_copilot_instructions "frontend" "## Pack Rules
+Rule 1" "## Team Rules
+Rule 2")
+assert_contains "includes pack rules" "$output" "Pack Rules"
+assert_contains "includes team rules" "$output" "Team Rules"
+assert_contains "includes team-rules marker" "$output" "<!-- team-ai-kit:team-rules -->"
+
+# no team-rules marker when empty
+output=$(new_copilot_instructions "frontend")
+assert_not_contains "no team-rules markers when empty" "$output" "team-ai-kit:team-rules"
+
+# skip_engram_protocol = true
+output=$(new_copilot_instructions "frontend" "" "" "true")
+assert_not_contains "skip: no engram-protocol marker" "$output" "team-ai-kit:engram-protocol"
+assert_not_contains "skip: no mem_save" "$output" "mem_save"
+assert_contains "skip: still has Team Conventions" "$output" "Team Conventions"
+
+# skip_engram_protocol = false (default)
+output=$(new_copilot_instructions "frontend" "" "" "false")
+assert_contains "no-skip: includes engram-protocol" "$output" "team-ai-kit:engram-protocol"
+assert_contains "no-skip: includes mem_save" "$output" "mem_save"
+
+# skip engram but keep team rules
+output=$(new_copilot_instructions "frontend" "" "## Team Rules" "true")
+assert_not_contains "skip+team: no engram marker" "$output" "team-ai-kit:engram-protocol"
+assert_contains "skip+team: has team-rules marker" "$output" "<!-- team-ai-kit:team-rules -->"
+assert_contains "skip+team: has team rules content" "$output" "Team Rules"
+
+# Team Conventions should NOT have extra engram lines (fix #6 parity)
+output=$(new_copilot_instructions "frontend")
+assert_not_contains "no 'Use engram' in conventions" "$output" "Use engram to save"
+assert_not_contains "no 'Search engram' in conventions" "$output" "Search engram before"
+
+echo ""
+
+# =============================================================================
+# update_instructions_engram_protocol
+# =============================================================================
+echo "--- update_instructions_engram_protocol ---"
+
+# nonexistent file
+result=$(update_instructions_engram_protocol "/tmp/nonexistent-$$.md")
+assert_eq "returns unchanged for nonexistent file" "unchanged" "$result"
+
+# appends protocol when no markers
+tmpfile=$(mktemp)
+echo "# Existing content" > "$tmpfile"
+result=$(update_instructions_engram_protocol "$tmpfile")
+assert_eq "appends: returns changed" "changed" "$result"
+content=$(cat "$tmpfile")
+assert_contains "appends: has start marker" "$content" "<!-- team-ai-kit:engram-protocol -->"
+assert_contains "appends: has mem_save" "$content" "mem_save"
+assert_contains "appends: has end marker" "$content" "<!-- /team-ai-kit:engram-protocol -->"
+rm -f "$tmpfile"
+
+# replaces content between existing markers
+tmpfile=$(mktemp)
+cat > "$tmpfile" <<'TESTEOF'
+# Header
+<!-- team-ai-kit:engram-protocol -->
+# Old Protocol
+<!-- /team-ai-kit:engram-protocol -->
+# Footer
+TESTEOF
+result=$(update_instructions_engram_protocol "$tmpfile")
+assert_eq "replaces: returns changed" "changed" "$result"
+content=$(cat "$tmpfile")
+assert_contains "replaces: has mem_save" "$content" "mem_save"
+assert_not_contains "replaces: no old protocol" "$content" "Old Protocol"
+assert_contains "replaces: preserves header" "$content" "# Header"
+assert_contains "replaces: preserves footer" "$content" "# Footer"
+rm -f "$tmpfile"
+
+# returns unchanged when content identical
+tmpfile=$(mktemp)
+protocol=$(get_engram_protocol_content)
+printf '# Header\n\n%s\n' "$protocol" > "$tmpfile"
+result=$(update_instructions_engram_protocol "$tmpfile")
+assert_eq "unchanged when identical" "unchanged" "$result"
+rm -f "$tmpfile"
+
+# skip: removes existing protocol
+tmpfile=$(mktemp)
+cat > "$tmpfile" <<'TESTEOF'
+# Header
+<!-- team-ai-kit:engram-protocol -->
+## Old Protocol
+<!-- /team-ai-kit:engram-protocol -->
+# Footer
+TESTEOF
+result=$(update_instructions_engram_protocol "$tmpfile" "true")
+assert_eq "skip-remove: returns changed" "changed" "$result"
+content=$(cat "$tmpfile")
+assert_not_contains "skip-remove: no engram marker" "$content" "engram-protocol"
+assert_contains "skip-remove: preserves header" "$content" "# Header"
+assert_contains "skip-remove: preserves footer" "$content" "# Footer"
+rm -f "$tmpfile"
+
+# skip: returns unchanged when no markers exist
+tmpfile=$(mktemp)
+echo "# No protocol here" > "$tmpfile"
+result=$(update_instructions_engram_protocol "$tmpfile" "true")
+assert_eq "skip-noop: returns unchanged" "unchanged" "$result"
+rm -f "$tmpfile"
+
+echo ""
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo "================================"
+echo "  PASS: $PASS  FAIL: $FAIL"
+echo "================================"
+if [[ "$FAIL" == "0" ]]; then
+    echo "  All tests passed!"
+    exit 0
+else
+    echo "  Some tests failed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Align bash CLI (`bin/team-ai-kit` + `lib/functions.sh`) with PowerShell parity across 6 critical issues

Closes #100

## Changes

| File | Change |
|------|--------|
| `lib/functions.sh` | Add `cursor` mapping to `get_gentle_ai_agent_id` |
| `lib/functions.sh` | Add engram protocol inclusion + `skip_engram_protocol` param to `new_copilot_instructions` |
| `lib/functions.sh` | Remove extra engram lines from Team Conventions (align with PS1) |
| `lib/functions.sh` | Add `skip_engram_protocol` support to `update_instructions_engram_protocol` |
| `bin/team-ai-kit` | Fix init re-init guard: `OPT_IDE` -> `OPT_TEAM_REPO` |
| `bin/team-ai-kit` | Replace hardcoded cursor check with `test_gentle_ai_supports_ide` in setup |
| `bin/team-ai-kit` | Add skip engram protocol logic in update command for gentle-ai IDEs |

## Test Plan

- [ ] Manually tested bash setup with cursor IDE
- [ ] Manually tested bash init + update with gentle-ai-supported IDE
- [ ] Verified engram protocol is skipped for supported IDEs

## PR Type

- [x] Bug fix