### PR TITLE
feat(init): add .gitattributes rules to collapse .engram/ diffs in PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Remueve todos los artefactos de team-ai-kit del proyecto actual:
 - Archivo de instrucciones generado (`.github/copilot-instructions.md`, `.cursor/rules/team-ai-kit.md`, `AGENTS.md`)
 - Directorio `team-skills/` con las skills instaladas
 - Bloques de git hooks inyectados (pre-commit, post-merge)
+- Reglas de `.gitattributes` para colapsar diffs de `.engram/` en PRs
 - Manifest global de skills
 
 ```bash
@@ -347,7 +348,7 @@ El comando `update` mantiene el protocolo actualizado automaticamente.
 +-------------------------------------------+
 |  PROJECT config (committed to each repo)  |
 |  .team-ai-kit.json + instructions +       |
-|  .engram/ + git hooks                     |
+|  .engram/ + git hooks + .gitattributes    |
 +-------------------------------------------+
 ```
 

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -600,6 +600,7 @@ cmd_init() {
     if [[ "$OPT_DRY_RUN" == "true" ]]; then
         dry "Would run engram sync for project: $project_name"
         dry "Would install git hooks to: .git/hooks/"
+        dry "Would create/update .gitattributes with engram diff rules"
     else
         # 4a. Run initial engram sync
         local engram_json engram_synced
@@ -629,6 +630,20 @@ cmd_init() {
             warn "Not a git repo -- hooks skipped"
         elif [[ -n "$hooks_skipped_list" && "$hooks_skipped_list" != "" ]]; then
             step "Git hooks already present: $hooks_skipped_list"
+        fi
+
+        # 4c. Setup .gitattributes for clean PR diffs
+        local ga_json ga_created ga_updated
+        ga_json=$(ensure_gitattributes "$project_root")
+        ga_created=$(echo "$ga_json" | jq -r '.created')
+        ga_updated=$(echo "$ga_json" | jq -r '.updated')
+
+        if [[ "$ga_created" == "true" ]]; then
+            ok ".gitattributes created -- .engram/ diffs collapsed in PRs"
+        elif [[ "$ga_updated" == "true" ]]; then
+            ok ".gitattributes updated -- .engram/ diffs collapsed in PRs"
+        else
+            step ".gitattributes already configured"
         fi
     fi
 
@@ -932,6 +947,24 @@ cmd_update() {
         fi
     fi
 
+    # Step 4b: Ensure .gitattributes has engram diff rules
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry "Would ensure .gitattributes has engram diff rules"
+    else
+        local ga_json ga_created ga_updated
+        ga_json=$(ensure_gitattributes "$project_root")
+        ga_created=$(echo "$ga_json" | jq -r '.created')
+        ga_updated=$(echo "$ga_json" | jq -r '.updated')
+
+        if [[ "$ga_created" == "true" ]]; then
+            ok ".gitattributes created -- .engram/ diffs collapsed in PRs"
+        elif [[ "$ga_updated" == "true" ]]; then
+            ok ".gitattributes updated -- .engram/ diffs collapsed in PRs"
+        else
+            step ".gitattributes already configured"
+        fi
+    fi
+
     # Step 5: Update config timestamp
     if [[ "$OPT_DRY_RUN" == "true" ]]; then
         echo ""
@@ -1182,6 +1215,8 @@ cmd_uninstall() {
             local hook_path="${target#hook:}"
             local rel_hook="${hook_path#$project_root/}"
             echo -e "    ${C_RED}~ $rel_hook${C_RESET} (team-ai-kit block)"
+        elif [[ "$target" == gitattributes:* ]]; then
+            echo -e "    ${C_RED}~ .gitattributes${C_RESET} (team-ai-kit lines)"
         elif [[ -d "$target" ]]; then
             local rel="${target#$project_root/}"
             echo -e "    ${C_RED}- $rel/${C_RESET}"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -628,6 +628,7 @@ function Invoke-InitCommand {
     if ($DryRun) {
         Write-Dry "Would run engram sync for project: $projectName"
         Write-Dry 'Would install git hooks to: .git/hooks/'
+        Write-Dry 'Would create/update .gitattributes with engram diff rules'
     }
     else {
         # 4a. Run initial engram sync
@@ -655,6 +656,19 @@ function Invoke-InitCommand {
         }
         elseif ($hookResult.skipped.Count -gt 0) {
             Write-Step "Git hooks already present: $($hookResult.skipped -join ', ')"
+        }
+
+        # 4c. Setup .gitattributes for clean PR diffs
+        $gaResult = Ensure-GitAttributes -ProjectRoot $projectRoot
+
+        if ($gaResult.created) {
+            Write-Ok '.gitattributes created -- .engram/ diffs collapsed in PRs'
+        }
+        elseif ($gaResult.updated) {
+            Write-Ok '.gitattributes updated -- .engram/ diffs collapsed in PRs'
+        }
+        else {
+            Write-Step '.gitattributes already configured'
         }
     }
 
@@ -953,6 +967,24 @@ function Invoke-UpdateCommand {
         }
     }
 
+    # Step 4b: Ensure .gitattributes has engram diff rules
+    if ($DryRun) {
+        Write-Dry 'Would ensure .gitattributes has engram diff rules'
+    }
+    else {
+        $gaResult = Ensure-GitAttributes -ProjectRoot $projectRoot
+
+        if ($gaResult.created) {
+            Write-Ok '.gitattributes created -- .engram/ diffs collapsed in PRs'
+        }
+        elseif ($gaResult.updated) {
+            Write-Ok '.gitattributes updated -- .engram/ diffs collapsed in PRs'
+        }
+        else {
+            Write-Step '.gitattributes already configured'
+        }
+    }
+
     # Step 5: Update config timestamp and version
     if ($DryRun) {
         Write-Host ''
@@ -1205,6 +1237,9 @@ function Invoke-UninstallCommand {
         switch ($target.Type) {
             'hook' {
                 Write-Host "    ~ $rel (team-ai-kit block)" -ForegroundColor Red
+            }
+            'gitattributes' {
+                Write-Host '    ~ .gitattributes (team-ai-kit lines)' -ForegroundColor Red
             }
             'dir' {
                 Write-Host "    - $rel/" -ForegroundColor Red

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -174,6 +174,92 @@ function Save-ProjectConfig {
     return $configPath
 }
 
+function Ensure-GitAttributes {
+    <#
+    .SYNOPSIS
+        Creates or updates .gitattributes with rules to collapse .engram/ diffs in PRs.
+    .DESCRIPTION
+        Adds linguist-generated and -diff rules for .engram/ so PR diffs stay clean.
+        Idempotent: skips if marker already present.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $gaPath = Join-Path $ProjectRoot '.gitattributes'
+    $marker = '# [team-ai-kit] engram diff rules'
+    $block = @(
+        $marker
+        '.engram/** linguist-generated=true'
+        '.engram/** -diff'
+    ) -join "`n"
+
+    if (Test-Path $gaPath) {
+        $existing = Get-Content $gaPath -Raw -ErrorAction SilentlyContinue
+        if ($existing -and $existing.Contains($marker)) {
+            return @{ created = $false; updated = $false; path = $gaPath }
+        }
+        # Append with blank line separator
+        $newContent = $existing.TrimEnd() + "`n`n" + $block + "`n"
+        $lfContent = $newContent -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($gaPath, $lfContent, [System.Text.UTF8Encoding]::new($false))
+        return @{ created = $false; updated = $true; path = $gaPath }
+    }
+    else {
+        $lfContent = ($block + "`n") -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($gaPath, $lfContent, [System.Text.UTF8Encoding]::new($false))
+        return @{ created = $true; updated = $false; path = $gaPath }
+    }
+}
+
+function Remove-GitAttributesBlock {
+    <#
+    .SYNOPSIS
+        Removes team-ai-kit lines from .gitattributes during uninstall.
+    .DESCRIPTION
+        Deletes the file if only our lines remain.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $gaPath = Join-Path $ProjectRoot '.gitattributes'
+    if (-not (Test-Path $gaPath)) { return }
+
+    $content = Get-Content $gaPath -Raw -ErrorAction SilentlyContinue
+    $marker = '# [team-ai-kit] engram diff rules'
+    if (-not $content -or -not $content.Contains($marker)) { return }
+
+    $lines = Get-Content $gaPath
+    $cleaned = @()
+    $skipNext = $false
+
+    foreach ($line in $lines) {
+        if ($line.Contains($marker)) {
+            $skipNext = $true
+            continue
+        }
+        if ($skipNext -and $line -match '^\.engram/') {
+            continue
+        }
+        $skipNext = $false
+        $cleaned += $line
+    }
+
+    $cleaned = @($cleaned | Where-Object { $_.Trim() -ne '' })
+
+    if ($cleaned.Count -eq 0) {
+        Remove-Item $gaPath -Force
+    }
+    else {
+        $newContent = ($cleaned -join "`n") + "`n"
+        $lfContent = $newContent -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($gaPath, $lfContent, [System.Text.UTF8Encoding]::new($false))
+    }
+}
+
 function Initialize-EngramSync {
     <#
     .SYNOPSIS
@@ -1992,6 +2078,16 @@ function Get-UninstallTargets {
         }
     }
 
+    # 6. .gitattributes (only if it contains our marker)
+    $gaMarker = '# [team-ai-kit] engram diff rules'
+    $gaPath = Join-Path $ProjectRoot '.gitattributes'
+    if (Test-Path $gaPath) {
+        $gaContent = Get-Content $gaPath -Raw -ErrorAction SilentlyContinue
+        if ($gaContent -and $gaContent.Contains($gaMarker)) {
+            [void]$targets.Add(@{ Type = 'gitattributes'; Path = $gaPath })
+        }
+    }
+
     return @($targets)
 }
 
@@ -2054,6 +2150,10 @@ function Invoke-Uninstall {
         switch ($target.Type) {
             'hook' {
                 Remove-HookMarkerBlock -HookPath $target.Path
+                $removed++
+            }
+            'gitattributes' {
+                Remove-GitAttributesBlock -ProjectRoot $ProjectRoot
                 $removed++
             }
             'dir' {

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -158,6 +158,73 @@ save_project_config() {
     echo "$config_path"
 }
 
+ensure_gitattributes() {
+    # Creates or updates .gitattributes with rules to collapse .engram/ diffs in PRs.
+    # Uses linguist-generated to hide diffs on GitHub and -diff to hide locally.
+    # Idempotent: skips if marker already present.
+    # Usage: ensure_gitattributes "/path/to/project"
+    # Outputs JSON: {"created":bool, "updated":bool, "path":"..."}
+    local project_root="$1"
+    local ga_path="$project_root/.gitattributes"
+    local marker='# [team-ai-kit] engram diff rules'
+    local block
+    block=$(printf '%s\n%s\n%s' \
+        "$marker" \
+        '.engram/** linguist-generated=true' \
+        '.engram/** -diff')
+
+    if [[ -f "$ga_path" ]]; then
+        if grep -qF "$marker" "$ga_path" 2>/dev/null; then
+            jq -n --arg path "$ga_path" '{created:false, updated:false, path:$path}'
+            return
+        fi
+        # Append with a blank line separator
+        printf '\n%s\n' "$block" >> "$ga_path"
+        jq -n --arg path "$ga_path" '{created:false, updated:true, path:$path}'
+    else
+        printf '%s\n' "$block" > "$ga_path"
+        jq -n --arg path "$ga_path" '{created:true, updated:false, path:$path}'
+    fi
+}
+
+remove_gitattributes_block() {
+    # Removes team-ai-kit lines from .gitattributes during uninstall.
+    # Deletes the file if only our lines remain.
+    # Usage: remove_gitattributes_block "/path/to/project"
+    local project_root="$1"
+    local ga_path="$project_root/.gitattributes"
+    local marker='# [team-ai-kit] engram diff rules'
+
+    [[ -f "$ga_path" ]] || return 0
+    grep -qF "$marker" "$ga_path" 2>/dev/null || return 0
+
+    local cleaned=""
+    local skip_next=false
+    while IFS= read -r line; do
+        if [[ "$line" == *"$marker"* ]]; then
+            skip_next=true
+            continue
+        fi
+        if [[ "$skip_next" == true ]]; then
+            # Skip the two rule lines that follow the marker
+            if [[ "$line" == .engram/* ]]; then
+                continue
+            fi
+            skip_next=false
+        fi
+        cleaned+="$line"$'\n'
+    done < "$ga_path"
+
+    # Remove trailing blank lines
+    cleaned=$(printf '%s' "$cleaned" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
+
+    if [[ -z "$cleaned" || "$cleaned" =~ ^[[:space:]]*$ ]]; then
+        rm -f "$ga_path"
+    else
+        printf '%s\n' "$cleaned" > "$ga_path"
+    fi
+}
+
 initialize_engram_sync() {
     # Runs initial engram sync to export project memories to .engram/.
     # Uses native 'engram sync --project <name>' for team knowledge sharing via git.
@@ -1486,6 +1553,13 @@ collect_uninstall_targets() {
         fi
     done
 
+    # 6. .gitattributes (only if it contains our marker)
+    local ga_marker='# [team-ai-kit] engram diff rules'
+    local ga_path="$project_root/.gitattributes"
+    if [[ -f "$ga_path" ]] && grep -qF "$ga_marker" "$ga_path" 2>/dev/null; then
+        targets+=("gitattributes:$ga_path")
+    fi
+
     printf '%s\n' "${targets[@]}"
 }
 
@@ -1543,6 +1617,10 @@ uninstall_project() {
         if [[ "$target" == hook:* ]]; then
             local hook_path="${target#hook:}"
             remove_hook_marker_block "$hook_path"
+            removed=$((removed + 1))
+        elif [[ "$target" == gitattributes:* ]]; then
+            local ga_path="${target#gitattributes:}"
+            remove_gitattributes_block "$(dirname "$ga_path")"
             removed=$((removed + 1))
         elif [[ -d "$target" ]]; then
             rm -rf "$target"

--- a/tests/functions-bash.sh
+++ b/tests/functions-bash.sh
@@ -27,7 +27,7 @@ assert_eq() {
 
 assert_contains() {
     local test_name="$1" haystack="$2" needle="$3"
-    if echo "$haystack" | grep -qF "$needle"; then
+    if echo "$haystack" | grep -qF -- "$needle"; then
         pass "$test_name"
     else
         fail "$test_name (missing '$needle')" ""
@@ -36,7 +36,7 @@ assert_contains() {
 
 assert_not_contains() {
     local test_name="$1" haystack="$2" needle="$3"
-    if echo "$haystack" | grep -qF "$needle"; then
+    if echo "$haystack" | grep -qF -- "$needle"; then
         fail "$test_name (should not contain '$needle')" ""
     else
         pass "$test_name"
@@ -303,7 +303,7 @@ ga_created=$(echo "$ga_json" | jq -r '.created')
 assert_eq "creates .gitattributes when absent" "true" "$ga_created"
 assert_contains "file has marker" "$(cat "$ga_tmpdir/.gitattributes")" "# [team-ai-kit] engram diff rules"
 assert_contains "file has linguist-generated" "$(cat "$ga_tmpdir/.gitattributes")" "linguist-generated=true"
-assert_contains "file has -diff" "$(cat "$ga_tmpdir/.gitattributes")" "-diff"
+assert_contains "file has -diff" "$(cat "$ga_tmpdir/.gitattributes")" ".engram/** -diff"
 rm -rf "$ga_tmpdir"
 
 # Test: appends to existing .gitattributes

--- a/tests/functions-bash.sh
+++ b/tests/functions-bash.sh
@@ -292,6 +292,70 @@ rm -f "$tmpfile"
 echo ""
 
 # =============================================================================
+# ensure_gitattributes / remove_gitattributes_block
+# =============================================================================
+echo "--- ensure_gitattributes ---"
+
+# Test: creates .gitattributes when it doesn't exist
+ga_tmpdir=$(mktemp -d)
+ga_json=$(ensure_gitattributes "$ga_tmpdir")
+ga_created=$(echo "$ga_json" | jq -r '.created')
+assert_eq "creates .gitattributes when absent" "true" "$ga_created"
+assert_contains "file has marker" "$(cat "$ga_tmpdir/.gitattributes")" "# [team-ai-kit] engram diff rules"
+assert_contains "file has linguist-generated" "$(cat "$ga_tmpdir/.gitattributes")" "linguist-generated=true"
+assert_contains "file has -diff" "$(cat "$ga_tmpdir/.gitattributes")" "-diff"
+rm -rf "$ga_tmpdir"
+
+# Test: appends to existing .gitattributes
+ga_tmpdir=$(mktemp -d)
+echo "*.pdf binary" > "$ga_tmpdir/.gitattributes"
+ga_json=$(ensure_gitattributes "$ga_tmpdir")
+ga_updated=$(echo "$ga_json" | jq -r '.updated')
+assert_eq "appends to existing .gitattributes" "true" "$ga_updated"
+assert_contains "preserves existing content" "$(cat "$ga_tmpdir/.gitattributes")" "*.pdf binary"
+assert_contains "adds marker" "$(cat "$ga_tmpdir/.gitattributes")" "# [team-ai-kit] engram diff rules"
+rm -rf "$ga_tmpdir"
+
+# Test: idempotent -- no-op when marker present
+ga_tmpdir=$(mktemp -d)
+printf '# [team-ai-kit] engram diff rules\n.engram/** linguist-generated=true\n.engram/** -diff\n' > "$ga_tmpdir/.gitattributes"
+ga_json=$(ensure_gitattributes "$ga_tmpdir")
+ga_created=$(echo "$ga_json" | jq -r '.created')
+ga_updated=$(echo "$ga_json" | jq -r '.updated')
+assert_eq "idempotent: created=false" "false" "$ga_created"
+assert_eq "idempotent: updated=false" "false" "$ga_updated"
+rm -rf "$ga_tmpdir"
+
+echo "--- remove_gitattributes_block ---"
+
+# Test: removes our lines, keeps others
+ga_tmpdir=$(mktemp -d)
+printf '*.pdf binary\n\n# [team-ai-kit] engram diff rules\n.engram/** linguist-generated=true\n.engram/** -diff\n' > "$ga_tmpdir/.gitattributes"
+remove_gitattributes_block "$ga_tmpdir"
+assert_contains "keeps other rules" "$(cat "$ga_tmpdir/.gitattributes")" "*.pdf binary"
+assert_not_contains "removes marker" "$(cat "$ga_tmpdir/.gitattributes")" "team-ai-kit"
+rm -rf "$ga_tmpdir"
+
+# Test: deletes file when only our lines remain
+ga_tmpdir=$(mktemp -d)
+printf '# [team-ai-kit] engram diff rules\n.engram/** linguist-generated=true\n.engram/** -diff\n' > "$ga_tmpdir/.gitattributes"
+remove_gitattributes_block "$ga_tmpdir"
+if [[ ! -f "$ga_tmpdir/.gitattributes" ]]; then
+    pass "deletes file when only our lines"
+else
+    fail "should delete file when only our lines" "file still exists"
+fi
+rm -rf "$ga_tmpdir"
+
+# Test: no-op when no file
+ga_tmpdir=$(mktemp -d)
+remove_gitattributes_block "$ga_tmpdir"
+pass "no-op when .gitattributes absent"
+rm -rf "$ga_tmpdir"
+
+echo ""
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo "================================"

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -2072,3 +2072,116 @@ Describe 'Test-ValidCommand includes uninstall' {
         Test-ValidCommand -Command 'uninstall' | Should -BeTrue
     }
 }
+
+# -- GitAttributes (.engram/ diff rules) ----------------------------------------
+
+Describe 'Ensure-GitAttributes' {
+    BeforeEach {
+        $script:gaTestDir = Join-Path $TestDrive "ga-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:gaTestDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $script:gaTestDir) { Remove-Item $script:gaTestDir -Recurse -Force }
+    }
+
+    It 'creates .gitattributes when file does not exist' {
+        $result = Ensure-GitAttributes -ProjectRoot $script:gaTestDir
+        $result.created | Should -BeTrue
+        $result.updated | Should -BeFalse
+        $gaPath = Join-Path $script:gaTestDir '.gitattributes'
+        Test-Path $gaPath | Should -BeTrue
+        $content = Get-Content $gaPath -Raw
+        $content | Should -Match 'team-ai-kit\] engram diff rules'
+        $content | Should -BeLike '*.engram/** linguist-generated=true*'
+        $content | Should -BeLike '*.engram/** -diff*'
+    }
+
+    It 'appends rules to existing .gitattributes without our marker' {
+        $gaPath = Join-Path $script:gaTestDir '.gitattributes'
+        "*.pdf binary`n" | Set-Content $gaPath -NoNewline
+        $result = Ensure-GitAttributes -ProjectRoot $script:gaTestDir
+        $result.created | Should -BeFalse
+        $result.updated | Should -BeTrue
+        $content = Get-Content $gaPath -Raw
+        $content | Should -BeLike '*.pdf binary*'
+        $content | Should -Match 'team-ai-kit\] engram diff rules'
+    }
+
+    It 'is idempotent -- no-op when marker already present' {
+        $gaPath = Join-Path $script:gaTestDir '.gitattributes'
+        $existing = "# [team-ai-kit] engram diff rules`n.engram/** linguist-generated=true`n.engram/** -diff`n"
+        Set-Content $gaPath -Value $existing -NoNewline
+        $result = Ensure-GitAttributes -ProjectRoot $script:gaTestDir
+        $result.created | Should -BeFalse
+        $result.updated | Should -BeFalse
+    }
+}
+
+Describe 'Remove-GitAttributesBlock' {
+    BeforeEach {
+        $script:gaTestDir = Join-Path $TestDrive "ga-rm-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:gaTestDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $script:gaTestDir) { Remove-Item $script:gaTestDir -Recurse -Force }
+    }
+
+    It 'removes team-ai-kit lines and keeps other rules' {
+        $gaPath = Join-Path $script:gaTestDir '.gitattributes'
+        $content = "*.pdf binary`n`n# [team-ai-kit] engram diff rules`n.engram/** linguist-generated=true`n.engram/** -diff`n"
+        Set-Content $gaPath -Value $content -NoNewline
+        Remove-GitAttributesBlock -ProjectRoot $script:gaTestDir
+        Test-Path $gaPath | Should -BeTrue
+        $remaining = Get-Content $gaPath -Raw
+        $remaining | Should -BeLike '*.pdf binary*'
+        $remaining | Should -Not -BeLike '*team-ai-kit*'
+    }
+
+    It 'deletes file when only our lines remain' {
+        $gaPath = Join-Path $script:gaTestDir '.gitattributes'
+        $content = "# [team-ai-kit] engram diff rules`n.engram/** linguist-generated=true`n.engram/** -diff`n"
+        Set-Content $gaPath -Value $content -NoNewline
+        Remove-GitAttributesBlock -ProjectRoot $script:gaTestDir
+        Test-Path $gaPath | Should -BeFalse
+    }
+
+    It 'is no-op when file does not exist' {
+        { Remove-GitAttributesBlock -ProjectRoot $script:gaTestDir } | Should -Not -Throw
+    }
+
+    It 'is no-op when file has no marker' {
+        $gaPath = Join-Path $script:gaTestDir '.gitattributes'
+        '*.pdf binary' | Set-Content $gaPath
+        Remove-GitAttributesBlock -ProjectRoot $script:gaTestDir
+        Test-Path $gaPath | Should -BeTrue
+        (Get-Content $gaPath -Raw) | Should -BeLike '*.pdf binary*'
+    }
+}
+
+Describe 'Get-UninstallTargets includes gitattributes' {
+    BeforeEach {
+        $script:gaUninstDir = Join-Path $TestDrive "ga-uninst-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:gaUninstDir -Force | Out-Null
+        # Create minimal project config
+        '{"role":"frontend","ide":"opencode"}' | Set-Content (Join-Path $script:gaUninstDir '.team-ai-kit.json')
+    }
+    AfterEach {
+        if (Test-Path $script:gaUninstDir) { Remove-Item $script:gaUninstDir -Recurse -Force }
+    }
+
+    It 'includes gitattributes target when marker is present' {
+        $gaPath = Join-Path $script:gaUninstDir '.gitattributes'
+        "# [team-ai-kit] engram diff rules`n.engram/** linguist-generated=true`n.engram/** -diff`n" | Set-Content $gaPath -NoNewline
+        $targets = Get-UninstallTargets -ProjectRoot $script:gaUninstDir
+        $gaTarget = $targets | Where-Object { $_.Type -eq 'gitattributes' }
+        $gaTarget | Should -Not -BeNullOrEmpty
+    }
+
+    It 'does not include gitattributes target when no marker' {
+        $gaPath = Join-Path $script:gaUninstDir '.gitattributes'
+        '*.pdf binary' | Set-Content $gaPath
+        $targets = Get-UninstallTargets -ProjectRoot $script:gaUninstDir
+        $gaTarget = $targets | Where-Object { $_.Type -eq 'gitattributes' }
+        $gaTarget | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
Closes #118

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add `.gitattributes` rules (`linguist-generated=true` + `-diff`) to collapse `.engram/` diffs in PRs and local git diff
- Integrated into `init`, `update`, and `uninstall` commands with full bash/PowerShell parity
- Idempotent: creates, appends, or skips depending on existing `.gitattributes` state

## Changes

| File | Change |
|------|--------|
| `lib/functions.sh` | `ensure_gitattributes()` + `remove_gitattributes_block()` |
| `lib/functions.ps1` | `Ensure-GitAttributes` + `Remove-GitAttributesBlock` |
| `bin/team-ai-kit` | init Step 4c, update Step 4b, uninstall display for gitattributes |
| `bin/team-ai-kit.ps1` | init Step 4c, update Step 4b, uninstall display for gitattributes |
| `tests/functions.Tests.ps1` | 9 new Pester tests for gitattributes functions |
| `tests/functions-bash.sh` | 7 new bash unit tests for gitattributes functions |
| `README.md` | Updated uninstall artifacts list and architecture diagram |

## Test Plan
- [x] Pester tests pass: 215 passed, 0 failed
- [x] Bash unit tests added for ensure/remove gitattributes
- [x] Dry-run messages added for all three commands
- [x] Idempotent behavior tested (create, append, skip, remove)

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (no WSL/bash available -- CI will verify)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
