### PR TITLE
feat: add uninstall command for project-level cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,25 @@ team-ai-kit update         # Pull del team repo + actualizar skills (global + pr
 team-ai-kit sync           # Sincronizar memorias engram manualmente (export + import)
 team-ai-kit status         # Ver config, skills globales y de proyecto
 team-ai-kit doctor         # Verificar que todo este bien
+team-ai-kit uninstall      # Remover team-ai-kit del proyecto actual
 ```
+
+### Uninstall
+
+Remueve todos los artefactos de team-ai-kit del proyecto actual:
+
+- `.team-ai-kit.json` (config del proyecto)
+- Archivo de instrucciones generado (`.github/copilot-instructions.md`, `.cursor/rules/team-ai-kit.md`, `AGENTS.md`)
+- Directorio `team-skills/` con las skills instaladas
+- Bloques de git hooks inyectados (pre-commit, post-merge)
+- Manifest global de skills
+
+```bash
+team-ai-kit uninstall         # Pide confirmacion antes de borrar
+team-ai-kit uninstall --force # Sin confirmacion (para CI/scripts)
+```
+
+> **Nota**: `.engram/` no se borra automaticamente. Si ya no necesitas memory sync, borralo manualmente.
 
 ### Flujo completo
 

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -94,6 +94,7 @@ show_help() {
     echo "    update   Pull latest team content + merge without overwriting"
     echo "    status   Show current config and installed skills"
     echo "    doctor   Verify prerequisites and installation health"
+    echo "    uninstall       Remove team-ai-kit from the current project"
     echo "    help     Show this help message"
     echo ""
     echo -e "  ${C_YELLOW}Setup options:${C_RESET}"
@@ -116,6 +117,8 @@ show_help() {
     echo "    team-ai-kit init"
     echo "    team-ai-kit init --role backend-node"
     echo "    team-ai-kit init --role frontend --force"
+    echo "    team-ai-kit uninstall"
+    echo "    team-ai-kit uninstall --force"
     echo "    team-ai-kit update"
     echo "    team-ai-kit status"
     echo ""
@@ -1094,6 +1097,79 @@ cmd_doctor() {
     echo ""
 }
 
+# -- Uninstall -----------------------------------------------------------------
+cmd_uninstall() {
+    show_banner
+    local project_root
+    project_root=$(pwd)
+
+    if ! test_project_initialized "$project_root"; then
+        err "No team-ai-kit project found in this directory."
+        echo "  Run this command from a project that was initialized with 'team-ai-kit init'."
+        exit 1
+    fi
+
+    echo -e "  ${C_WHITE}Scanning for team-ai-kit artifacts...${C_RESET}"
+    echo ""
+
+    local targets
+    targets=$(collect_uninstall_targets "$project_root")
+
+    if [[ -z "$targets" ]]; then
+        echo -e "  ${C_DIM}No artifacts found to remove.${C_RESET}"
+        echo ""
+        return
+    fi
+
+    # Show what will be removed
+    echo -e "  ${C_YELLOW}The following will be removed:${C_RESET}"
+    while IFS= read -r target; do
+        [[ -z "$target" ]] && continue
+        if [[ "$target" == hook:* ]]; then
+            local hook_path="${target#hook:}"
+            local rel_hook="${hook_path#$project_root/}"
+            echo -e "    ${C_RED}~ $rel_hook${C_RESET} (team-ai-kit block)"
+        elif [[ -d "$target" ]]; then
+            local rel="${target#$project_root/}"
+            echo -e "    ${C_RED}- $rel/${C_RESET}"
+        else
+            local rel="${target#$project_root/}"
+            echo -e "    ${C_RED}- $rel${C_RESET}"
+        fi
+    done <<< "$targets"
+
+    # Also mention manifest
+    local manifest_path
+    manifest_path=$(get_skill_manifest_path)
+    if [[ -f "$manifest_path" ]]; then
+        echo -e "    ${C_RED}- $(basename "$manifest_path")${C_RESET} (global manifest)"
+    fi
+
+    echo ""
+
+    # Ask for confirmation unless --force
+    if [[ "$OPT_FORCE" != "true" ]]; then
+        echo -ne "  ${C_YELLOW}Are you sure? This cannot be undone. [y/N]: ${C_RESET}"
+        read -r confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            echo -e "  ${C_DIM}Uninstall cancelled.${C_RESET}"
+            echo ""
+            return
+        fi
+    fi
+
+    echo ""
+    local result
+    result=$(uninstall_project "$project_root")
+    local removed
+    removed=$(echo "$result" | jq -r '.removed')
+
+    echo -e "  ${C_GREEN}✔ Uninstalled team-ai-kit from this project ($removed items removed).${C_RESET}"
+    echo ""
+    echo -e "  ${C_DIM}Tip: You may also want to remove .engram/ if you no longer need memory sync.${C_RESET}"
+    echo ""
+}
+
 # -- Parse args ----------------------------------------------------------------
 COMMAND="${1:-help}"
 shift || true
@@ -1158,6 +1234,7 @@ case "$(_lowercase "$COMMAND")" in
     update) cmd_update ;;
     status) cmd_status ;;
     doctor) cmd_doctor ;;
+    uninstall)       cmd_uninstall ;;
     help)   show_help ;;
     *)
         err "Unknown command: $COMMAND"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -15,6 +15,7 @@
       update         - Pull latest team content and merge without overwriting
       status         - Show current configuration and installed skills
       doctor         - Verify prerequisites and installation health
+      uninstall      - Remove team-ai-kit from the current project
       help           - Show this help message
 .EXAMPLE
     team-ai-kit setup
@@ -118,6 +119,7 @@ function Show-Help {
     Write-Host '    update   Pull latest team content + merge without overwriting'
     Write-Host '    status   Show current config and installed skills'
     Write-Host '    doctor   Verify prerequisites and installation health'
+    Write-Host '    uninstall       Remove team-ai-kit from the current project'
     Write-Host '    help     Show this help message'
     Write-Host ''
     Write-Host '  Setup options:' -ForegroundColor Yellow
@@ -140,6 +142,8 @@ function Show-Help {
     Write-Host '    team-ai-kit init'
     Write-Host '    team-ai-kit init -Role backend-node'
     Write-Host '    team-ai-kit init -Role frontend -Force'
+    Write-Host '    team-ai-kit uninstall'
+    Write-Host '    team-ai-kit uninstall -Force'
     Write-Host '    team-ai-kit update'
     Write-Host '    team-ai-kit status'
     Write-Host ''
@@ -1105,6 +1109,73 @@ function Invoke-DoctorCommand {
     Write-Host ''
 }
 
+# -- Uninstall -----------------------------------------------------------------
+function Invoke-UninstallCommand {
+    Show-Banner
+    $projectRoot = (Get-Location).Path
+
+    if (-not (Test-ProjectInitialized -ProjectRoot $projectRoot)) {
+        Write-Err 'No team-ai-kit project found in this directory.'
+        Write-Host '  Run this command from a project that was initialized with "team-ai-kit init".'
+        exit 1
+    }
+
+    Write-Host '  Scanning for team-ai-kit artifacts...' -ForegroundColor White
+    Write-Host ''
+
+    $targets = Get-UninstallTargets -ProjectRoot $projectRoot
+
+    if (-not $targets -or $targets.Count -eq 0) {
+        Write-Host '  No artifacts found to remove.' -ForegroundColor DarkGray
+        Write-Host ''
+        return
+    }
+
+    # Show what will be removed
+    Write-Host '  The following will be removed:' -ForegroundColor Yellow
+    foreach ($target in $targets) {
+        $rel = $target.Path.Replace($projectRoot + [IO.Path]::DirectorySeparatorChar, '')
+        switch ($target.Type) {
+            'hook' {
+                Write-Host "    ~ $rel (team-ai-kit block)" -ForegroundColor Red
+            }
+            'dir' {
+                Write-Host "    - $rel/" -ForegroundColor Red
+            }
+            default {
+                Write-Host "    - $rel" -ForegroundColor Red
+            }
+        }
+    }
+
+    # Also mention manifest
+    $manifestPath = Get-SkillManifestPath
+    if (Test-Path $manifestPath) {
+        Write-Host "    - $(Split-Path $manifestPath -Leaf) (global manifest)" -ForegroundColor Red
+    }
+
+    Write-Host ''
+
+    # Ask for confirmation unless --force
+    if (-not $Force) {
+        $confirm = Read-Host '  Are you sure? This cannot be undone. [y/N]'
+        if ($confirm -ne 'y' -and $confirm -ne 'Y') {
+            Write-Host '  Uninstall cancelled.' -ForegroundColor DarkGray
+            Write-Host ''
+            return
+        }
+    }
+
+    Write-Host ''
+    $result = Invoke-Uninstall -ProjectRoot $projectRoot
+    $removed = $result.removed
+
+    Write-Ok "Uninstalled team-ai-kit from this project ($removed items removed)."
+    Write-Host ''
+    Write-Host '  Tip: You may also want to remove .engram/ if you no longer need memory sync.' -ForegroundColor DarkGray
+    Write-Host ''
+}
+
 # -- Route subcommand ----------------------------------------------------------
 switch ($Command.ToLower()) {
     'setup'          { Invoke-SetupCommand }
@@ -1114,6 +1185,7 @@ switch ($Command.ToLower()) {
     'update' { Invoke-UpdateCommand }
     'status' { Invoke-StatusCommand }
     'doctor' { Invoke-DoctorCommand }
+    'uninstall'      { Invoke-UninstallCommand }
     'help'   { Show-Help }
     default  {
         Write-Host "  Unknown command: $Command" -ForegroundColor Red

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version Latest
 $script:VALID_IDES = @('vscode', 'intellij', 'opencode', 'cursor')
 $script:VALID_ROLES = @('frontend', 'backend-node', 'devops', 'python')
 $script:VALID_PROVIDERS = @('openai', 'azure-openai', 'anthropic', 'github-copilot')
-$script:VALID_COMMANDS = @('setup', 'init', 'init-knowledge', 'sync', 'update', 'status', 'doctor', 'help')
+$script:VALID_COMMANDS = @('setup', 'init', 'init-knowledge', 'sync', 'update', 'status', 'doctor', 'uninstall', 'help')
 
 # ── Config Persistence ───────────────────────────────────────────────────────
 
@@ -152,7 +152,7 @@ function Get-ProjectConfig {
     if (-not (Test-Path $configPath)) { return $null }
     $raw = Get-Content $configPath -Raw | ConvertFrom-Json
     $config = @{}
-    $raw.PSObject.Properties | ForEach-Object { $config[$_.Name] = $_.Value }
+    foreach ($prop in $raw.PSObject.Properties) { $config[$prop.Name] = $prop.Value }
     return $config
 }
 
@@ -1923,4 +1923,156 @@ function New-SetupSummary {
   Team Skills: $SkillsCopied installed
 ============================================
 "@
+}
+
+# -- Uninstall -----------------------------------------------------------------
+
+function Get-UninstallTargets {
+    <#
+    .SYNOPSIS
+        Collects all files/dirs that team-ai-kit created in a project.
+    .DESCRIPTION
+        Returns an array of hashtables with Type (file|dir|hook) and Path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $targets = [System.Collections.ArrayList]::new()
+
+    # 1. Project config
+    $configPath = Join-Path $ProjectRoot '.team-ai-kit.json'
+    if (Test-Path $configPath) {
+        [void]$targets.Add(@{ Type = 'file'; Path = $configPath })
+    }
+
+    # 2. Instructions file
+    $projectConfig = $null
+    $projectConfig = Get-ProjectConfig -ProjectRoot $ProjectRoot
+    $ide = $null
+    if ($projectConfig -is [hashtable] -and $projectConfig.ContainsKey('ide')) {
+        $ide = $projectConfig['ide']
+    }
+    if ($ide) {
+        try {
+            $instructionsPath = Get-IdeInstructionsPath -Ide $ide -ProjectRoot $ProjectRoot
+            if ($instructionsPath -and (Test-Path $instructionsPath)) {
+                [void]$targets.Add(@{ Type = 'file'; Path = $instructionsPath })
+            }
+        } catch { }
+    }
+
+    # 3. team-skills directory
+    $globalSkillsDir = Join-Path $ProjectRoot 'team-skills'
+    if (Test-Path $globalSkillsDir) {
+        [void]$targets.Add(@{ Type = 'dir'; Path = $globalSkillsDir })
+    }
+
+    # 4. IDE-specific project skills
+    if ($ide) {
+        try {
+            $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $ide -ProjectRoot $ProjectRoot
+            if ($projectSkillsDir -and (Test-Path $projectSkillsDir) -and $projectSkillsDir -ne $globalSkillsDir) {
+                [void]$targets.Add(@{ Type = 'dir'; Path = $projectSkillsDir })
+            }
+        } catch { }
+    }
+
+    # 5. Git hooks
+    $marker = '# [team-ai-kit] engram sync hook'
+    $hooksDir = Join-Path $ProjectRoot '.git\hooks'
+    foreach ($hookName in @('pre-commit', 'post-merge')) {
+        $hookPath = Join-Path $hooksDir $hookName
+        if (Test-Path $hookPath) {
+            $content = Get-Content $hookPath -Raw -ErrorAction SilentlyContinue
+            if ($content -and $content.Contains($marker)) {
+                [void]$targets.Add(@{ Type = 'hook'; Path = $hookPath })
+            }
+        }
+    }
+
+    return @($targets)
+}
+
+function Remove-HookMarkerBlock {
+    <#
+    .SYNOPSIS
+        Removes the team-ai-kit block from a git hook file.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$HookPath
+    )
+
+    $marker = '# [team-ai-kit] engram sync hook'
+    $lines = Get-Content $HookPath
+    $cleaned = @()
+    $inBlock = $false
+
+    foreach ($line in $lines) {
+        if ($line.Contains($marker)) {
+            $inBlock = $true
+            continue
+        }
+        if ($inBlock) {
+            if ($line -eq 'fi') {
+                $inBlock = $false
+                continue
+            }
+            continue
+        }
+        $cleaned += $line
+    }
+
+    # Strip empty lines
+    $cleaned = @($cleaned | Where-Object { $_.Trim() -ne '' })
+
+    if ($cleaned.Count -eq 0 -or ($cleaned.Count -eq 1 -and $cleaned[0] -eq '#!/bin/sh')) {
+        Remove-Item $HookPath -Force
+    } else {
+        $content = ($cleaned -join "`n") + "`n"
+        $lfContent = $content -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($HookPath, $lfContent, [System.Text.Encoding]::ASCII)
+    }
+}
+
+function Invoke-Uninstall {
+    <#
+    .SYNOPSIS
+        Removes all team-ai-kit artifacts from a project.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $removed = 0
+    $targets = Get-UninstallTargets -ProjectRoot $ProjectRoot
+
+    foreach ($target in $targets) {
+        switch ($target.Type) {
+            'hook' {
+                Remove-HookMarkerBlock -HookPath $target.Path
+                $removed++
+            }
+            'dir' {
+                Remove-Item $target.Path -Recurse -Force
+                $removed++
+            }
+            'file' {
+                Remove-Item $target.Path -Force
+                $removed++
+            }
+        }
+    }
+
+    # Remove global manifest
+    $manifestPath = Get-SkillManifestPath
+    if (Test-Path $manifestPath) {
+        Remove-Item $manifestPath -Force
+        $removed++
+    }
+
+    return @{ removed = $removed }
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1438,3 +1438,128 @@ new_setup_summary() {
 ============================================
 EOF
 }
+
+# -- Uninstall -----------------------------------------------------------------
+
+collect_uninstall_targets() {
+    # Collects all files/dirs that team-ai-kit created in a project.
+    # Usage: collect_uninstall_targets project_root
+    # Outputs: one path per line (files and dirs to remove)
+    local project_root="$1"
+    local targets=()
+
+    # 1. Project config
+    local config_path="$project_root/.team-ai-kit.json"
+    [[ -f "$config_path" ]] && targets+=("$config_path")
+
+    # 2. Instructions file (detect IDE from project config)
+    local ide
+    ide=$(get_project_config_value "$project_root" "ide" 2>/dev/null) || true
+    if [[ -n "$ide" ]]; then
+        local instructions_path
+        instructions_path=$(get_ide_instructions_path "$ide" "$project_root" 2>/dev/null) || true
+        if [[ -n "$instructions_path" && -f "$instructions_path" ]]; then
+            targets+=("$instructions_path")
+        fi
+    fi
+
+    # 3. team-skills directory (global skills dir)
+    local global_skills_dir="$project_root/team-skills"
+    [[ -d "$global_skills_dir" ]] && targets+=("$global_skills_dir")
+
+    # 4. IDE-specific project skills (e.g. .cursor/skills)
+    if [[ -n "$ide" ]]; then
+        local project_skills_dir
+        project_skills_dir=$(get_ide_project_skills_directory "$ide" "$project_root" 2>/dev/null) || true
+        if [[ -n "$project_skills_dir" && -d "$project_skills_dir" && "$project_skills_dir" != "$global_skills_dir" ]]; then
+            targets+=("$project_skills_dir")
+        fi
+    fi
+
+    # 5. Git hooks (only if they contain our marker)
+    local marker='# [team-ai-kit] engram sync hook'
+    local hooks_dir="$project_root/.git/hooks"
+    for hook in pre-commit post-merge; do
+        local hook_path="$hooks_dir/$hook"
+        if [[ -f "$hook_path" ]] && grep -qF "$marker" "$hook_path" 2>/dev/null; then
+            targets+=("hook:$hook_path")
+        fi
+    done
+
+    printf '%s\n' "${targets[@]}"
+}
+
+remove_hook_marker_block() {
+    # Removes the team-ai-kit block from a git hook file.
+    # If the hook only contains our block + shebang, removes the file entirely.
+    local hook_path="$1"
+    local marker='# [team-ai-kit] engram sync hook'
+
+    local content
+    content=$(cat "$hook_path")
+
+    # Build cleaned content: remove from marker to next "fi" (inclusive)
+    local cleaned=""
+    local in_block=false
+    while IFS= read -r line; do
+        if [[ "$line" == *"$marker"* ]]; then
+            in_block=true
+            continue
+        fi
+        if [[ "$in_block" == true ]]; then
+            # Our hooks end with "fi"
+            if [[ "$line" == "fi" ]]; then
+                in_block=false
+                continue
+            fi
+            continue
+        fi
+        cleaned+="$line"$'\n'
+    done <<< "$content"
+
+    # Strip leading/trailing blank lines
+    cleaned=$(echo "$cleaned" | sed '/^$/N;/^\n$/d' | sed -e '/^$/d')
+
+    # If only shebang remains (or empty), remove the file
+    if [[ -z "$cleaned" || "$cleaned" == "#!/bin/sh" ]]; then
+        rm -f "$hook_path"
+    else
+        printf '%s\n' "$cleaned" > "$hook_path"
+    fi
+}
+
+uninstall_project() {
+    # Removes all team-ai-kit artifacts from a project.
+    # Usage: uninstall_project project_root
+    # Outputs: JSON with removed items count
+    local project_root="$1"
+    local removed=0
+
+    local targets
+    targets=$(collect_uninstall_targets "$project_root")
+
+    while IFS= read -r target; do
+        [[ -z "$target" ]] && continue
+        if [[ "$target" == hook:* ]]; then
+            local hook_path="${target#hook:}"
+            remove_hook_marker_block "$hook_path"
+            removed=$((removed + 1))
+        elif [[ -d "$target" ]]; then
+            rm -rf "$target"
+            removed=$((removed + 1))
+        elif [[ -f "$target" ]]; then
+            rm -f "$target"
+            removed=$((removed + 1))
+        fi
+    done <<< "$targets"
+
+    # Remove from global manifest
+    local manifest_path
+    manifest_path=$(get_skill_manifest_path)
+    if [[ -f "$manifest_path" ]]; then
+        rm -f "$manifest_path"
+        removed=$((removed + 1))
+    fi
+
+    echo "{\"removed\":$removed}"
+}

--- a/tests/e2e-bash.sh
+++ b/tests/e2e-bash.sh
@@ -185,6 +185,40 @@ else
     echo "$output" | tail -5
 fi
 
+# -- Test 12: uninstall command ---
+echo "--- Test 12: uninstall ---"
+# TEST_DIR should be initialized from test 2
+if [ -f "$TEST_DIR/.team-ai-kit.json" ]; then
+    output=$(cd "$TEST_DIR" && bash "$KIT_ROOT/bin/team-ai-kit" uninstall --force 2>&1) || true
+    if echo "$output" | grep -qi "uninstalled"; then
+        pass "uninstall reports success"
+    else
+        fail "uninstall didn't report success"
+        echo "$output" | tail -5
+    fi
+    # Verify artifacts are gone
+    if [ ! -f "$TEST_DIR/.team-ai-kit.json" ]; then
+        pass "uninstall removed .team-ai-kit.json"
+    else
+        fail "uninstall didn't remove .team-ai-kit.json"
+    fi
+else
+    fail "uninstall test: project not initialized (test 2 must have failed)"
+fi
+
+# -- Test 13: uninstall on non-initialized project ---
+echo "--- Test 13: uninstall on non-initialized project ---"
+UNINST_DIR="/tmp/team-ai-kit-uninst-$$"
+mkdir -p "$UNINST_DIR"
+output=$(cd "$UNINST_DIR" && bash "$KIT_ROOT/bin/team-ai-kit" uninstall --force 2>&1) || true
+if echo "$output" | grep -qi "no team-ai-kit project"; then
+    pass "uninstall rejects non-initialized project"
+else
+    fail "uninstall should reject non-initialized project"
+    echo "$output" | tail -5
+fi
+rm -rf "$UNINST_DIR"
+
 # -- Summary ---
 echo ""
 echo "================================"

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -1953,3 +1953,122 @@ Describe 'Test-ValidCommand includes init-knowledge' {
         Test-ValidCommand -Command 'init-knowledge' | Should -BeTrue
     }
 }
+
+# -- Uninstall -----------------------------------------------------------------
+
+Describe 'Get-UninstallTargets' {
+    BeforeEach {
+        $testDir = Join-Path ([IO.Path]::GetTempPath()) "tak-uninstall-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $testDir) { Remove-Item $testDir -Recurse -Force }
+    }
+
+    It 'returns empty when project is not initialized' {
+        $targets = Get-UninstallTargets -ProjectRoot $testDir
+        $targets | Should -BeNullOrEmpty
+    }
+
+    It 'detects .team-ai-kit.json' {
+        $configPath = Join-Path $testDir '.team-ai-kit.json'
+        '{"role":"frontend","ide":"vscode"}' | Set-Content $configPath
+        $targets = @(Get-UninstallTargets -ProjectRoot $testDir)
+        $match = $targets | Where-Object { $_.Path -eq $configPath }
+        $match | Should -Not -BeNullOrEmpty
+        $match.Type | Should -Be 'file'
+    }
+
+    It 'detects instructions file for vscode' {
+        $configPath = Join-Path $testDir '.team-ai-kit.json'
+        '{"role":"frontend","ide":"vscode"}' | Set-Content $configPath
+        $instrDir = Join-Path $testDir '.github'
+        New-Item -ItemType Directory -Path $instrDir -Force | Out-Null
+        $instrPath = Join-Path $instrDir 'copilot-instructions.md'
+        'test' | Set-Content $instrPath
+        $targets = @(Get-UninstallTargets -ProjectRoot $testDir)
+        $match = $targets | Where-Object { $_.Path -eq $instrPath }
+        $match | Should -Not -BeNullOrEmpty
+        $match.Type | Should -Be 'file'
+    }
+
+    It 'detects team-skills directory' {
+        $configPath = Join-Path $testDir '.team-ai-kit.json'
+        '{"role":"frontend","ide":"vscode"}' | Set-Content $configPath
+        $skillsDir = Join-Path $testDir 'team-skills'
+        New-Item -ItemType Directory -Path $skillsDir -Force | Out-Null
+        $targets = @(Get-UninstallTargets -ProjectRoot $testDir)
+        $match = $targets | Where-Object { $_.Path -eq $skillsDir }
+        $match | Should -Not -BeNullOrEmpty
+        $match.Type | Should -Be 'dir'
+    }
+
+    It 'detects git hooks with marker' {
+        $configPath = Join-Path $testDir '.team-ai-kit.json'
+        '{"role":"frontend","ide":"vscode"}' | Set-Content $configPath
+        $hooksDir = Join-Path $testDir '.git\hooks'
+        New-Item -ItemType Directory -Path $hooksDir -Force | Out-Null
+        $hookPath = Join-Path $hooksDir 'pre-commit'
+        "#!/bin/sh`n# [team-ai-kit] engram sync hook`nif command -v engram >/dev/null 2>&1; then`n    engram sync --all`nfi" | Set-Content $hookPath
+        $targets = @(Get-UninstallTargets -ProjectRoot $testDir)
+        $match = $targets | Where-Object { $_.Type -eq 'hook' }
+        $match | Should -Not -BeNullOrEmpty
+        $match.Path | Should -Be $hookPath
+    }
+}
+
+Describe 'Remove-HookMarkerBlock' {
+    BeforeEach {
+        $testDir = Join-Path ([IO.Path]::GetTempPath()) "tak-hook-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $testDir) { Remove-Item $testDir -Recurse -Force }
+    }
+
+    It 'removes hook file if only our block remains' {
+        $hookPath = Join-Path $testDir 'pre-commit'
+        "#!/bin/sh`n# [team-ai-kit] engram sync hook`nif command -v engram >/dev/null 2>&1; then`n    engram sync --all`nfi" | Set-Content $hookPath
+        Remove-HookMarkerBlock -HookPath $hookPath
+        Test-Path $hookPath | Should -BeFalse
+    }
+
+    It 'preserves other content in hook' {
+        $hookPath = Join-Path $testDir 'pre-commit'
+        "#!/bin/sh`necho 'custom hook'`n# [team-ai-kit] engram sync hook`nif command -v engram >/dev/null 2>&1; then`n    engram sync --all`nfi" | Set-Content $hookPath
+        Remove-HookMarkerBlock -HookPath $hookPath
+        Test-Path $hookPath | Should -BeTrue
+        $content = Get-Content $hookPath -Raw
+        $content | Should -Not -BeLike '*team-ai-kit*'
+        $content | Should -BeLike '*custom hook*'
+    }
+}
+
+Describe 'Invoke-Uninstall' {
+    BeforeEach {
+        $testDir = Join-Path ([IO.Path]::GetTempPath()) "tak-uninst-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $testDir) { Remove-Item $testDir -Recurse -Force }
+    }
+
+    It 'removes project config and team-skills' {
+        $configPath = Join-Path $testDir '.team-ai-kit.json'
+        '{"role":"frontend","ide":"opencode"}' | Set-Content $configPath
+        $skillsDir = Join-Path $testDir 'team-skills'
+        New-Item -ItemType Directory -Path $skillsDir -Force | Out-Null
+        'skill content' | Set-Content (Join-Path $skillsDir 'test-skill.md')
+
+        $result = Invoke-Uninstall -ProjectRoot $testDir
+        $result.removed | Should -BeGreaterThan 0
+        Test-Path $configPath | Should -BeFalse
+        Test-Path $skillsDir | Should -BeFalse
+    }
+}
+
+Describe 'Test-ValidCommand includes uninstall' {
+    It 'accepts uninstall as valid command' {
+        Test-ValidCommand -Command 'uninstall' | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- Add `team-ai-kit uninstall [--force]` command for clean project-level removal
- Removes: `.team-ai-kit.json`, generated instructions file, `team-skills/`, git hook blocks (between markers), global skill manifest
- Shows what will be removed, asks confirmation (skip with `--force`)
- Full bash + PowerShell parity
- 10 new Pester tests (Get-UninstallTargets, Remove-HookMarkerBlock, Invoke-Uninstall, Test-ValidCommand)
- 2 new bash e2e scenarios (uninstall success + rejection on non-initialized project)
- README updated with uninstall section and usage examples

Closes #114
