### PR TITLE
fix: resolve CI failures from PR #105 (shellcheck + syntax)

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -701,7 +701,8 @@ cmd_sync() {
     # Check project config for project name
     local project_name=""
     if test_project_initialized "$project_root"; then
-        project_name=$(_sanitize_project_name "$(basename "$project_root")")    fi
+        project_name=$(_sanitize_project_name "$(basename "$project_root")")
+    fi
 
     echo -e "  ${C_WHITE}Syncing engram memories...${C_RESET}"
     echo ""

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -910,6 +910,7 @@ install_skills_with_merge() {
     local timestamp
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+    # shellcheck disable=SC2178,SC2128  # local integers, not the arrays from install_git_hooks
     local installed=0 updated=0 skipped=0
     local skills_base="$kit_root/skills"
 
@@ -970,6 +971,7 @@ install_project_skills() {
     # Outputs: JSON with installed/updated/skipped counts
     local role="$1" team_repo_url="$2" target_dir="$3"
 
+    # shellcheck disable=SC2178,SC2128  # local integers, not the arrays from install_git_hooks
     local installed=0 updated=0 skipped=0
 
     local team_repo_path
@@ -1272,6 +1274,7 @@ update_instructions_engram_protocol() {
         if echo "$existing" | grep -qF "$start_marker"; then
             local tmpfile
             tmpfile=$(mktemp)
+            # shellcheck disable=SC2064  # intentional: expand $tmpfile now, not at signal time
             trap "rm -f '$tmpfile'" EXIT
             local in_section=false
             while IFS= read -r line || [[ -n "$line" ]]; do
@@ -1311,6 +1314,7 @@ update_instructions_engram_protocol() {
         # Replace between markers using temp file to avoid escape issues
         local tmpfile
         tmpfile=$(mktemp)
+        # shellcheck disable=SC2064  # intentional: expand $tmpfile now, not at signal time
         trap "rm -f '$tmpfile'" EXIT
         local in_section=false
         while IFS= read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
## Summary
- Fix `if/fi` syntax error in `cmd_sync` where `fi` was on same line as command (broke all bash E2E tests)
- Add `shellcheck disable` directives for SC2178/SC2128 (false positive: local integers shadowing array names in different function) and SC2064 (intentional early expansion in trap)

Closes #106
