### PR TITLE
feat: add --dry-run flag for init, update, and uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ team-ai-kit uninstall         # Pide confirmacion antes de borrar
 team-ai-kit uninstall --force # Sin confirmacion (para CI/scripts)
 ```
 
+### Dry Run
+
+Usa `--dry-run` (bash) o `-DryRun` (PowerShell) para ver que haria cada comando **sin modificar nada**:
+
+```bash
+team-ai-kit init --dry-run       # Muestra que archivos crearia
+team-ai-kit update --dry-run     # Muestra que skills/rules actualizaria
+team-ai-kit uninstall --dry-run  # Muestra que archivos borraria
+```
+
 > **Nota**: `.engram/` no se borra automaticamente. Si ya no necesitas memory sync, borralo manualmente.
 
 ### Flujo completo

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -81,6 +81,9 @@ show_banner() {
     echo ""
 }
 
+# -- Dry-run helper ------------------------------------------------------------
+dry() { echo -e "  ${C_CYAN}[DRY-RUN]${C_RESET} $1"; }
+
 # -- Help ----------------------------------------------------------------------
 show_help() {
     show_banner
@@ -109,6 +112,7 @@ show_help() {
     echo -e "  ${C_YELLOW}Init options:${C_RESET}"
     echo "    --role <role>              Override global role for this project"
     echo "    --force                    Re-initialize without asking"
+    echo "    --dry-run                  Preview changes without writing to disk"
     echo ""
     echo -e "  ${C_YELLOW}Examples:${C_RESET}"
     echo "    team-ai-kit setup"
@@ -551,28 +555,38 @@ cmd_init() {
         skip_engram_protocol="true"
     fi
 
-    local instructions
-    instructions=$(new_copilot_instructions "$effective_role" "$pack_rules_content" "$team_rules_content" "$skip_engram_protocol")
-    printf '%s\n' "$instructions" > "$instructions_path"
     local rel_instructions_path="${instructions_path#$project_root/}"
-    ok "Created: $rel_instructions_path"
+
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry "Would create: $rel_instructions_path"
+    else
+        local instructions
+        instructions=$(new_copilot_instructions "$effective_role" "$pack_rules_content" "$team_rules_content" "$skip_engram_protocol")
+        printf '%s\n' "$instructions" > "$instructions_path"
+        ok "Created: $rel_instructions_path"
+    fi
 
     # 3b. Install team-repo skills to project-level directory
     if [[ -n "$effective_team_repo" ]] && test_team_repo_cloned "$effective_team_repo"; then
         local project_skills_dir
         project_skills_dir=$(get_ide_project_skills_directory "$effective_ide" "$project_root")
         local rel_skills_dir="${project_skills_dir#$project_root/}"
-        step "Installing team skills to project: $rel_skills_dir"
 
-        local ps_json ps_installed ps_updated
-        ps_json=$(install_project_skills "$effective_role" "$effective_team_repo" "$project_skills_dir")
-        ps_installed=$(echo "$ps_json" | jq -r '.installed')
-        ps_updated=$(echo "$ps_json" | jq -r '.updated')
-        local ps_total=$((ps_installed + ps_updated))
-        if [[ "$ps_total" -gt 0 ]]; then
-            ok "$ps_installed installed, $ps_updated updated team skills"
+        if [[ "$OPT_DRY_RUN" == "true" ]]; then
+            dry "Would install team skills to: $rel_skills_dir"
         else
-            step "No team skills to install (repo has no skills for this role)"
+            step "Installing team skills to project: $rel_skills_dir"
+
+            local ps_json ps_installed ps_updated
+            ps_json=$(install_project_skills "$effective_role" "$effective_team_repo" "$project_skills_dir")
+            ps_installed=$(echo "$ps_json" | jq -r '.installed')
+            ps_updated=$(echo "$ps_json" | jq -r '.updated')
+            local ps_total=$((ps_installed + ps_updated))
+            if [[ "$ps_total" -gt 0 ]]; then
+                ok "$ps_installed installed, $ps_updated updated team skills"
+            else
+                step "No team skills to install (repo has no skills for this role)"
+            fi
         fi
     fi
 
@@ -583,71 +597,86 @@ cmd_init() {
     local project_name
     project_name=$(_sanitize_project_name "$(basename "$project_root")")
 
-    # 4a. Run initial engram sync
-    local engram_json engram_synced
-    engram_json=$(initialize_engram_sync "$project_root" "$project_name")
-    engram_synced=$(echo "$engram_json" | jq -r '.synced')
-
-    if [[ "$engram_synced" == "true" ]]; then
-        ok "engram sync completed -- .engram/ ready for team sharing"
-    elif test_engram_installed; then
-        ok "engram sync attempted -- no memories for this project yet"
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry "Would run engram sync for project: $project_name"
+        dry "Would install git hooks to: .git/hooks/"
     else
-        ok ".engram/ will be created on first sync"
-        warn "engram not installed -- sync will work after installing engram"
-    fi
+        # 4a. Run initial engram sync
+        local engram_json engram_synced
+        engram_json=$(initialize_engram_sync "$project_root" "$project_name")
+        engram_synced=$(echo "$engram_json" | jq -r '.synced')
 
-    # 4b. Install git hooks
-    local hooks_json hooks_installed_list hooks_installed_count hooks_skipped_list
-    hooks_json=$(install_git_hooks "$project_root" "$project_name")
-    hooks_installed_list=$(echo "$hooks_json" | jq -r '.installed | join(", ")')
-    hooks_installed_count=$(echo "$hooks_json" | jq '.installed | length')
-    hooks_skipped_list=$(echo "$hooks_json" | jq -r '.skipped | join(", ")')
+        if [[ "$engram_synced" == "true" ]]; then
+            ok "engram sync completed -- .engram/ ready for team sharing"
+        elif test_engram_installed; then
+            ok "engram sync attempted -- no memories for this project yet"
+        else
+            ok ".engram/ will be created on first sync"
+            warn "engram not installed -- sync will work after installing engram"
+        fi
 
-    if [[ "$hooks_installed_count" -gt 0 ]]; then
-        ok "Git hooks installed: $hooks_installed_list"
-    fi
-    if echo "$hooks_json" | jq -e '.skipped | index("not-a-git-repo")' >/dev/null 2>&1; then
-        warn "Not a git repo -- hooks skipped"
-    elif [[ -n "$hooks_skipped_list" && "$hooks_skipped_list" != "" ]]; then
-        step "Git hooks already present: $hooks_skipped_list"
+        # 4b. Install git hooks
+        local hooks_json hooks_installed_list hooks_installed_count hooks_skipped_list
+        hooks_json=$(install_git_hooks "$project_root" "$project_name")
+        hooks_installed_list=$(echo "$hooks_json" | jq -r '.installed | join(", ")')
+        hooks_installed_count=$(echo "$hooks_json" | jq '.installed | length')
+        hooks_skipped_list=$(echo "$hooks_json" | jq -r '.skipped | join(", ")')
+
+        if [[ "$hooks_installed_count" -gt 0 ]]; then
+            ok "Git hooks installed: $hooks_installed_list"
+        fi
+        if echo "$hooks_json" | jq -e '.skipped | index("not-a-git-repo")' >/dev/null 2>&1; then
+            warn "Not a git repo -- hooks skipped"
+        elif [[ -n "$hooks_skipped_list" && "$hooks_skipped_list" != "" ]]; then
+            step "Git hooks already present: $hooks_skipped_list"
+        fi
     fi
 
     # -- Save project config ---------------------------------------------------
-    local now
-    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    local project_config
-    project_config=$(jq -n \
-        --arg role "$effective_role" \
-        --arg ide "$effective_ide" \
-        --arg team_repo "$effective_team_repo" \
-        --arg initialized_at "$now" \
-        --arg last_sync "$now" \
-        --arg version "$KIT_VERSION" \
-        '{role:$role, ide:$ide, teamRepo:$team_repo, initializedAt:$initialized_at, lastSync:$last_sync, version:$version}')
-    save_project_config "$project_root" "$project_config" >/dev/null
-    ok "Project config saved: .team-ai-kit.json"
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry "Would save project config: .team-ai-kit.json"
+    else
+        local now
+        now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        local project_config
+        project_config=$(jq -n \
+            --arg role "$effective_role" \
+            --arg ide "$effective_ide" \
+            --arg team_repo "$effective_team_repo" \
+            --arg initialized_at "$now" \
+            --arg last_sync "$now" \
+            --arg version "$KIT_VERSION" \
+            '{role:$role, ide:$ide, teamRepo:$team_repo, initializedAt:$initialized_at, lastSync:$last_sync, version:$version}')
+        save_project_config "$project_root" "$project_config" >/dev/null
+        ok "Project config saved: .team-ai-kit.json"
+    fi
 
     # -- Summary ---------------------------------------------------------------
-    echo ""
-    echo -e "${C_GREEN}$(new_init_summary "$effective_ide" "$effective_role" "$rel_instructions_path" "$engram_synced" "$hooks_installed_count")${C_RESET}"
-
-    echo ""
-    echo -e "  ${C_YELLOW}Next steps:${C_RESET}"
-    echo -e "    ${C_WHITE}1. Commit .team-ai-kit.json and $rel_instructions_path to your repo${C_RESET}"
-    if [[ -n "$effective_team_repo" ]]; then
-        local rel_skills_dir
-        rel_skills_dir="$(get_ide_project_skills_directory "$effective_ide" "$project_root")"
-        rel_skills_dir="${rel_skills_dir#$project_root/}"
-        echo -e "    ${C_WHITE}2. Commit $rel_skills_dir/ (team skills for this project)${C_RESET}"
-        echo -e "    ${C_WHITE}3. Commit .engram/ to share knowledge with your team${C_RESET}"
-        echo -e "    ${C_WHITE}4. Start working -- git hooks will sync engram automatically!${C_RESET}"
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        echo ""
+        echo -e "  ${C_CYAN}[DRY-RUN] No changes were made. The above shows what would happen.${C_RESET}"
+        echo ""
     else
-        echo -e "    ${C_WHITE}2. Commit .engram/ to share knowledge with your team${C_RESET}"
-        echo -e "    ${C_WHITE}3. Start working -- git hooks will sync engram automatically!${C_RESET}"
+        echo ""
+        echo -e "${C_GREEN}$(new_init_summary "$effective_ide" "$effective_role" "$rel_instructions_path" "$engram_synced" "$hooks_installed_count")${C_RESET}"
+
+        echo ""
+        echo -e "  ${C_YELLOW}Next steps:${C_RESET}"
+        echo -e "    ${C_WHITE}1. Commit .team-ai-kit.json and $rel_instructions_path to your repo${C_RESET}"
+        if [[ -n "$effective_team_repo" ]]; then
+            local rel_skills_dir
+            rel_skills_dir="$(get_ide_project_skills_directory "$effective_ide" "$project_root")"
+            rel_skills_dir="${rel_skills_dir#$project_root/}"
+            echo -e "    ${C_WHITE}2. Commit $rel_skills_dir/ (team skills for this project)${C_RESET}"
+            echo -e "    ${C_WHITE}3. Commit .engram/ to share knowledge with your team${C_RESET}"
+            echo -e "    ${C_WHITE}4. Start working -- git hooks will sync engram automatically!${C_RESET}"
+        else
+            echo -e "    ${C_WHITE}2. Commit .engram/ to share knowledge with your team${C_RESET}"
+            echo -e "    ${C_WHITE}3. Start working -- git hooks will sync engram automatically!${C_RESET}"
+        fi
+        echo -e "    ${C_DIM}   (manual sync: team-ai-kit sync)${C_RESET}"
+        echo ""
     fi
-    echo -e "    ${C_DIM}   (manual sync: team-ai-kit sync)${C_RESET}"
-    echo ""
 }
 
 # -- Init Knowledge (scaffold team knowledge repo) ----------------------------
@@ -807,19 +836,23 @@ cmd_update() {
         target_skills_dir=$(get_ide_skills_directory "$config_ide")
     fi
 
-    step "Merging kit base skills to global: $target_skills_dir"
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry "Would merge kit base skills to: $target_skills_dir"
+    else
+        step "Merging kit base skills to global: $target_skills_dir"
 
-    local merge_json
-    merge_json=$(install_skills_with_merge "$KIT_ROOT" "$config_role" "$target_skills_dir" "false" "")
-    local m_installed m_updated m_skipped
-    m_installed=$(echo "$merge_json" | jq -r '.installed')
-    m_updated=$(echo "$merge_json" | jq -r '.updated')
-    m_skipped=$(echo "$merge_json" | jq -r '.skipped')
+        local merge_json
+        merge_json=$(install_skills_with_merge "$KIT_ROOT" "$config_role" "$target_skills_dir" "false" "")
+        local m_installed m_updated m_skipped
+        m_installed=$(echo "$merge_json" | jq -r '.installed')
+        m_updated=$(echo "$merge_json" | jq -r '.updated')
+        m_skipped=$(echo "$merge_json" | jq -r '.skipped')
 
-    echo ""
-    ok "Installed: $m_installed new skills"
-    [[ "$m_updated" -gt 0 ]] && ok "Updated:   $m_updated skills (source changed, yours untouched)"
-    [[ "$m_skipped" -gt 0 ]] && step "Unchanged: $m_skipped skills (already up to date or user-modified)"
+        echo ""
+        ok "Installed: $m_installed new skills"
+        [[ "$m_updated" -gt 0 ]] && ok "Updated:   $m_updated skills (source changed, yours untouched)"
+        [[ "$m_skipped" -gt 0 ]] && step "Unchanged: $m_skipped skills (already up to date or user-modified)"
+    fi
 
     # Step 2b: Install team-repo skills to project-level directory
     if [[ "$has_team_repo" == "true" && "$has_project_config" == "true" ]]; then
@@ -829,19 +862,23 @@ cmd_update() {
         effective_role_proj=$(get_project_config_value "$project_root" "role" 2>/dev/null) || true
         [[ -z "$effective_role_proj" ]] && effective_role_proj="$config_role"
         project_skills_dir=$(get_ide_project_skills_directory "$effective_ide" "$project_root")
-
-        echo ""
         local rel_dir="${project_skills_dir#$project_root/}"
-        step "Merging team skills to project: $rel_dir"
 
-        local ps_json ps_installed ps_updated ps_skipped
-        ps_json=$(install_project_skills "$effective_role_proj" "$effective_team_repo" "$project_skills_dir")
-        ps_installed=$(echo "$ps_json" | jq -r '.installed')
-        ps_updated=$(echo "$ps_json" | jq -r '.updated')
-        ps_skipped=$(echo "$ps_json" | jq -r '.skipped')
-        [[ "$ps_installed" -gt 0 ]] && ok "Installed: $ps_installed new team skills"
-        [[ "$ps_updated" -gt 0 ]] && ok "Updated:   $ps_updated team skills"
-        [[ "$ps_skipped" -gt 0 ]] && step "Unchanged: $ps_skipped team skills"
+        if [[ "$OPT_DRY_RUN" == "true" ]]; then
+            dry "Would merge team skills to: $rel_dir"
+        else
+            echo ""
+            step "Merging team skills to project: $rel_dir"
+
+            local ps_json ps_installed ps_updated ps_skipped
+            ps_json=$(install_project_skills "$effective_role_proj" "$effective_team_repo" "$project_skills_dir")
+            ps_installed=$(echo "$ps_json" | jq -r '.installed')
+            ps_updated=$(echo "$ps_json" | jq -r '.updated')
+            ps_skipped=$(echo "$ps_json" | jq -r '.skipped')
+            [[ "$ps_installed" -gt 0 ]] && ok "Installed: $ps_installed new team skills"
+            [[ "$ps_updated" -gt 0 ]] && ok "Updated:   $ps_updated team skills"
+            [[ "$ps_skipped" -gt 0 ]] && step "Unchanged: $ps_skipped team skills"
+        fi
     fi
 
     # Step 3: Auto-update team rules in instructions if project is initialized
@@ -852,12 +889,16 @@ cmd_update() {
             local instructions_path
             instructions_path=$(get_ide_instructions_path "$config_ide" "$project_root")
             if [[ -f "$instructions_path" ]]; then
-                local rules_result
-                rules_result=$(update_instructions_team_rules "$instructions_path" "$team_rules_content")
-                if [[ "$rules_result" == "changed" ]]; then
-                    ok "Team rules updated in project instructions"
+                if [[ "$OPT_DRY_RUN" == "true" ]]; then
+                    dry "Would update team rules in: ${instructions_path#$project_root/}"
                 else
-                    step "Team rules unchanged in project instructions"
+                    local rules_result
+                    rules_result=$(update_instructions_team_rules "$instructions_path" "$team_rules_content")
+                    if [[ "$rules_result" == "changed" ]]; then
+                        ok "Team rules updated in project instructions"
+                    else
+                        step "Team rules unchanged in project instructions"
+                    fi
                 fi
             fi
         fi
@@ -869,33 +910,45 @@ cmd_update() {
         local instructions_path
         instructions_path=$(get_ide_instructions_path "$config_ide" "$project_root")
         if [[ -f "$instructions_path" ]]; then
-            local skip_engram_protocol="false"
-            if test_gentle_ai_supports_ide "$config_ide"; then
-                skip_engram_protocol="true"
-            fi
-            local protocol_result
-            protocol_result=$(update_instructions_engram_protocol "$instructions_path" "$skip_engram_protocol")
-            if [[ "$protocol_result" == "changed" ]]; then
-                if [[ "$skip_engram_protocol" == "true" ]]; then
-                    ok "Engram Memory Protocol removed from project instructions (gentle-ai handles it)"
-                else
-                    ok "Engram Memory Protocol updated in project instructions"
-                fi
+            if [[ "$OPT_DRY_RUN" == "true" ]]; then
+                dry "Would update engram protocol in: ${instructions_path#$project_root/}"
             else
-                step "Engram Memory Protocol unchanged in project instructions"
+                local skip_engram_protocol="false"
+                if test_gentle_ai_supports_ide "$config_ide"; then
+                    skip_engram_protocol="true"
+                fi
+                local protocol_result
+                protocol_result=$(update_instructions_engram_protocol "$instructions_path" "$skip_engram_protocol")
+                if [[ "$protocol_result" == "changed" ]]; then
+                    if [[ "$skip_engram_protocol" == "true" ]]; then
+                        ok "Engram Memory Protocol removed from project instructions (gentle-ai handles it)"
+                    else
+                        ok "Engram Memory Protocol updated in project instructions"
+                    fi
+                else
+                    step "Engram Memory Protocol unchanged in project instructions"
+                fi
             fi
         fi
     fi
 
     # Step 5: Update config timestamp
-    local now
-    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    local updated_config
-    updated_config=$(get_config | jq --arg ts "$now" --arg ver "$KIT_VERSION" '.lastUpdate = $ts | .version = $ver')
-    save_config "$updated_config" >/dev/null
-    echo ""
-    ok "Update complete"
-    echo ""
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        echo ""
+        dry "Would update global config timestamp"
+        echo ""
+        echo -e "  ${C_CYAN}[DRY-RUN] No changes were made. The above shows what would happen.${C_RESET}"
+        echo ""
+    else
+        local now
+        now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        local updated_config
+        updated_config=$(get_config | jq --arg ts "$now" --arg ver "$KIT_VERSION" '.lastUpdate = $ts | .version = $ver')
+        save_config "$updated_config" >/dev/null
+        echo ""
+        ok "Update complete"
+        echo ""
+    fi
 }
 
 # -- Status --------------------------------------------------------------------
@@ -1147,6 +1200,12 @@ cmd_uninstall() {
 
     echo ""
 
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        echo -e "  ${C_CYAN}[DRY-RUN] No changes were made. The above shows what would be removed.${C_RESET}"
+        echo ""
+        return
+    fi
+
     # Ask for confirmation unless --force
     if [[ "$OPT_FORCE" != "true" ]]; then
         echo -ne "  ${C_YELLOW}Are you sure? This cannot be undone. [y/N]: ${C_RESET}"
@@ -1182,6 +1241,7 @@ OPT_TARGET_DIR=""
 SKIP_PREREQUISITES="false"
 SKIP_GENTLE_AI="false"
 OPT_FORCE="false"
+OPT_DRY_RUN="false"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -1203,6 +1263,7 @@ while [[ $# -gt 0 ]]; do
         --skip-prerequisites) SKIP_PREREQUISITES="true"; shift ;;
         --skip-gentle-ai)    SKIP_GENTLE_AI="true"; shift ;;
         --force)             OPT_FORCE="true"; shift ;;
+        --dry-run)           OPT_DRY_RUN="true"; shift ;;
         *)
             err "Unknown option: $1"
             echo '  Run "team-ai-kit help" for usage.'

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -75,7 +75,9 @@ param(
 
     [switch]$Update,
 
-    [switch]$Force
+    [switch]$Force,
+
+    [switch]$DryRun
 )
 
 Set-StrictMode -Version Latest
@@ -95,6 +97,7 @@ function Write-Step { param([string]$Msg) Write-Host "  > $Msg" -ForegroundColor
 function Write-Ok   { param([string]$Msg) Write-Host "  + $Msg" -ForegroundColor Green }
 function Write-Warn { param([string]$Msg) Write-Host "  ! $Msg" -ForegroundColor Yellow }
 function Write-Err  { param([string]$Msg) Write-Host "  x $Msg" -ForegroundColor Red }
+function Write-Dry  { param([string]$Msg) Write-Host "  [DRY-RUN] $Msg" -ForegroundColor Cyan }
 
 # -- Banner --------------------------------------------------------------------
 function Show-Banner {
@@ -134,6 +137,7 @@ function Show-Help {
     Write-Host '  Init options:' -ForegroundColor Yellow
     Write-Host '    -Role <role>             Override global role for this project'
     Write-Host '    -Force                   Re-initialize without asking'
+    Write-Host '    -DryRun                  Preview changes without writing to disk'
     Write-Host ''
     Write-Host '  Examples:' -ForegroundColor Yellow
     Write-Host '    team-ai-kit setup'
@@ -581,23 +585,36 @@ function Invoke-InitCommand {
     }
 
     $skipProtocol = Test-GentleAiSupportsIde -Ide $effectiveIde
-    $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent -SkipEngramProtocol:$skipProtocol
-    [System.IO.File]::WriteAllText($instructionsPath, $instructions, [System.Text.Encoding]::UTF8)
     $relInstructionsPath = $instructionsPath.Replace($projectRoot, '').TrimStart('\', '/')
-    Write-Ok "Created: $relInstructionsPath"
+
+    if ($DryRun) {
+        Write-Dry "Would create: $relInstructionsPath"
+    }
+    else {
+        $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent -SkipEngramProtocol:$skipProtocol
+        [System.IO.File]::WriteAllText($instructionsPath, $instructions, [System.Text.Encoding]::UTF8)
+        Write-Ok "Created: $relInstructionsPath"
+    }
 
     # 3b. Install team-repo skills to project-level directory
     if ($effectiveTeamRepo -and (Test-TeamRepoCloned -RepoUrl $effectiveTeamRepo)) {
         $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot
-        Write-Step "Installing team skills to project: $($projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/'))"
+        $relSkillsDir = $projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/')
 
-        $projectSkillResults = Install-ProjectSkills -Role $effectiveRole -TeamRepoUrl $effectiveTeamRepo -TargetDir $projectSkillsDir
-        $pTotal = $projectSkillResults.installed + $projectSkillResults.updated
-        if ($pTotal -gt 0) {
-            Write-Ok "$($projectSkillResults.installed) installed, $($projectSkillResults.updated) updated team skills"
+        if ($DryRun) {
+            Write-Dry "Would install team skills to: $relSkillsDir"
         }
         else {
-            Write-Step 'No team skills to install (repo has no skills for this role)'
+            Write-Step "Installing team skills to project: $relSkillsDir"
+
+            $projectSkillResults = Install-ProjectSkills -Role $effectiveRole -TeamRepoUrl $effectiveTeamRepo -TargetDir $projectSkillsDir
+            $pTotal = $projectSkillResults.installed + $projectSkillResults.updated
+            if ($pTotal -gt 0) {
+                Write-Ok "$($projectSkillResults.installed) installed, $($projectSkillResults.updated) updated team skills"
+            }
+            else {
+                Write-Step 'No team skills to install (repo has no skills for this role)'
+            }
         }
     }
 
@@ -608,66 +625,84 @@ function Invoke-InitCommand {
     # Derive project name from directory
     $projectName = Split-Path $projectRoot -Leaf
 
-    # 4a. Run initial engram sync
-    $engramResult = Initialize-EngramSync -ProjectRoot $projectRoot -ProjectName $projectName
-
-    if ($engramResult.synced) {
-        Write-Ok 'engram sync completed -- .engram/ ready for team sharing'
-    }
-    elseif (Test-EngramInstalled) {
-        Write-Ok 'engram sync attempted -- no memories for this project yet'
+    if ($DryRun) {
+        Write-Dry "Would run engram sync for project: $projectName"
+        Write-Dry 'Would install git hooks to: .git/hooks/'
     }
     else {
-        Write-Ok '.engram/ will be created on first sync'
-        Write-Warn 'engram not installed -- sync will work after installing engram'
-    }
+        # 4a. Run initial engram sync
+        $engramResult = Initialize-EngramSync -ProjectRoot $projectRoot -ProjectName $projectName
 
-    # 4b. Install git hooks
-    $hookResult = Install-GitHooks -ProjectRoot $projectRoot -ProjectName $projectName
+        if ($engramResult.synced) {
+            Write-Ok 'engram sync completed -- .engram/ ready for team sharing'
+        }
+        elseif (Test-EngramInstalled) {
+            Write-Ok 'engram sync attempted -- no memories for this project yet'
+        }
+        else {
+            Write-Ok '.engram/ will be created on first sync'
+            Write-Warn 'engram not installed -- sync will work after installing engram'
+        }
 
-    if ($hookResult.installed.Count -gt 0) {
-        Write-Ok "Git hooks installed: $($hookResult.installed -join ', ')"
-    }
-    if ($hookResult.skipped -contains 'not-a-git-repo') {
-        Write-Warn 'Not a git repo -- hooks skipped'
-    }
-    elseif ($hookResult.skipped.Count -gt 0) {
-        Write-Step "Git hooks already present: $($hookResult.skipped -join ', ')"
+        # 4b. Install git hooks
+        $hookResult = Install-GitHooks -ProjectRoot $projectRoot -ProjectName $projectName
+
+        if ($hookResult.installed.Count -gt 0) {
+            Write-Ok "Git hooks installed: $($hookResult.installed -join ', ')"
+        }
+        if ($hookResult.skipped -contains 'not-a-git-repo') {
+            Write-Warn 'Not a git repo -- hooks skipped'
+        }
+        elseif ($hookResult.skipped.Count -gt 0) {
+            Write-Step "Git hooks already present: $($hookResult.skipped -join ', ')"
+        }
     }
 
     # -- Save project config ---------------------------------------------------
-    $now = Get-Date -Format 'o'
-    $projectConfig = @{
-        role          = $effectiveRole
-        ide           = $effectiveIde
-        teamRepo      = $effectiveTeamRepo
-        initializedAt = $now
-        lastSync      = $now
-        version       = $KitVersion
-    }
-    $null = Save-ProjectConfig -ProjectRoot $projectRoot -Config $projectConfig
-    Write-Ok 'Project config saved: .team-ai-kit.json'
-
-    # -- Summary ---------------------------------------------------------------
-    Write-Host ''
-    $summary = New-InitSummary -Ide $effectiveIde -Role $effectiveRole -InstructionsPath $relInstructionsPath -EngramSynced $engramResult.synced -HooksInstalled $hookResult.installed.Count
-    Write-Host $summary -ForegroundColor Green
-
-    Write-Host ''
-    Write-Host '  Next steps:' -ForegroundColor Yellow
-    Write-Host "    1. Commit .team-ai-kit.json and $relInstructionsPath to your repo" -ForegroundColor White
-    if ($effectiveTeamRepo) {
-        $relSkillsDir = (Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot).Replace($projectRoot, '').TrimStart('\', '/')
-        Write-Host "    2. Commit $relSkillsDir/ (team skills for this project)" -ForegroundColor White
-        Write-Host '    3. Commit .engram/ to share knowledge with your team' -ForegroundColor White
-        Write-Host '    4. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+    if ($DryRun) {
+        Write-Dry 'Would save project config: .team-ai-kit.json'
     }
     else {
-        Write-Host '    2. Commit .engram/ to share knowledge with your team' -ForegroundColor White
-        Write-Host '    3. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+        $now = Get-Date -Format 'o'
+        $projectConfig = @{
+            role          = $effectiveRole
+            ide           = $effectiveIde
+            teamRepo      = $effectiveTeamRepo
+            initializedAt = $now
+            lastSync      = $now
+            version       = $KitVersion
+        }
+        $null = Save-ProjectConfig -ProjectRoot $projectRoot -Config $projectConfig
+        Write-Ok 'Project config saved: .team-ai-kit.json'
     }
-    Write-Host '       (manual sync: team-ai-kit sync)' -ForegroundColor DarkGray
-    Write-Host ''
+
+    # -- Summary ---------------------------------------------------------------
+    if ($DryRun) {
+        Write-Host ''
+        Write-Host '  [DRY-RUN] No changes were made. The above shows what would happen.' -ForegroundColor Cyan
+        Write-Host ''
+    }
+    else {
+        Write-Host ''
+        $summary = New-InitSummary -Ide $effectiveIde -Role $effectiveRole -InstructionsPath $relInstructionsPath -EngramSynced $engramResult.synced -HooksInstalled $hookResult.installed.Count
+        Write-Host $summary -ForegroundColor Green
+
+        Write-Host ''
+        Write-Host '  Next steps:' -ForegroundColor Yellow
+        Write-Host "    1. Commit .team-ai-kit.json and $relInstructionsPath to your repo" -ForegroundColor White
+        if ($effectiveTeamRepo) {
+            $relSkillsDir = (Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot).Replace($projectRoot, '').TrimStart('\', '/')
+            Write-Host "    2. Commit $relSkillsDir/ (team skills for this project)" -ForegroundColor White
+            Write-Host '    3. Commit .engram/ to share knowledge with your team' -ForegroundColor White
+            Write-Host '    4. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+        }
+        else {
+            Write-Host '    2. Commit .engram/ to share knowledge with your team' -ForegroundColor White
+            Write-Host '    3. Start working -- git hooks will sync engram automatically!' -ForegroundColor White
+        }
+        Write-Host '       (manual sync: team-ai-kit sync)' -ForegroundColor DarkGray
+        Write-Host ''
+    }
 }
 
 # -- Init Knowledge (scaffold team knowledge repo) ----------------------------
@@ -817,23 +852,28 @@ function Invoke-UpdateCommand {
         $targetSkillsDir = Get-IdeSkillsDirectory -Ide $config.ide
     }
 
-    Write-Step "Merging kit base skills to global: $targetSkillsDir"
-
-    $mergeParams = @{
-        KitRoot   = $kitRoot
-        Role      = $config.role
-        TargetDir = $targetSkillsDir
+    if ($DryRun) {
+        Write-Dry "Would merge kit base skills to: $targetSkillsDir"
     }
+    else {
+        Write-Step "Merging kit base skills to global: $targetSkillsDir"
 
-    $mergeResults = Install-SkillsWithMerge @mergeParams
+        $mergeParams = @{
+            KitRoot   = $kitRoot
+            Role      = $config.role
+            TargetDir = $targetSkillsDir
+        }
 
-    Write-Host ''
-    Write-Ok "Installed: $($mergeResults.installed.Count) new skills"
-    if ($mergeResults.updated.Count -gt 0) {
-        Write-Ok "Updated:   $($mergeResults.updated.Count) skills (source changed, yours untouched)"
-    }
-    if ($mergeResults.skipped.Count -gt 0) {
-        Write-Step "Unchanged: $($mergeResults.skipped.Count) skills (already up to date or user-modified)"
+        $mergeResults = Install-SkillsWithMerge @mergeParams
+
+        Write-Host ''
+        Write-Ok "Installed: $($mergeResults.installed.Count) new skills"
+        if ($mergeResults.updated.Count -gt 0) {
+            Write-Ok "Updated:   $($mergeResults.updated.Count) skills (source changed, yours untouched)"
+        }
+        if ($mergeResults.skipped.Count -gt 0) {
+            Write-Step "Unchanged: $($mergeResults.skipped.Count) skills (already up to date or user-modified)"
+        }
     }
 
     # Step 2b: Install team-repo skills to project-level directory
@@ -841,19 +881,25 @@ function Invoke-UpdateCommand {
         $effectiveIde = if ($projectConfig.ide) { $projectConfig.ide } else { $config.ide }
         $effectiveRole = if ($projectConfig.role) { $projectConfig.role } else { $config.role }
         $projectSkillsDir = Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot
+        $relDir = $projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/')
 
-        Write-Host ''
-        Write-Step "Merging team skills to project: $($projectSkillsDir.Replace($projectRoot, '').TrimStart('\', '/'))"
+        if ($DryRun) {
+            Write-Dry "Would merge team skills to: $relDir"
+        }
+        else {
+            Write-Host ''
+            Write-Step "Merging team skills to project: $relDir"
 
-        $projectSkillResults = Install-ProjectSkills -Role $effectiveRole -TeamRepoUrl $effectiveTeamRepo -TargetDir $projectSkillsDir
-        if ($projectSkillResults.installed -gt 0) {
-            Write-Ok "Installed: $($projectSkillResults.installed) new team skills"
-        }
-        if ($projectSkillResults.updated -gt 0) {
-            Write-Ok "Updated:   $($projectSkillResults.updated) team skills"
-        }
-        if ($projectSkillResults.skipped -gt 0) {
-            Write-Step "Unchanged: $($projectSkillResults.skipped) team skills"
+            $projectSkillResults = Install-ProjectSkills -Role $effectiveRole -TeamRepoUrl $effectiveTeamRepo -TargetDir $projectSkillsDir
+            if ($projectSkillResults.installed -gt 0) {
+                Write-Ok "Installed: $($projectSkillResults.installed) new team skills"
+            }
+            if ($projectSkillResults.updated -gt 0) {
+                Write-Ok "Updated:   $($projectSkillResults.updated) team skills"
+            }
+            if ($projectSkillResults.skipped -gt 0) {
+                Write-Step "Unchanged: $($projectSkillResults.skipped) team skills"
+            }
         }
     }
 
@@ -863,12 +909,18 @@ function Invoke-UpdateCommand {
         if ($teamRulesContent) {
             $instructionsPath = Get-IdeInstructionsPath -Ide $config.ide -ProjectRoot $projectRoot
             if (Test-Path $instructionsPath) {
-                $rulesChanged = Update-InstructionsTeamRules -FilePath $instructionsPath -TeamRulesContent $teamRulesContent
-                if ($rulesChanged) {
-                    Write-Ok 'Team rules updated in project instructions'
+                if ($DryRun) {
+                    $relPath = $instructionsPath.Replace($projectRoot, '').TrimStart('\', '/')
+                    Write-Dry "Would update team rules in: $relPath"
                 }
                 else {
-                    Write-Step 'Team rules unchanged in project instructions'
+                    $rulesChanged = Update-InstructionsTeamRules -FilePath $instructionsPath -TeamRulesContent $teamRulesContent
+                    if ($rulesChanged) {
+                        Write-Ok 'Team rules updated in project instructions'
+                    }
+                    else {
+                        Write-Step 'Team rules unchanged in project instructions'
+                    }
                 }
             }
         }
@@ -879,29 +931,44 @@ function Invoke-UpdateCommand {
     if ($projectConfig) {
         $instructionsPath = Get-IdeInstructionsPath -Ide $config.ide -ProjectRoot $projectRoot
         if (Test-Path $instructionsPath) {
-            $skipProtocol = Test-GentleAiSupportsIde -Ide $config.ide
-            $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath -SkipEngramProtocol:$skipProtocol
-            if ($protocolChanged) {
-                if ($skipProtocol) {
-                    Write-Ok 'Engram Memory Protocol removed from project instructions (gentle-ai handles it)'
-                }
-                else {
-                    Write-Ok 'Engram Memory Protocol updated in project instructions'
-                }
+            if ($DryRun) {
+                $relPath = $instructionsPath.Replace($projectRoot, '').TrimStart('\', '/')
+                Write-Dry "Would update engram protocol in: $relPath"
             }
             else {
-                Write-Step 'Engram Memory Protocol unchanged in project instructions'
+                $skipProtocol = Test-GentleAiSupportsIde -Ide $config.ide
+                $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath -SkipEngramProtocol:$skipProtocol
+                if ($protocolChanged) {
+                    if ($skipProtocol) {
+                        Write-Ok 'Engram Memory Protocol removed from project instructions (gentle-ai handles it)'
+                    }
+                    else {
+                        Write-Ok 'Engram Memory Protocol updated in project instructions'
+                    }
+                }
+                else {
+                    Write-Step 'Engram Memory Protocol unchanged in project instructions'
+                }
             }
         }
     }
 
     # Step 5: Update config timestamp and version
-    $config.lastUpdate = Get-Date -Format 'o'
-    $config.version = $KitVersion
-    Save-TeamAiKitConfig -Config $config | Out-Null
-    Write-Host ''
-    Write-Ok 'Update complete'
-    Write-Host ''
+    if ($DryRun) {
+        Write-Host ''
+        Write-Dry 'Would update global config timestamp'
+        Write-Host ''
+        Write-Host '  [DRY-RUN] No changes were made. The above shows what would happen.' -ForegroundColor Cyan
+        Write-Host ''
+    }
+    else {
+        $config.lastUpdate = Get-Date -Format 'o'
+        $config.version = $KitVersion
+        Save-TeamAiKitConfig -Config $config | Out-Null
+        Write-Host ''
+        Write-Ok 'Update complete'
+        Write-Host ''
+    }
 }
 
 # -- Status --------------------------------------------------------------------
@@ -1155,6 +1222,12 @@ function Invoke-UninstallCommand {
     }
 
     Write-Host ''
+
+    if ($DryRun) {
+        Write-Host '  [DRY-RUN] No changes were made. The above shows what would be removed.' -ForegroundColor Cyan
+        Write-Host ''
+        return
+    }
 
     # Ask for confirmation unless --force
     if (-not $Force) {

--- a/tests/e2e-bash.sh
+++ b/tests/e2e-bash.sh
@@ -219,6 +219,55 @@ else
 fi
 rm -rf "$UNINST_DIR"
 
+# -- Test 14: init --dry-run does not create files ---
+echo "--- Test 14: init --dry-run ---"
+DRYRUN_DIR="/tmp/team-ai-kit-dryrun-$$"
+DRYRUN_HOME="/tmp/team-ai-kit-dryrun-home-$$"
+mkdir -p "$DRYRUN_HOME" "$DRYRUN_DIR/.git"
+# Setup first
+HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide vscode --role frontend --target-dir "$DRYRUN_DIR" --skip-prerequisites --skip-gentle-ai 2>&1 >/dev/null || true
+# Init with --dry-run
+output=$(cd "$DRYRUN_DIR" && HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init --dry-run 2>&1) || true
+if echo "$output" | grep -q "\[DRY-RUN\]"; then
+    pass "init --dry-run shows DRY-RUN output"
+else
+    fail "init --dry-run should show DRY-RUN prefix"
+    echo "$output" | tail -10
+fi
+if [ ! -f "$DRYRUN_DIR/.team-ai-kit.json" ]; then
+    pass "init --dry-run did not create .team-ai-kit.json"
+else
+    fail "init --dry-run should not create .team-ai-kit.json"
+fi
+if [ ! -f "$DRYRUN_DIR/.github/copilot-instructions.md" ]; then
+    pass "init --dry-run did not create instructions file"
+else
+    fail "init --dry-run should not create instructions file"
+fi
+
+# -- Test 15: uninstall --dry-run does not remove files ---
+echo "--- Test 15: uninstall --dry-run ---"
+# Actually init first (without dry-run)
+(cd "$DRYRUN_DIR" && HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init 2>&1) >/dev/null || true
+# Verify it was initialized
+if [ -f "$DRYRUN_DIR/.team-ai-kit.json" ]; then
+    output=$(cd "$DRYRUN_DIR" && HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" uninstall --dry-run 2>&1) || true
+    if echo "$output" | grep -q "\[DRY-RUN\]"; then
+        pass "uninstall --dry-run shows DRY-RUN output"
+    else
+        fail "uninstall --dry-run should show DRY-RUN prefix"
+        echo "$output" | tail -10
+    fi
+    if [ -f "$DRYRUN_DIR/.team-ai-kit.json" ]; then
+        pass "uninstall --dry-run preserved .team-ai-kit.json"
+    else
+        fail "uninstall --dry-run should not remove .team-ai-kit.json"
+    fi
+else
+    fail "dry-run uninstall test: project not initialized"
+fi
+rm -rf "$DRYRUN_DIR" "$DRYRUN_HOME"
+
 # -- Summary ---
 echo ""
 echo "================================"


### PR DESCRIPTION
﻿## Summary
- Adds `--dry-run` flag (bash) / `-DryRun` switch (PowerShell) for `init`, `update`, and `uninstall` commands
- Runs all detection/resolution logic but skips all disk writes (no files created, updated, or removed)
- Prints `[DRY-RUN]` prefixed messages showing what would happen
- 2 new bash e2e tests verifying no files are written during dry-run

Closes #116
