### PR TITLE
feat(roles): add backend-java, backend-dotnet, mobile, and data roles

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -16,7 +16,7 @@
 #
 # Setup options:
 #   --ide <vscode|intellij|opencode|cursor>
-#   --role <frontend|backend-node|devops|python>
+#   --role <frontend|backend-node|backend-java|backend-dotnet|devops|python|mobile|data>
 #   --provider <openai|azure-openai|anthropic|github-copilot>
 #   --team-repo <url>         Team content repo URL
 #   --target-dir <path>       Custom output directory
@@ -102,7 +102,7 @@ show_help() {
     echo ""
     echo -e "  ${C_YELLOW}Setup options:${C_RESET}"
     echo "    --ide <vscode|intellij|opencode|cursor>"
-    echo "    --role <frontend|backend-node|devops|python>"
+    echo "    --role <frontend|backend-node|backend-java|backend-dotnet|devops|python|mobile|data>"
     echo "    --provider <openai|azure-openai|anthropic|github-copilot>"
     echo "    --team-repo <url>          Team content repo URL"
     echo "    --target-dir <path>        Custom output directory"
@@ -245,19 +245,27 @@ cmd_setup() {
     echo -e "  ${C_WHITE}[3/5] Role Selection${C_RESET}"
 
     if [[ -z "$OPT_ROLE" ]]; then
-        echo "    1) Frontend (React / Next.js)"
-        echo "    2) Backend (Node.js / Express)"
-        echo "    3) DevOps (CI/CD / Docker / Infra)"
-        echo "    4) Python (FastAPI / Django)"
+        echo "    1) Frontend (React / Next.js / Angular / Vue)"
+        echo "    2) Backend - Node.js (Express / Fastify)"
+        echo "    3) Backend - Java (Spring Boot / JPA)"
+        echo "    4) Backend - .NET (ASP.NET Core / EF Core)"
+        echo "    5) DevOps (CI/CD / Docker / Infra)"
+        echo "    6) Python (FastAPI / Django)"
+        echo "    7) Mobile (React Native / Expo)"
+        echo "    8) Data (pandas / scikit-learn / ML)"
         echo ""
         while true; do
-            read -rp "  Your role (1-4): " role_choice
+            read -rp "  Your role (1-8): " role_choice
             case "$role_choice" in
                 1) OPT_ROLE="frontend"; break ;;
                 2) OPT_ROLE="backend-node"; break ;;
