### PR TITLE
feat(skills): add Angular and Vue skills to frontend role

### DIFF
--- a/skills/roles/frontend/angular/SKILL.md
+++ b/skills/roles/frontend/angular/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: frontend-angular
+description: >
+  Angular development patterns: standalone components, signals, dependency injection, reactive forms, RxJS, routing.
+  Trigger: When building Angular components, services, forms, or configuring routing and state management.
+globs:
+  - "**/*.component.ts"
+  - "**/*.service.ts"
+  - "**/*.module.ts"
+  - "**/angular.json"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+## When to Use
+
+- Building Angular components, directives, or pipes with the standalone API (no NgModule).
+- Managing reactive state with Angular Signals (`signal()`, `computed()`, `linkedSignal()`, `effect()`).
+- Injecting services using the functional `inject()` API instead of constructor injection.
+- Creating or validating reactive forms with `FormBuilder`, typed `FormGroup`, and validators.
+- Configuring HTTP clients with functional interceptors via `provideHttpClient` and `withInterceptors`.
+- Setting up routing with `provideRouter`, lazy-loaded routes, and route guards.
+
+---
+
+## Critical Patterns
+
+### Pattern 1: Standalone Components (No NgModule)
+
+Modern Angular uses standalone components exclusively. Every component declares its own
+imports directly in the `@Component` decorator. Application bootstrap uses `bootstrapApplication`
+with provider functions instead of `NgModule`.
+
+```typescript
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptors, withFetch } from '@angular/common/http';
+import { routes } from './app.routes';
+import { authInterceptor } from './interceptors/auth.interceptor';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
+  ],
+};
+```
+
+```typescript
+// main.ts
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
+```
+
+```typescript
+// user-card.component.ts
+import { Component, input } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-user-card',
+  standalone: true,                        // explicit — default in Angular 19+
+  imports: [DatePipe, RouterLink],         // declare deps per component
+  template: `
+    <article>
+      <h3>{{ name() }}</h3>
+      <p>Joined: {{ joinedAt() | date:'mediumDate' }}</p>
+      <a [routerLink]="['/users', id()]">View profile</a>
+    </article>
+  `,
+})
+export class UserCardComponent {
+  id = input.required<string>();
+  name = input.required<string>();
+  joinedAt = input.required<Date>();
+}
+```
+
+> **Rule**: Never create an `NgModule` for new code. Use `imports` in `@Component` for
+> template dependencies and `providers` arrays in `app.config.ts` for application-wide services.
+
+---
+
+### Pattern 2: Signals for Reactive State
+
+Signals are Angular's primary reactivity primitive. Use `signal()` for writable state,
+`computed()` for derived read-only state, `linkedSignal()` for derived writable state,
+and `effect()` for side effects that react to signal changes.
+
+```typescript
+import { Component, signal, computed, effect, linkedSignal } from '@angular/core';
+
+@Component({
+  selector: 'app-counter',
+  standalone: true,
+  template: `
+    <p>Count: {{ count() }}</p>
+    <p>Double: {{ double() }}</p>
+    <button (click)="increment()">+1</button>
+    <button (click)="reset()">Reset</button>
+  `,
+})
+export class CounterComponent {
+  // Writable signal — source of truth
+  count = signal(0);
+
+  // Read-only derived signal — recalculates when count changes
+  double = computed(() => this.count() * 2);
+
+  // Linked signal — derived but writable, re-syncs when source changes
+  // Useful for "defaults that can be overridden"
+  label = linkedSignal(() => `Count is ${this.count()}`);
+
+  constructor() {
+    // Side effect — runs whenever referenced signals change
+    effect(() => {
+      console.log(`Count changed to ${this.count()}`);
+    });
+  }
+
+  increment(): void {
+    this.count.update((c) => c + 1);
+  }
+
+  reset(): void {
+    this.count.set(0);
+  }
+}
+```
+
+> **Rule**: Prefer `computed()` over `effect()` when deriving state. Use `effect()` only
+> for true side effects (logging, localStorage, API calls). Never mutate signals inside
+> `computed()`.
+
+---
+
+### Pattern 3: Dependency Injection with `inject()`
+
+The functional `inject()` API replaces constructor-based injection. It is more concise,
+works in any injection context, and enables better composition through helper functions.
+
+```typescript
+// auth.service.ts
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+  private router = inject(Router);
+
+  private currentUser = signal<User | null>(null);
+
+  isAuthenticated = computed(() => this.currentUser() !== null);
+  user = this.currentUser.asReadonly();
+
+  login(credentials: LoginPayload): void {
+    this.http.post<User>('/api/auth/login', credentials).subscribe({
+      next: (user) => this.currentUser.set(user),
+      error: (err) => console.error('Login failed', err),
+    });
+  }
+
+  logout(): void {
+    this.currentUser.set(null);
+    this.router.navigate(['/login']);
+  }
+}
+```
+
+```typescript
+// Composable injection functions — reusable across components
+import { inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs';
+
+export function injectRouteParam(param: string) {
+  return inject(ActivatedRoute).params.pipe(map((p) => p[param]));
+}
+
+// Usage in component
+export class UserDetailComponent {
+  userId$ = injectRouteParam('id');
+}
+```
+
+> **Rule**: Always use `inject()` over constructor injection. It enables extracting
+> injection logic into reusable functions, which constructor injection cannot do.
+
+---
+
+### Pattern 4: Reactive Forms with FormBuilder + Typed FormGroup
+
+Use `FormBuilder` with `inject()` to create strongly-typed reactive forms.
+Angular's typed forms (since v14) catch mismatches at compile time.
+
+```typescript
+import { Component, inject } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms';
+
+@Component({
+  selector: 'app-registration',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <label>
+        Email
+        <input formControlName="email" type="email" />
+      </label>
+      @if (form.controls.email.errors?.['email']) {
+        <span class="error">Invalid email</span>
+      }
+
+      <label>
+        Password
+        <input formControlName="password" type="password" />
+      </label>
+      @if (form.controls.password.errors?.['minlength']) {
+        <span class="error">Minimum 8 characters</span>
+      }
+
+      <fieldset formGroupName="profile">
+        <legend>Profile</legend>
+        <input formControlName="firstName" placeholder="First name" />
+        <input formControlName="lastName" placeholder="Last name" />
+      </fieldset>
+
+      <button type="submit" [disabled]="form.invalid">Register</button>
+    </form>
+  `,
+})
+export class RegistrationComponent {
+  private fb = inject(FormBuilder);
+
+  // Typed FormGroup — TS infers the shape from the builder
+  form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(8)]],
+    profile: this.fb.nonNullable.group({
+      firstName: ['', Validators.required],
+      lastName: ['', Validators.required],
+    }),
+  });
+
+  onSubmit(): void {
+    if (this.form.invalid) return;
+
+    // form.getRawValue() is fully typed:
+    // { email: string; password: string; profile: { firstName: string; lastName: string } }
+    const value = this.form.getRawValue();
+    console.log(value);
+  }
+}
+```
+
+> **Rule**: Always use `fb.nonNullable.group()` to get non-nullable typed controls.
+> Access errors via `form.controls.fieldName.errors` — the type system will guide you.
+
+---
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Using NgModule When Standalone Is Available
+
+NgModules add indirection and boilerplate. Every new component requires editing a
+module file, which creates coupling and slows development.
+
+```typescript
+// ❌ BAD — NgModule-based component
+@NgModule({
+  declarations: [DashboardComponent, WidgetComponent],
+  imports: [CommonModule, SharedModule, RouterModule.forChild(routes)],
+  exports: [DashboardComponent],
+})
+export class DashboardModule {}
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+})
+export class DashboardComponent {}
+```
+
+```typescript
+// ✅ GOOD — Standalone component, self-contained
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [WidgetComponent, RouterLink, DatePipe],
+  templateUrl: './dashboard.component.html',
+})
+export class DashboardComponent {}
+
+// Route config — no module needed
+export const dashboardRoutes: Routes = [
+  {
+    path: '',
+    component: DashboardComponent,
+  },
+  {
+    path: ':id',
+    loadComponent: () =>
+      import('./detail/detail.component').then((m) => m.DetailComponent),
+  },
+];
+```
+
+> Standalone components are the default since Angular 19. Modules exist only for
+> legacy compatibility.
+
+---
+
+### Anti-Pattern 2: Manual Subscriptions Without Cleanup
+
+Subscribing to observables without cleanup causes memory leaks. Components that
+manually call `.subscribe()` must ensure unsubscription on destroy.
+
+```typescript
+// ❌ BAD — subscription leaks when component is destroyed
+@Component({ /* ... */ })
+export class BadComponent {
+  private http = inject(HttpClient);
+
+  ngOnInit(): void {
+    this.http.get('/api/data').subscribe((data) => {
+      // This callback may fire AFTER the component is destroyed
+      this.processData(data);
+    });
+
+    interval(1000).subscribe(() => {
+      // This runs FOREVER — classic memory leak
+      this.tick();
+    });
+  }
+}
+```
+
+```typescript
+// ✅ GOOD — Option A: takeUntilDestroyed (for imperative subscriptions)
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, inject } from '@angular/core';
+
+@Component({ /* ... */ })
+export class GoodComponentA {
+  private http = inject(HttpClient);
+  private destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
+    this.http
+      .get('/api/data')
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data) => this.processData(data));
+
+    interval(1000)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.tick());
+  }
+}
+```
+
+```typescript
+// ✅ GOOD — Option B: async pipe (declarative, no manual subscription)
+import { AsyncPipe } from '@angular/common';
+
+@Component({
+  standalone: true,
+  imports: [AsyncPipe],
+  template: `
+    @if (data$ | async; as data) {
+      <app-widget [data]="data" />
+    }
+  `,
+})
+export class GoodComponentB {
+  private http = inject(HttpClient);
+  data$ = this.http.get<WidgetData>('/api/data');
+}
+```
+
+```typescript
+// ✅ GOOD — Option C: toSignal (convert observable to signal — best of both worlds)
+import { toSignal } from '@angular/core/rxjs-interop';
+
+@Component({
+  standalone: true,
+  template: `
+    @if (data(); as data) {
+      <app-widget [data]="data" />
+    }
+  `,
+})
+export class GoodComponentC {
+  private http = inject(HttpClient);
+  data = toSignal(this.http.get<WidgetData>('/api/data'));
+}
+```
+
+> **Preference order**: `toSignal()` > `async` pipe > `takeUntilDestroyed()`.
+> Use signals as the default. Fall back to RxJS only for complex async flows
+> (debounce, merge, switchMap).
+
+---
+
+## Quick Reference
+
+| Concept                  | Modern API                                            | Legacy (avoid)                     |
+| ------------------------ | ----------------------------------------------------- | ---------------------------------- |
+| Component declaration    | `standalone: true` + `imports` in `@Component`        | `NgModule` declarations            |
+| App bootstrap            | `bootstrapApplication(App, appConfig)`                | `platformBrowserDynamic().bootstrapModule()` |
+| Dependency injection     | `inject(Service)` function                            | `constructor(private svc: Service)` |
+| HTTP setup               | `provideHttpClient(withInterceptors([...]))`          | `HttpClientModule` import          |
+| Routing setup            | `provideRouter(routes)`                               | `RouterModule.forRoot(routes)`     |
+| Writable state           | `signal(initialValue)`                                | Component property + `ChangeDetectorRef` |
+| Derived state            | `computed(() => ...)`                                 | `get` accessor + manual change detection |
+| Derived writable state   | `linkedSignal(() => ...)`                             | No equivalent                      |
+| Side effects             | `effect(() => ...)`                                   | `ngOnChanges` / `ngDoCheck`        |
+| Observable to signal     | `toSignal(obs$)`                                      | Manual subscribe + signal.set      |
+| Signal to observable     | `toObservable(sig)`                                   | No equivalent                      |
+| Sub cleanup              | `takeUntilDestroyed(destroyRef)`                      | `Subject` + `takeUntil` + `ngOnDestroy` |
+| Template sub             | `async` pipe or `toSignal()`                          | Manual subscribe in `ngOnInit`     |
+| Forms                    | `fb.nonNullable.group({...})`                         | `new FormGroup({...})` untyped     |
+| Control flow             | `@if`, `@for`, `@switch`                              | `*ngIf`, `*ngFor`, `[ngSwitch]`   |
+| Lazy loading             | `loadComponent: () => import(...)`                    | `loadChildren` with module         |
+| Functional interceptor   | `(req, next) => next(req).pipe(...)`                  | Class-based `HttpInterceptor`      |
+| Functional guard         | `() => inject(Auth).isAuthenticated()`                | Class-based `CanActivate`          |

--- a/skills/roles/frontend/vue/SKILL.md
+++ b/skills/roles/frontend/vue/SKILL.md
@@ -1,0 +1,501 @@
+---
+name: frontend-vue
+description: >
+  Vue.js development patterns: Composition API, composables, Pinia state management, Vue Router, SFC patterns.
+  Trigger: When building Vue components, composables, stores, or configuring routing and state management.
+globs:
+  - "**/*.vue"
+  - "**/composables/*.ts"
+  - "**/stores/*.ts"
+  - "**/vite.config.ts"
+metadata:
+  author: team-ai-kit
+  version: "1.0"
+---
+
+## When to Use
+
+- Building Vue 3 Single File Components (SFCs) with `<script setup>` syntax
+- Creating reusable composables (`useXxx`) to extract and share stateful logic
+- Setting up Pinia stores for global state management with the setup (composition) syntax
+- Configuring Vue Router with typed routes, navigation guards, and lazy-loaded views
+- Wiring up `defineProps`, `defineEmits`, `provide`/`inject` for component communication
+- Working with reactivity primitives: `ref`, `reactive`, `computed`, `watch`, `watchEffect`
+
+---
+
+## Critical Patterns
+
+### Pattern 1: Composition API with `<script setup>`
+
+Use `<script setup>` for all new components. It removes boilerplate, enables automatic
+component/directive registration, and provides compile-time optimizations.
+
+**Reactivity primitives**
+
+```vue
+<script setup lang="ts">
+import { ref, reactive, computed, watch } from 'vue'
+
+// --- Refs for primitive/single values ---
+const count = ref(0)
+const label = ref('Clicks')
+
+// --- Reactive for object state ---
+const form = reactive({
+  name: '',
+  email: '',
+})
+
+// --- Computed (cached, auto-tracked) ---
+const displayLabel = computed(() => `${label.value}: ${count.value}`)
+
+// --- Watch a single ref ---
+watch(count, (newVal, oldVal) => {
+  console.log(`count changed: ${oldVal} -> ${newVal}`)
+})
+
+// --- Watch multiple sources ---
+watch([count, label], ([newCount, newLabel]) => {
+  console.log(newCount, newLabel)
+})
+
+function increment() {
+  count.value++
+}
+</script>
+
+<template>
+  <button @click="increment">{{ displayLabel }}</button>
+</template>
+```
+
+**Props and Emits (typed)**
+
+```vue
+<script setup lang="ts">
+// --- Typed props with defaults ---
+const props = withDefaults(
+  defineProps<{
+    title: string
+    count?: number
+    variant?: 'primary' | 'secondary'
+  }>(),
+  {
+    count: 0,
+    variant: 'primary',
+  },
+)
+
+// --- Typed emits ---
+const emit = defineEmits<{
+  (e: 'update', value: number): void
+  (e: 'close'): void
+}>()
+
+function handleClick() {
+  emit('update', props.count + 1)
+}
+</script>
+
+<template>
+  <div :class="variant">
+    <h2>{{ title }}</h2>
+    <button @click="handleClick">Count: {{ count }}</button>
+  </div>
+</template>
+```
+
+**Provide / Inject (typed)**
+
+```typescript
+// keys.ts — shared injection key with type safety
+import type { InjectionKey, Ref } from 'vue'
+
+export const ThemeKey: InjectionKey<Ref<'light' | 'dark'>> = Symbol('theme')
+```
+
+```vue
+<!-- Provider.vue -->
+<script setup lang="ts">
+import { provide, ref } from 'vue'
+import { ThemeKey } from './keys'
+
+const theme = ref<'light' | 'dark'>('light')
+provide(ThemeKey, theme)
+</script>
+```
+
+```vue
+<!-- Consumer.vue -->
+<script setup lang="ts">
+import { inject } from 'vue'
+import { ThemeKey } from './keys'
+
+const theme = inject(ThemeKey) // Ref<'light' | 'dark'> | undefined
+</script>
+
+<template>
+  <div :class="theme">Themed content</div>
+</template>
+```
+
+---
+
+### Pattern 2: Composables for Reusable Logic
+
+Composables are functions prefixed with `use` that encapsulate reactive state and logic.
+They return refs, computed values, and methods — never raw mutable objects.
+
+```typescript
+// composables/useFetch.ts
+import { ref, shallowRef, type Ref } from 'vue'
+
+interface UseFetchReturn<T> {
+  data: Ref<T | null>
+  error: Ref<string | null>
+  isLoading: Ref<boolean>
+  execute: () => Promise<void>
+}
+
+export function useFetch<T>(url: string | Ref<string>): UseFetchReturn<T> {
+  const data = shallowRef<T | null>(null)
+  const error = ref<string | null>(null)
+  const isLoading = ref(false)
+
+  async function execute() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const resolvedUrl = typeof url === 'string' ? url : url.value
+      const response = await fetch(resolvedUrl)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      data.value = await response.json()
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Unknown error'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  execute()
+  return { data, error, isLoading, execute }
+}
+```
+
+```vue
+<!-- Usage in component -->
+<script setup lang="ts">
+import { useFetch } from '@/composables/useFetch'
+
+interface User {
+  id: number
+  name: string
+}
+
+const { data: users, isLoading, error } = useFetch<User[]>('/api/users')
+</script>
+
+<template>
+  <p v-if="isLoading">Loading...</p>
+  <p v-else-if="error">{{ error }}</p>
+  <ul v-else>
+    <li v-for="user in users" :key="user.id">{{ user.name }}</li>
+  </ul>
+</template>
+```
+
+**Composable rules:**
+- Always prefix with `use`
+- Return explicit refs and functions — never mutate external state directly
+- Accept both raw values and refs as inputs (`MaybeRef<T>` pattern)
+- Keep composables pure: no side effects in the function body except lifecycle hooks
+- Use `shallowRef` for large non-primitive data that does not need deep reactivity
+
+---
+
+### Pattern 3: Pinia Stores with Setup Syntax
+
+Use the **setup function** syntax for Pinia stores. It mirrors the Composition API directly:
+`ref()` = state, `computed()` = getters, plain functions = actions.
+
+```typescript
+// stores/useAuthStore.ts
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+
+interface User {
+  id: string
+  email: string
+  role: 'admin' | 'user'
+}
+
+export const useAuthStore = defineStore('auth', () => {
+  // --- State (ref) ---
+  const user = ref<User | null>(null)
+  const token = ref<string | null>(null)
+
+  // --- Getters (computed) ---
+  const isAuthenticated = computed(() => !!token.value)
+  const isAdmin = computed(() => user.value?.role === 'admin')
+
+  // --- Actions (functions) ---
+  async function login(email: string, password: string) {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    if (!res.ok) throw new Error('Login failed')
+    const data = await res.json()
+    user.value = data.user
+    token.value = data.token
+  }
+
+  function logout() {
+    user.value = null
+    token.value = null
+  }
+
+  return { user, token, isAuthenticated, isAdmin, login, logout }
+})
+```
+
+```vue
+<!-- Usage in component -->
+<script setup lang="ts">
+import { useAuthStore } from '@/stores/useAuthStore'
+import { storeToRefs } from 'pinia'
+
+const authStore = useAuthStore()
+
+// Use storeToRefs to keep reactivity when destructuring state/getters
+const { user, isAuthenticated } = storeToRefs(authStore)
+
+// Actions can be destructured directly (they are plain functions)
+const { login, logout } = authStore
+</script>
+
+<template>
+  <div v-if="isAuthenticated">
+    <p>Welcome, {{ user?.email }}</p>
+    <button @click="logout">Logout</button>
+  </div>
+  <button v-else @click="login('test@example.com', 'pass')">Login</button>
+</template>
+```
+
+**Store rules:**
+- One store per domain concern (auth, cart, ui)
+- Always use `storeToRefs()` when destructuring state or getters — direct destructuring loses reactivity
+- Actions are plain functions; destructure them directly from the store instance
+- Return ALL state from the setup function — Pinia cannot detect unreturned refs
+
+---
+
+### Pattern 4: Vue Router with Typed Routes and Navigation Guards
+
+```typescript
+// router/index.ts
+import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
+import { useAuthStore } from '@/stores/useAuthStore'
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    name: 'Home',
+    component: () => import('@/views/HomeView.vue'),
+  },
+  {
+    path: '/dashboard',
+    name: 'Dashboard',
+    component: () => import('@/views/DashboardView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
+    path: '/login',
+    name: 'Login',
+    component: () => import('@/views/LoginView.vue'),
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    name: 'NotFound',
+    component: () => import('@/views/NotFoundView.vue'),
+  },
+]
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes,
+})
+
+// Global navigation guard
+router.beforeEach((to) => {
+  const auth = useAuthStore()
+
+  if (to.meta.requiresAuth && !auth.isAuthenticated) {
+    return { name: 'Login', query: { redirect: to.fullPath } }
+  }
+})
+
+export default router
+```
+
+**Augment route meta types globally:**
+
+```typescript
+// router/types.ts
+import 'vue-router'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    requiresAuth?: boolean
+    roles?: Array<'admin' | 'user'>
+  }
+}
+```
+
+**Using router in components:**
+
+```vue
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+
+// Access typed params and query
+const id = route.params.id as string
+
+async function goToDashboard() {
+  await router.push({ name: 'Dashboard' })
+}
+</script>
+```
+
+**Per-route guard with `beforeEnter`:**
+
+```typescript
+{
+  path: '/admin',
+  name: 'Admin',
+  component: () => import('@/views/AdminView.vue'),
+  meta: { requiresAuth: true, roles: ['admin'] },
+  beforeEnter: (to) => {
+    const auth = useAuthStore()
+    if (!auth.isAdmin) return { name: 'Home' }
+  },
+}
+```
+
+---
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Options API in New Code
+
+The Options API (`data`, `methods`, `computed` object syntax) fragments related logic
+across multiple sections, making large components hard to follow and refactor.
+
+```vue
+<!-- ❌ BAD: Options API scatters related logic -->
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  data() {
+    return { count: 0, label: 'Clicks' }
+  },
+  computed: {
+    display(): string {
+      return `${this.label}: ${this.count}`
+    },
+  },
+  methods: {
+    increment() {
+      this.count++
+    },
+  },
+})
+</script>
+```
+
+```vue
+<!-- ✅ GOOD: Composition API groups logic by concern -->
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+const count = ref(0)
+const label = ref('Clicks')
+const display = computed(() => `${label.value}: ${count.value}`)
+
+function increment() {
+  count.value++
+}
+</script>
+```
+
+**Why:** `<script setup>` + Composition API co-locates related state and logic, enables
+full TypeScript inference without type gymnastics, and produces smaller compiled output.
+
+---
+
+### Anti-Pattern 2: Vuex in New Projects
+
+Vuex requires verbose mutations/actions/getters boilerplate, has weak TypeScript support,
+and does not align with the Composition API.
+
+```typescript
+// ❌ BAD: Vuex store — mutations, string-based commits, no type safety
+const store = createStore({
+  state: () => ({ count: 0 }),
+  mutations: {
+    INCREMENT(state) {
+      state.count++
+    },
+  },
+  actions: {
+    increment({ commit }) {
+      commit('INCREMENT') // string key, no type check
+    },
+  },
+})
+```
+
+```typescript
+// ✅ GOOD: Pinia setup store — typed, minimal, Composition API native
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0)
+  function increment() {
+    count.value++
+  }
+  return { count, increment }
+})
+```
+
+**Why:** Pinia is the official Vue state management library (replacing Vuex). It has
+first-class TypeScript support, no mutations concept, smaller bundle size, and uses
+the same `ref`/`computed` patterns as your components.
+
+---
+
+## Quick Reference
+
+| Concept            | API / Pattern                              | Notes                                             |
+| ------------------ | ------------------------------------------ | ------------------------------------------------- |
+| Component state    | `ref()`, `reactive()`                      | `ref` for primitives, `reactive` for objects       |
+| Derived state      | `computed(() => ...)`                      | Cached, auto-tracked dependencies                  |
+| Side effects       | `watch()`, `watchEffect()`                 | `watch` = explicit source; `watchEffect` = auto    |
+| Props              | `defineProps<T>()`                         | Compile-time macro, no import needed               |
+| Emits              | `defineEmits<T>()`                         | Type-safe event declarations                       |
+| Dependency inject  | `provide(key, val)` / `inject(key)`        | Use typed `InjectionKey<T>` for safety             |
+| Composable         | `function useXxx(): { refs, methods }`     | Return refs + functions, accept `MaybeRef` inputs  |
+| Pinia store        | `defineStore('id', () => { ... })`         | Setup syntax; return all state                     |
+| Store destructure  | `storeToRefs(store)`                       | Keeps reactivity on state/getters                  |
+| Router access      | `useRoute()`, `useRouter()`                | Composables for route/router in `<script setup>`   |
+| Route guard        | `router.beforeEach((to, from) => ...)`     | Return `false`, route object, or `undefined`       |
+| Lazy routes        | `component: () => import('...')`           | Code-split views automatically                     |
+| Route meta typing  | `declare module 'vue-router' { ... }`      | Augment `RouteMeta` interface globally             |

--- a/tests/e2e-bash.sh
+++ b/tests/e2e-bash.sh
@@ -49,10 +49,10 @@ fi
 echo "--- Test 3: skills installed ---"
 if [ -d "$TEST_DIR/team-skills" ]; then
     skill_count=$(find "$TEST_DIR/team-skills" -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
-    if [ "$skill_count" = "7" ]; then
-        pass "7 skills installed"
+    if [ "$skill_count" = "9" ]; then
+        pass "9 skills installed"
     else
-        fail "expected 7 skills, got $skill_count"
+        fail "expected 9 skills, got $skill_count"
         find "$TEST_DIR/team-skills" -name '*.md' -type f 2>/dev/null
     fi
 else
@@ -80,8 +80,8 @@ echo "--- Test 5: manifest ---"
 if [ -f "$HOME/.team-ai-kit/manifest.json" ]; then
     pass "manifest.json exists"
     mcount=$(jq '.files | length' "$HOME/.team-ai-kit/manifest.json" 2>/dev/null) || mcount="error"
-    if [ "$mcount" = "7" ]; then
-        pass "manifest tracks 7 files"
+    if [ "$mcount" = "9" ]; then
+        pass "manifest tracks 9 files"
     else
         fail "manifest tracks $mcount files"
         jq '.files | keys' "$HOME/.team-ai-kit/manifest.json" 2>/dev/null || true

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -164,7 +164,7 @@ Describe 'Get-RoleSkillPaths' {
     It 'returns frontend skills' {
         $skills = Get-RoleSkillPaths -KitRoot $script:kitRoot -Role 'frontend'
         $skills | Should -Not -BeNullOrEmpty
-        $skills.Count | Should -Be 2  # react + nextjs
+        $skills.Count | Should -Be 4  # react + nextjs + angular + vue
     }
 
     It 'returns backend-node skills' {
@@ -218,7 +218,7 @@ Describe 'Get-RoleSkillPaths' {
 Describe 'Get-AllSkillPathsForRole' {
     It 'combines shared + role skills for frontend' {
         $all = Get-AllSkillPathsForRole -KitRoot $script:kitRoot -Role 'frontend'
-        $all.Count | Should -Be 7  # 5 shared + 2 frontend
+        $all.Count | Should -Be 9  # 5 shared + 4 frontend
     }
 
     It 'combines shared + role skills for backend-node' {
@@ -1849,7 +1849,7 @@ Describe 'Install-SkillsWithMerge' {
         $env:USERPROFILE = $script:mergeTestProfile
         try {
             $results = Install-SkillsWithMerge -KitRoot $script:kitRoot -Role 'frontend' -TargetDir $script:mergeTestDir
-            $results.installed.Count | Should -Be 7  # 5 shared + 2 frontend
+            $results.installed.Count | Should -Be 9  # 5 shared + 4 frontend
             $results.updated.Count | Should -Be 0
             $results.skipped.Count | Should -Be 0
         }
@@ -1863,7 +1863,7 @@ Describe 'Install-SkillsWithMerge' {
         $env:USERPROFILE = $script:mergeTestProfile
         try {
             $manifest = Get-SkillManifest
-            $manifest.files.Count | Should -Be 7
+            $manifest.files.Count | Should -Be 9
             # All should be source=default
             $manifest.files.Values | ForEach-Object { $_.source | Should -Be 'default' }
         }
@@ -1879,7 +1879,7 @@ Describe 'Install-SkillsWithMerge' {
             $results = Install-SkillsWithMerge -KitRoot $script:kitRoot -Role 'frontend' -TargetDir $script:mergeTestDir
             $results.installed.Count | Should -Be 0
             $results.updated.Count | Should -Be 0
-            $results.skipped.Count | Should -Be 7
+            $results.skipped.Count | Should -Be 9
         }
         finally {
             $env:USERPROFILE = $originalProfile
@@ -1895,7 +1895,7 @@ Describe 'Install-SkillsWithMerge' {
             Set-Content -Path $archSkill -Value '# User customized this skill'
 
             $results = Install-SkillsWithMerge -KitRoot $script:kitRoot -Role 'frontend' -TargetDir $script:mergeTestDir
-            $results.skipped.Count | Should -Be 7  # all skipped, including modified one
+            $results.skipped.Count | Should -Be 9  # all skipped, including modified one
 
             # Verify content was NOT overwritten
             $content = Get-Content $archSkill -Raw

--- a/tests/skills.Tests.ps1
+++ b/tests/skills.Tests.ps1
@@ -71,16 +71,16 @@ Describe 'Skill file inventory' {
         }
     }
 
-    It 'has 2 skills per role' {
+    It 'has at least 2 skills per role' {
         foreach ($role in $script:roleNames) {
             $roleDir = Join-Path $script:rolesDir $role
             $files = @(Get-ChildItem -Path $roleDir -Filter '*.md' -Recurse -ErrorAction SilentlyContinue)
-            $files.Count | Should -Be 2 -Because "role '$role' should have exactly 2 skills"
+            $files.Count | Should -BeGreaterOrEqual 2 -Because "role '$role' should have at least 2 skills"
         }
     }
 
-    It 'has 21 total skill files (5 shared + 16 role)' {
-        $script:allSkillFiles.Count | Should -Be 21
+    It 'has 23 total skill files (5 shared + 18 role)' {
+        $script:allSkillFiles.Count | Should -Be 23
     }
 }
 


### PR DESCRIPTION
## Summary

- Add 2 new skills to the frontend role: **Angular** and **Vue**
- Frontend role expanded from 2 skills (React + Next.js) to 4 skills
- Both skills follow the established format with ❌/✅ code examples, sourced from official docs via Context7

## Skills Added

| Skill | Lines | Key Topics |
|-------|-------|------------|
| angular | ~430 | Standalone components, signals (`signal/computed/effect`), `inject()` DI, reactive forms, `takeUntilDestroyed` |
| vue | ~400 | Composition API `<script setup>`, composables (`useXxx`), Pinia setup stores, Vue Router typed routes |

## Test Updates

- Total skill count: 21 → 23
- Frontend role skills: 2 → 4
- Install/manifest counts: 7 → 9
- **skills.Tests.ps1**: 19/19 ✅
- **functions.Tests.ps1**: 223/223 ✅ (1 pre-existing skip)

Closes #124
