### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Auto-detect text files and normalize line endings to LF in the repo
+* text=auto eol=lf
+
+# Shell scripts — MUST be LF (bash breaks on CRLF)
+*.sh text eol=lf
+bin/team-ai-kit text eol=lf
+
+# PowerShell — LF in repo, OS converts on checkout
+*.ps1 text eol=lf
+
+# Templates
+*.template text eol=lf
+
+# Markdown & docs
+*.md text eol=lf
+*.html text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to enforce LF line endings across all text files in the repo
- Shell scripts (`*.sh`, `bin/team-ai-kit`) are explicitly forced to LF — bash breaks on CRLF
- All other text formats (`.ps1`, `.md`, `.yml`, `.json`, `.template`) also normalized to LF in the index
- Without this, line endings depended on each developer's local `core.autocrlf` setting

Closes #110