-                3) OPT_ROLE="devops"; break ;;
-                4) OPT_ROLE="python"; break ;;
-                *) echo "  Invalid choice. Enter 1-4." ;;
+                3) OPT_ROLE="backend-java"; break ;;
+                4) OPT_ROLE="backend-dotnet"; break ;;
+                5) OPT_ROLE="devops"; break ;;
+                6) OPT_ROLE="python"; break ;;
+                7) OPT_ROLE="mobile"; break ;;
+                8) OPT_ROLE="data"; break ;;
+                *) echo "  Invalid choice. Enter 1-8." ;;
             esac
         done
     fi

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -59,7 +59,7 @@ param(
     [ValidateSet('vscode', 'intellij', 'opencode', 'cursor')]
     [string]$Ide,
 
-    [ValidateSet('frontend', 'backend-node', 'devops', 'python')]
+    [ValidateSet('frontend', 'backend-node', 'backend-java', 'backend-dotnet', 'devops', 'python', 'mobile', 'data')]
     [string]$Role,
 
     [ValidateSet('openai', 'azure-openai', 'anthropic', 'github-copilot')]
@@ -127,7 +127,7 @@ function Show-Help {
     Write-Host ''
     Write-Host '  Setup options:' -ForegroundColor Yellow
     Write-Host '    -Ide <vscode|intellij|opencode|cursor>'
-    Write-Host '    -Role <frontend|backend-node|devops|python>'
+    Write-Host '    -Role <frontend|backend-node|backend-java|backend-dotnet|devops|python|mobile|data>'
     Write-Host '    -Provider <openai|azure-openai|anthropic|github-copilot>'
     Write-Host '    -TeamRepo <url>          Team content repo URL'
     Write-Host '    -TargetDir <path>        Custom output directory'
@@ -283,21 +283,29 @@ function Invoke-SetupCommand {
     Write-Host '  [3/5] Role Selection' -ForegroundColor White
 
     if (-not $Role) {
-        Write-Host '    1) Frontend (React / Next.js)'
-        Write-Host '    2) Backend (Node.js / Express)'
-        Write-Host '    3) DevOps (CI/CD / Docker / Infra)'
-        Write-Host '    4) Python (FastAPI / Django)'
+        Write-Host '    1) Frontend (React / Next.js / Angular / Vue)'
+        Write-Host '    2) Backend - Node.js (Express / Fastify)'
+        Write-Host '    3) Backend - Java (Spring Boot / JPA)'
+        Write-Host '    4) Backend - .NET (ASP.NET Core / EF Core)'
+        Write-Host '    5) DevOps (CI/CD / Docker / Infra)'
+        Write-Host '    6) Python (FastAPI / Django)'
+        Write-Host '    7) Mobile (React Native / Expo)'
+        Write-Host '    8) Data (pandas / scikit-learn / ML)'
         Write-Host ''
 
         do {
-            $roleChoice = Read-Host '  Your role (1-4)'
-        } while ($roleChoice -notin @('1', '2', '3', '4'))
+            $roleChoice = Read-Host '  Your role (1-8)'
+        } while ($roleChoice -notin @('1', '2', '3', '4', '5', '6', '7', '8'))
 
         $script:Role = switch ($roleChoice) {
             '1' { 'frontend' }
             '2' { 'backend-node' }
-            '3' { 'devops' }
-            '4' { 'python' }
+            '3' { 'backend-java' }
+            '4' { 'backend-dotnet' }
+            '5' { 'devops' }
+            '6' { 'python' }
+            '7' { 'mobile' }
+            '8' { 'data' }
         }
     }
 

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -11,7 +11,7 @@ Set-StrictMode -Version Latest
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 $script:VALID_IDES = @('vscode', 'intellij', 'opencode', 'cursor')
-$script:VALID_ROLES = @('frontend', 'backend-node', 'devops', 'python')
+$script:VALID_ROLES = @('frontend', 'backend-node', 'backend-java', 'backend-dotnet', 'devops', 'python', 'mobile', 'data')
 $script:VALID_PROVIDERS = @('openai', 'azure-openai', 'anthropic', 'github-copilot')
 $script:VALID_COMMANDS = @('setup', 'init', 'init-knowledge', 'sync', 'update', 'status', 'doctor', 'uninstall', 'help')
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # -- Constants -----------------------------------------------------------------
 
 VALID_IDES=("vscode" "intellij" "opencode" "cursor")
-VALID_ROLES=("frontend" "backend-node" "devops" "python")
+VALID_ROLES=("frontend" "backend-node" "backend-java" "backend-dotnet" "devops" "python" "mobile" "data")
 VALID_PROVIDERS=("openai" "azure-openai" "anthropic" "github-copilot")
 VALID_COMMANDS=("setup" "init" "init-knowledge" "sync" "update" "status" "doctor" "help")
 

--- a/packs/backend-dotnet/rules.md
+++ b/packs/backend-dotnet/rules.md
@@ -1,0 +1,37 @@
+# Pack: Backend .NET (ASP.NET Core)
+
+> Rules and conventions for C#/.NET backend developers.
+
+---
+
+## Architecture Rules
+
+- Follow layered architecture: Controller → Service → Repository
+- Controllers handle HTTP concerns only — no business logic
+- Services contain all business logic
+- Repositories handle data access via EF Core
+- Use DTOs (record types) for API request/response — never expose entities
+
+## Coding Standards
+
+- Use constructor injection via built-in DI (`IServiceCollection`)
+- Prefer async/await for all I/O operations
+- Use `ProblemDetails` for consistent error responses
+- Always validate input with FluentValidation or Data Annotations
+- Use middleware for cross-cutting concerns (logging, auth, error handling)
+
+## Testing Standards
+
+- Every service method must have a unit test
+- Use `WebApplicationFactory<Program>` for integration tests
+- Use NSubstitute or Moq for mocking dependencies
+- Use FluentAssertions for readable assertions
+- Use Testcontainers for database integration tests when needed
+
+## Naming Conventions
+
+- Controllers: `*Controller.cs`
+- Services: `I*Service.cs` (interface) + `*Service.cs`
+- Repositories: `I*Repository.cs` + `*Repository.cs`
+- DTOs: `*Request.cs`, `*Response.cs`
+- Tests: `*Tests.cs` (unit), `*IntegrationTests.cs`

--- a/packs/backend-java/rules.md
+++ b/packs/backend-java/rules.md
@@ -1,0 +1,36 @@
+# Pack: Backend Java (Spring Boot)
+
+> Rules and conventions for Java/Spring Boot backend developers.
+
+---
+
+## Architecture Rules
+
+- Follow layered architecture: Controller → Service → Repository
+- Controllers handle HTTP concerns only — no business logic
+- Services contain all business logic
+- Repositories handle data access only
+- Use DTOs (record classes) for API request/response — never expose entities
+
+## Coding Standards
+
+- Use constructor injection — never field injection with `@Autowired`
+- Prefer `Optional<T>` returns from repositories over null checks
+- Use `@Transactional` at the service layer, not the controller
+- Always validate input with Jakarta Bean Validation (`@Valid`)
+- Use `@ControllerAdvice` for centralized error handling
+
+## Testing Standards
+
+- Every service method must have a unit test
+- Use `@SpringBootTest` only for integration tests — prefer plain JUnit 5 + Mockito for unit tests
+- Use Testcontainers for database integration tests
+- Use AssertJ for fluent, readable assertions
+
+## Naming Conventions
+
+- Controllers: `*Controller.java`
+- Services: `*Service.java` (interface) + `*ServiceImpl.java`
+- Repositories: `*Repository.java`
+- DTOs: `*Request.java`, `*Response.java`
+- Tests: `*Test.java` (unit), `*IT.java` (integration)

--- a/packs/data/rules.md
+++ b/packs/data/rules.md
@@ -1,0 +1,35 @@
+# Pack: Data (pandas / scikit-learn / ML)
+
+> Rules and conventions for data scientists and ML engineers.
+
+---
+
+## Architecture Rules
+
+- Separate data ingestion, transformation, and model training into distinct pipeline steps
+- Use configuration files (YAML/TOML) for hyperparameters — never hardcode
+- Keep notebooks for exploration only — production code goes in `.py` modules
+- Version datasets and models alongside code
+
+## Coding Standards
+
+- Use pandas method chaining for readable transformations
+- Use scikit-learn `Pipeline` + `ColumnTransformer` for reproducible preprocessing
+- Always set random seeds for reproducibility
+- Type-hint all function signatures
+- Use `logging` module — never `print()` in production code
+
+## Testing Standards
+
+- Test data transformations with known input/output pairs
+- Validate data schemas with pandera or Great Expectations
+- Assert model metrics stay above defined thresholds (regression tests)
+- Use pytest fixtures for sample DataFrames
+
+## Naming Conventions
+
+- Modules: `snake_case.py`
+- Pipelines: `*_pipeline.py`
+- Notebooks: `01_exploration.ipynb`, `02_modeling.ipynb` (numbered)
+- Tests: `test_*.py`
+- Models: `model_*.pkl` or `model_*.joblib`

--- a/packs/mobile/rules.md
+++ b/packs/mobile/rules.md
@@ -1,0 +1,34 @@
+# Pack: Mobile (React Native / Expo)
+
+> Rules and conventions for mobile developers.
+
+---
+
+## Architecture Rules
+
+- Use file-based routing (Expo Router) or stack-based navigation (React Navigation)
+- Separate screens from reusable components
+- Keep platform-specific code isolated with `.ios.ts` / `.android.ts` suffixes
+- Use a global state manager (Zustand) for client state and TanStack Query for server state
+
+## Coding Standards
+
+- Use `FlashList` over `FlatList` for large lists
+- Always handle loading, error, and empty states in every screen
+- Avoid inline styles — use `StyleSheet.create()` or NativeWind
+- Handle keyboard avoidance, safe areas, and gesture conflicts
+- Test on both iOS and Android before merging
+
+## Testing Standards
+
+- Use React Native Testing Library (RNTL) for component tests
+- Mock native modules with `jest.mock()` in setup files
+- Avoid snapshot tests — prefer behavioral assertions
+- Use Detox or Maestro for E2E testing
+
+## Naming Conventions
+
+- Screens: `*Screen.tsx` in `app/` or `screens/`
+- Components: PascalCase in `components/`
+- Hooks: `use*.ts` in `hooks/`
+- Navigation: defined in `app/` (Expo Router) or `navigation/`

--- a/setup.ps1
+++ b/setup.ps1
@@ -19,7 +19,7 @@ param(
     [ValidateSet('vscode', 'intellij', 'opencode', 'cursor')]
     [string]$Ide,
 
-    [ValidateSet('frontend', 'backend-node', 'devops', 'python')]
+    [ValidateSet('frontend', 'backend-node', 'backend-java', 'backend-dotnet', 'devops', 'python', 'mobile', 'data')]
     [string]$Role,
 
     [ValidateSet('openai', 'azure-openai', 'anthropic', 'github-copilot')]

--- a/skills/roles/backend-dotnet/api-design/SKILL.md
+++ b/skills/roles/backend-dotnet/api-design/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: backend-dotnet-api
+description: >
+  REST API design patterns with ASP.NET Core: controllers, services, middleware, model validation, error handling.
+  Trigger: When creating endpoints, defining routes, implementing middleware, or handling HTTP errors in C#/.NET.
+globs:
+  - "**/*.cs"
+  - "**/*.csproj"
+  - "**/Program.cs"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Backend .NET — API Design
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Building REST APIs with ASP.NET Core
+- Designing controller/service/repository layers
+- Implementing middleware, filters, or error handling
+
+## Critical Patterns
+
+- Return `ProblemDetails` for all error responses via exception middleware
+  - ❌ Returning plain strings or custom error shapes per endpoint
+  - ✅ Centralized exception middleware producing RFC 7807 `ProblemDetails`
+- Use record types for DTOs to decouple API contracts from EF entities
+- Register services with the correct lifetime (`Scoped` for DB contexts, `Singleton` for stateless)
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Architecture | Controller → Service → Repository |
+| Validation | Data Annotations + FluentValidation |
+| Error handling | Exception middleware + ProblemDetails |
+| DTOs | Record types for request/response |
+| DI | Built-in `IServiceCollection` |

--- a/skills/roles/backend-dotnet/testing/SKILL.md
+++ b/skills/roles/backend-dotnet/testing/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: backend-dotnet-testing
+description: >
+  Testing patterns for ASP.NET Core applications: xUnit, NSubstitute/Moq, integration tests, WebApplicationFactory.
+  Trigger: When writing tests, mocking dependencies, or setting up test infrastructure in C#/.NET.
+globs:
+  - "**/*Tests.cs"
+  - "**/*Test.cs"
+  - "**/*.Tests/**/*.cs"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Backend .NET — Testing
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Writing unit tests with xUnit + NSubstitute/Moq
+- Writing integration tests with `WebApplicationFactory`
+- Testing EF Core with in-memory provider or Testcontainers
+
+## Critical Patterns
+
+- Use `WebApplicationFactory<Program>` for integration tests, not manual host setup
+  - ❌ `new HttpClient()` pointing at a running server
+  - ✅ `factory.CreateClient()` with service overrides
+- Use FluentAssertions for readable assertions
+- One logical assertion per test method
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Unit tests | xUnit + NSubstitute (`Substitute.For<T>()`) |
+| Integration | `WebApplicationFactory<Program>` |
+| DB tests | EF Core InMemory or Testcontainers |
+| Assertions | FluentAssertions |

--- a/skills/roles/backend-java/api-design/SKILL.md
+++ b/skills/roles/backend-java/api-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: backend-java-api
+description: >
+  REST API design patterns with Spring Boot: controllers, services, repositories, validation, error handling.
+  Trigger: When creating endpoints, defining routes, implementing middleware, or handling HTTP errors in Java/Spring.
+globs:
+  - "**/*.java"
+  - "**/pom.xml"
+  - "**/build.gradle"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Backend Java — API Design
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Building REST APIs with Spring Boot
+- Designing controller/service/repository layers
+- Implementing validation, error handling, or middleware
+
+## Critical Patterns
+
+- Always return consistent error responses via `@ControllerAdvice`
+  - ❌ Throwing raw exceptions from controllers
+  - ✅ Centralized exception handler returning `ProblemDetail`
+- Use DTOs (record classes) to decouple API contracts from entities
+  - ❌ Exposing JPA entities directly in responses
+  - ✅ Mapping entities to response records via a mapper
+- Validate input at the controller boundary with `@Valid`
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Architecture | Controller → Service → Repository |
+| Validation | Jakarta Bean Validation (`@Valid`) |
+| Error handling | `@ControllerAdvice` + `@ExceptionHandler` |
+| DTOs | Record classes for request/response |

--- a/skills/roles/backend-java/testing/SKILL.md
+++ b/skills/roles/backend-java/testing/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: backend-java-testing
+description: >
+  Testing patterns for Spring Boot applications: JUnit 5, Mockito, integration tests, testcontainers.
+  Trigger: When writing tests, mocking dependencies, or setting up test infrastructure in Java/Spring.
+globs:
+  - "**/*Test.java"
+  - "**/*Tests.java"
+  - "**/test/**/*.java"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Backend Java — Testing
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Writing unit tests with JUnit 5 + Mockito
+- Writing integration tests with `@SpringBootTest`
+- Using Testcontainers for database/infra tests
+
+## Critical Patterns
+
+- Use `@MockBean` only in integration tests; prefer constructor injection with `@Mock` in unit tests
+  - ❌ `@MockBean` in every test class (slow Spring context reload)
+  - ✅ `@ExtendWith(MockitoExtension.class)` + `@Mock` for unit tests
+- Use AssertJ fluent assertions over JUnit assertions
+- One assertion concept per test method
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Unit tests | JUnit 5 + Mockito (`@Mock`, `@InjectMocks`) |
+| Integration | `@SpringBootTest` + `@AutoConfigureMockMvc` |
+| DB tests | Testcontainers or H2 in-memory |
+| Assertions | AssertJ fluent assertions |

--- a/skills/roles/data/pipelines/SKILL.md
+++ b/skills/roles/data/pipelines/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: data-pipelines
+description: >
+  Data pipeline and ML workflow patterns: pandas, scikit-learn, data validation, feature engineering, model training.
+  Trigger: When building data pipelines, transforming data, training models, or setting up ML workflows.
+globs:
+  - "**/*.py"
+  - "**/*.ipynb"
+  - "**/requirements.txt"
+  - "**/pyproject.toml"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Data — Pipelines & ML
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Building ETL / data transformation pipelines
+- Feature engineering and data validation
+- Training and evaluating ML models
+- Setting up reproducible experiments
+
+## Critical Patterns
+
+- Use method chaining with pandas for readable transformations
+  - ❌ Mutating DataFrames in-place across multiple statements
+  - ✅ `df.pipe(clean).pipe(transform).pipe(validate)` chaining
+- Validate data schemas at pipeline boundaries with pandera
+- Use scikit-learn `Pipeline` to prevent train/test leakage
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| DataFrames | pandas with method chaining |
+| Validation | pandera or Great Expectations |
+| ML pipeline | scikit-learn Pipeline + ColumnTransformer |
+| Experiments | MLflow or Weights & Biases |

--- a/skills/roles/data/testing/SKILL.md
+++ b/skills/roles/data/testing/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: data-testing
+description: >
+  Testing patterns for data and ML projects: pytest, data validation, model evaluation, pipeline testing.
+  Trigger: When writing tests for data transformations, model accuracy, or pipeline correctness.
+globs:
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/tests/**/*.py"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Data — Testing
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Testing data transformations and pipeline steps
+- Validating data schemas and quality
+- Testing model performance and regressions
+- Property-based testing for data functions
+
+## Critical Patterns
+
+- Use pytest fixtures for reusable sample DataFrames
+  - ❌ Recreating test data in every test function
+  - ✅ `@pytest.fixture` returning a canonical DataFrame
+- Assert model metrics against minimum thresholds, not exact values
+- Use pandera schema tests to validate pipeline output shapes
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Framework | pytest + pytest-cov |
+| Data validation | pandera schema tests |
+| Model testing | Assert metrics above thresholds |
+| Fixtures | pytest fixtures for sample DataFrames |

--- a/skills/roles/mobile/architecture/SKILL.md
+++ b/skills/roles/mobile/architecture/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: mobile-architecture
+description: >
+  Mobile app architecture patterns with React Native/Expo: navigation, state management, platform-specific code, performance.
+  Trigger: When building screens, setting up navigation, managing state, or optimizing mobile performance.
+globs:
+  - "**/*.tsx"
+  - "**/*.ts"
+  - "**/app.json"
+  - "**/app.config.ts"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Mobile — Architecture
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Building mobile apps with React Native / Expo
+- Setting up navigation (React Navigation / Expo Router)
+- Managing state in mobile contexts
+- Handling platform-specific code (iOS vs Android)
+
+## Critical Patterns
+
+- Use FlashList instead of FlatList for large lists
+  - ❌ `<FlatList>` with 1000+ items
+  - ✅ `<FlashList estimatedItemSize={50}>` for performant rendering
+- Separate platform-specific code with `.ios.ts` / `.android.ts` suffixes
+- Keep navigation configuration colocated with screen definitions
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Navigation | Expo Router (file-based) or React Navigation |
+| State | Zustand for client, TanStack Query for server |
+| Lists | FlashList over FlatList |
+| Styling | StyleSheet.create or NativeWind |

--- a/skills/roles/mobile/testing/SKILL.md
+++ b/skills/roles/mobile/testing/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: mobile-testing
+description: >
+  Testing patterns for React Native/Expo apps: Jest, React Native Testing Library, Detox E2E.
+  Trigger: When writing tests for mobile components, screens, navigation, or E2E flows.
+globs:
+  - "**/*.test.tsx"
+  - "**/*.test.ts"
+  - "**/*.spec.tsx"
+  - "**/*.spec.ts"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+# Mobile — Testing
+
+> Placeholder skill. Full content coming in a follow-up PR.
+
+## When to Use
+
+- Writing unit tests for components with RNTL
+- Testing navigation flows
+- Writing E2E tests with Detox or Maestro
+
+## Critical Patterns
+
+- Prefer behavioral tests over snapshot tests
+  - ❌ `expect(tree).toMatchSnapshot()` for component logic
+  - ✅ `expect(screen.getByText('Submit')).toBeTruthy()` for behavior
+- Mock native modules at the top of test files with `jest.mock()`
+- Test user interactions with `fireEvent` / `userEvent` from RNTL
+
+## Quick Reference
+
+| Topic | Pattern |
+|-------|---------|
+| Unit tests | Jest + React Native Testing Library |
+| Mocking | `jest.mock()` for native modules |
+| E2E | Detox or Maestro |
+| Snapshots | Avoid — prefer behavioral tests |

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -185,8 +185,32 @@ Describe 'Get-RoleSkillPaths' {
         $skills.Count | Should -Be 2  # api-design + testing
     }
 
-    It 'returns empty array for nonexistent role' {
+    It 'returns backend-java skills' {
+        $skills = Get-RoleSkillPaths -KitRoot $script:kitRoot -Role 'backend-java'
+        $skills | Should -Not -BeNullOrEmpty
+        $skills.Count | Should -Be 2  # api-design + testing
+    }
+
+    It 'returns backend-dotnet skills' {
+        $skills = Get-RoleSkillPaths -KitRoot $script:kitRoot -Role 'backend-dotnet'
+        $skills | Should -Not -BeNullOrEmpty
+        $skills.Count | Should -Be 2  # api-design + testing
+    }
+
+    It 'returns mobile skills' {
         $skills = Get-RoleSkillPaths -KitRoot $script:kitRoot -Role 'mobile'
+        $skills | Should -Not -BeNullOrEmpty
+        $skills.Count | Should -Be 2  # architecture + testing
+    }
+
+    It 'returns data skills' {
+        $skills = Get-RoleSkillPaths -KitRoot $script:kitRoot -Role 'data'
+        $skills | Should -Not -BeNullOrEmpty
+        $skills.Count | Should -Be 2  # pipelines + testing
+    }
+
+    It 'returns empty array for nonexistent role' {
+        $skills = Get-RoleSkillPaths -KitRoot $script:kitRoot -Role 'nonexistent'
         $skills | Should -BeNullOrEmpty
     }
 }
@@ -211,11 +235,31 @@ Describe 'Get-AllSkillPathsForRole' {
         $all = Get-AllSkillPathsForRole -KitRoot $script:kitRoot -Role 'python'
         $all.Count | Should -Be 7  # 5 shared + 2 python
     }
+
+    It 'combines shared + role skills for backend-java' {
+        $all = Get-AllSkillPathsForRole -KitRoot $script:kitRoot -Role 'backend-java'
+        $all.Count | Should -Be 7  # 5 shared + 2 backend-java
+    }
+
+    It 'combines shared + role skills for backend-dotnet' {
+        $all = Get-AllSkillPathsForRole -KitRoot $script:kitRoot -Role 'backend-dotnet'
+        $all.Count | Should -Be 7  # 5 shared + 2 backend-dotnet
+    }
+
+    It 'combines shared + role skills for mobile' {
+        $all = Get-AllSkillPathsForRole -KitRoot $script:kitRoot -Role 'mobile'
+        $all.Count | Should -Be 7  # 5 shared + 2 mobile
+    }
+
+    It 'combines shared + role skills for data' {
+        $all = Get-AllSkillPathsForRole -KitRoot $script:kitRoot -Role 'data'
+        $all.Count | Should -Be 7  # 5 shared + 2 data
+    }
 }
 
 Describe 'Get-PackRulesPath' {
     It 'returns path for existing role packs' {
-        foreach ($role in @('frontend', 'backend-node', 'devops', 'python')) {
+        foreach ($role in @('frontend', 'backend-node', 'backend-java', 'backend-dotnet', 'devops', 'python', 'mobile', 'data')) {
             $path = Get-PackRulesPath -KitRoot $script:kitRoot -Role $role
             $path | Should -Not -BeNullOrEmpty
             Test-Path $path | Should -BeTrue
@@ -223,7 +267,7 @@ Describe 'Get-PackRulesPath' {
     }
 
     It 'returns $null for nonexistent role' {
-        $path = Get-PackRulesPath -KitRoot $script:kitRoot -Role 'mobile'
+        $path = Get-PackRulesPath -KitRoot $script:kitRoot -Role 'nonexistent'
         $path | Should -BeNullOrEmpty
     }
 }

--- a/tests/skills.Tests.ps1
+++ b/tests/skills.Tests.ps1
@@ -14,7 +14,7 @@ BeforeAll {
 
     $script:allSkillFiles = @(Get-ChildItem -Path (Join-Path $script:kitRoot 'skills') -Filter '*.md' -Recurse)
     $script:sharedSkillFiles = @(Get-ChildItem -Path $script:sharedDir -Filter '*.md' -Recurse)
-    $script:roleNames = @('frontend', 'backend-node', 'devops', 'python')
+    $script:roleNames = @('frontend', 'backend-node', 'backend-java', 'backend-dotnet', 'devops', 'python', 'mobile', 'data')
 
     function Get-Frontmatter {
         <#
@@ -79,8 +79,8 @@ Describe 'Skill file inventory' {
         }
     }
 
-    It 'has 13 total skill files (5 shared + 8 role)' {
-        $script:allSkillFiles.Count | Should -Be 13
+    It 'has 21 total skill files (5 shared + 16 role)' {
+        $script:allSkillFiles.Count | Should -Be 21
     }
 }
 


### PR DESCRIPTION
## Summary

- Add 4 new roles (`backend-java`, `backend-dotnet`, `mobile`, `data`) to `VALID_ROLES` in both bash and PowerShell
- Create 8 placeholder SKILL.md files (2 per role) with proper frontmatter, metadata, and section structure
- Create 4 pack rules files with role-specific conventions
- Update interactive role selection menus (1-4 → 1-8) in both CLIs
- Update `ValidateSet` attributes, help text, and usage examples
- Add Pester tests for new role skill paths, combined skill counts, and pack rules
- Update skill inventory test counts (13 → 21 total skills)

## Test Results

- **skills.Tests.ps1**: 19/19 passing ✅
- **functions.Tests.ps1**: 223/223 passing ✅ (1 pre-existing skip)

## Files Changed

| Area | Files |
|------|-------|
| Core | `lib/functions.sh`, `lib/functions.ps1` |
| CLI | `bin/team-ai-kit`, `bin/team-ai-kit.ps1`, `setup.ps1` |
| Skills | 8 new `SKILL.md` files in `skills/roles/` |
| Packs | 4 new `rules.md` files in `packs/` |
| Tests | `tests/functions.Tests.ps1`, `tests/skills.Tests.ps1` |

Closes #120
