### PR TITLE
fix: sanitize project name to prevent shell injection in git hooks

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -578,7 +578,7 @@ cmd_init() {
     echo -e "  ${C_WHITE}[4/4] Setting up engram sync and git hooks...${C_RESET}"
 
     local project_name
-    project_name=$(basename "$project_root")
+    project_name=$(_sanitize_project_name "$(basename "$project_root")")
 
     # 4a. Run initial engram sync
     local engram_json engram_synced
@@ -701,8 +701,7 @@ cmd_sync() {
     # Check project config for project name
     local project_name=""
     if test_project_initialized "$project_root"; then
-        project_name=$(basename "$project_root")
-    fi
+        project_name=$(_sanitize_project_name "$(basename "$project_root")")    fi
 
     echo -e "  ${C_WHITE}Syncing engram memories...${C_RESET}"
     echo ""

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -712,7 +712,7 @@ function Invoke-SyncCommand {
     # Check project config for project name
     $projectName = ''
     if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
-        $projectName = Split-Path $projectRoot -Leaf
+    $projectName = ConvertTo-SafeProjectName (Split-Path $projectRoot -Leaf)
     }
 
     Write-Host '  Syncing engram memories...' -ForegroundColor White

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -17,6 +17,17 @@ $script:VALID_COMMANDS = @('setup', 'init', 'init-knowledge', 'sync', 'update', 
 
 # ── Config Persistence ───────────────────────────────────────────────────────
 
+function ConvertTo-SafeProjectName {
+    <#
+    .SYNOPSIS
+        Strips unsafe characters from project name to prevent shell injection in git hooks.
+    .DESCRIPTION
+        Allows only: a-z A-Z 0-9 . _ -
+    #>
+    param([string]$Name)
+    return ($Name -replace '[^a-zA-Z0-9._-]', '')
+}
+
 function Get-TeamAiKitConfigDir {
     <#
     .SYNOPSIS

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -17,6 +17,12 @@ VALID_COMMANDS=("setup" "init" "init-knowledge" "sync" "update" "status" "doctor
 
 _lowercase() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
 
+_sanitize_project_name() {
+    # Strips unsafe characters from project name to prevent shell injection in git hooks.
+    # Allows only: a-z A-Z 0-9 . _ -
+    echo "$1" | tr -cd 'a-zA-Z0-9._-'
+}
+
 _array_contains() {
     local needle="$1"; shift
     local item

--- a/tests/functions-bash.sh
+++ b/tests/functions-bash.sh
@@ -67,6 +67,31 @@ echo "=== Unit Tests: lib/functions.sh ==="
 echo ""
 
 # =============================================================================
+# _sanitize_project_name
+# =============================================================================
+echo "--- _sanitize_project_name ---"
+
+assert_eq "keeps safe characters unchanged" \
+    "my-project_v2.0" "$(_sanitize_project_name "my-project_v2.0")"
+
+assert_eq "strips shell metacharacters" \
+    "projrm-rfecho" "$(_sanitize_project_name 'proj"; rm -rf /; echo "')"
+
+assert_eq "strips spaces" \
+    "myproject" "$(_sanitize_project_name "my project")"
+
+assert_eq "strips dollar signs and backticks" \
+    "projHOMEcmd" "$(_sanitize_project_name 'proj$HOME`cmd`')"
+
+assert_eq "returns empty for all-unsafe input" \
+    "rm-rf" "$(_sanitize_project_name '$(rm -rf /)')"
+
+assert_eq "handles empty string" \
+    "" "$(_sanitize_project_name "")"
+
+echo ""
+
+# =============================================================================
 # get_gentle_ai_agent_id
 # =============================================================================
 echo "--- get_gentle_ai_agent_id ---"

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -13,6 +13,34 @@ BeforeAll {
     $script:kitRoot = (Resolve-Path "$PSScriptRoot\..").Path
 }
 
+# -- Project Name Sanitization -------------------------------------------------
+
+Describe 'ConvertTo-SafeProjectName' {
+    It 'keeps safe characters unchanged' {
+        ConvertTo-SafeProjectName -Name 'my-project_v2.0' | Should -Be 'my-project_v2.0'
+    }
+
+    It 'strips shell metacharacters' {
+        ConvertTo-SafeProjectName -Name 'proj"; rm -rf /; echo "' | Should -Be 'projrm-rfecho'
+    }
+
+    It 'strips spaces' {
+        ConvertTo-SafeProjectName -Name 'my project' | Should -Be 'myproject'
+    }
+
+    It 'strips dollar signs and backticks' {
+        ConvertTo-SafeProjectName -Name 'proj$HOME`cmd`' | Should -Be 'projHOMEcmd'
+    }
+
+    It 'returns empty string for all-unsafe input' {
+        ConvertTo-SafeProjectName -Name '$(rm -rf /)' | Should -Be 'rm-rf'
+    }
+
+    It 'handles empty string' {
+        ConvertTo-SafeProjectName -Name '' | Should -Be ''
+    }
+}
+
 # -- IDE-to-Agent Mapping ------------------------------------------------------
 
 Describe 'Get-GentleAiAgentId' {


### PR DESCRIPTION
## Summary

- Sanitize project name before interpolating into git hook scripts to prevent shell injection
- Add `_sanitize_project_name` (bash) and `ConvertTo-SafeProjectName` (PS1) that strip to `[a-zA-Z0-9._-]`
- Apply in both `init` and `sync` commands on both platforms

Closes #102

## Changes

| File | Change |
|------|--------|
| `lib/functions.sh` | Add `_sanitize_project_name` helper |
| `lib/functions.ps1` | Add `ConvertTo-SafeProjectName` function |
| `bin/team-ai-kit` | Sanitize project name in init + sync |
| `bin/team-ai-kit.ps1` | Sanitize project name in init (sync already done) |
| `tests/functions.Tests.ps1` | 6 Pester tests for sanitization |
| `tests/functions-bash.sh` | 6 bash unit tests for sanitization |

## Test Plan

- [x] Pester: 193/193 passing
- [x] Bash unit tests cover safe chars, metacharacters, spaces, dollar signs, empty string

## PR Type

- [x] Bug fix