### PR TITLE
feat(skills): translate and improve all 13 existing skills to English

### DIFF
--- a/skills/roles/backend-node/api-design/SKILL.md
+++ b/skills/roles/backend-node/api-design/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: backend-node-api
 description: >
-  Patrones de diseño de APIs REST con Node.js/Express/Fastify: rutas, controllers, middleware, validación.
-  Trigger: Al crear endpoints, definir rutas, implementar middleware, manejar errores HTTP.
+  Node.js REST API design patterns: routes, controllers, middleware, validation, error handling with Express and Fastify.
+  Trigger: When creating endpoints, defining routes, implementing middleware, or handling HTTP errors.
+globs:
+  - "**/*.controller.ts"
+  - "**/*.route.ts"
+  - "**/*.router.ts"
+  - "**/*.middleware.ts"
+  - "**/routes/**"
+  - "**/controllers/**"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,21 +17,25 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Creas o modificas endpoints REST
-- Implementas middleware (auth, logging, error handling)
-- Diseñas la estructura de controllers y routes
-- Manejas validación de request/response
+- Creating or modifying REST endpoints
+- Implementing middleware (auth, logging, rate limiting, error handling)
+- Designing the structure of controllers and routes
+- Handling request/response validation
+- Setting up API versioning or pagination
+- Configuring CORS or security headers
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Controller delgado — lógica en services
+### Pattern 1: Thin Controllers — Logic Lives in Services
+
+Controllers parse the request, delegate to a service, and send the response. Nothing else.
 
 ```typescript
-// ❌ MAL — controller hace todo
+// ❌ BAD — controller does everything
 router.post('/users', async (req, res) => {
     const { email, password } = req.body
     const existing = await db.users.findByEmail(email)
@@ -35,32 +46,35 @@ router.post('/users', async (req, res) => {
     res.status(201).json({ user, token })
 })
 
-// ✅ BIEN — controller delega a service
-router.post('/users', async (req, res, next) => {
-    try {
-        const dto = CreateUserSchema.parse(req.body)
-        const result = await userService.register(dto)
+// ✅ GOOD — controller delegates to service
+router.post(
+    '/users',
+    validate(CreateUserSchema),
+    asyncHandler(async (req, res) => {
+        const result = await userService.register(req.body)
         res.status(201).json(result)
-    } catch (error) {
-        next(error)
-    }
-})
+    }),
+)
 ```
 
-### Pattern 2: Validación en el borde con Zod
+### Pattern 2: Edge Validation with Zod
+
+Validate at the boundary. Never trust incoming data past the middleware layer.
 
 ```typescript
 import { z } from 'zod'
+import type { Request, Response, NextFunction } from 'express'
 
+// --- Schema definition ---
 export const CreateUserSchema = z.object({
     email: z.string().email(),
-    password: z.string().min(8),
+    password: z.string().min(8).max(128),
     name: z.string().min(2).max(100),
 })
 
 export type CreateUserDto = z.infer<typeof CreateUserSchema>
 
-// Middleware de validación reutilizable
+// --- Reusable validation middleware ---
 export function validate<T>(schema: z.ZodSchema<T>) {
     return (req: Request, _res: Response, next: NextFunction) => {
         try {
@@ -71,9 +85,36 @@ export function validate<T>(schema: z.ZodSchema<T>) {
         }
     }
 }
+
+// --- Validate query params separately ---
+export function validateQuery<T>(schema: z.ZodSchema<T>) {
+    return (req: Request, _res: Response, next: NextFunction) => {
+        try {
+            req.query = schema.parse(req.query) as any
+            next()
+        } catch (error) {
+            next(error)
+        }
+    }
+}
 ```
 
-### Pattern 3: Error handling centralizado
+```typescript
+// ❌ BAD — manual validation scattered in handler
+router.post('/users', async (req, res) => {
+    if (!req.body.email) return res.status(400).json({ error: 'Email required' })
+    if (!req.body.email.includes('@')) return res.status(400).json({ error: 'Invalid email' })
+    if (!req.body.password || req.body.password.length < 8) return res.status(400).json({ error: 'Password too short' })
+    // ... handler logic
+})
+
+// ✅ GOOD — declarative schema, single middleware
+router.post('/users', validate(CreateUserSchema), asyncHandler(userController.create))
+```
+
+### Pattern 3: Centralized Error Handling
+
+Define domain errors as classes. Handle them in ONE place.
 
 ```typescript
 // errors/domain-errors.ts
@@ -100,7 +141,15 @@ export class ConflictError extends AppError {
     }
 }
 
+export class ForbiddenError extends AppError {
+    constructor(message = 'Insufficient permissions') {
+        super(message, 403, 'FORBIDDEN')
+    }
+}
+
 // middleware/error-handler.ts
+import { ZodError } from 'zod'
+
 export function errorHandler(err: Error, _req: Request, res: Response, _next: NextFunction) {
     if (err instanceof AppError) {
         return res.status(err.statusCode).json({
@@ -112,12 +161,17 @@ export function errorHandler(err: Error, _req: Request, res: Response, _next: Ne
             error: { code: 'VALIDATION_ERROR', details: err.errors },
         })
     }
+    // Never leak internal errors to the client
     console.error('Unhandled error:', err)
-    res.status(500).json({ error: { code: 'INTERNAL', message: 'Internal server error' } })
+    res.status(500).json({
+        error: { code: 'INTERNAL', message: 'Internal server error' },
+    })
 }
 ```
 
-### Pattern 4: Repository abstrae la DB
+### Pattern 4: Repository Abstracts the Database
+
+Services depend on an interface, not a concrete ORM. This enables testing and swapping storage.
 
 ```typescript
 // contracts/user.repository.ts
@@ -126,6 +180,7 @@ export interface UserRepository {
     findByEmail(email: string): Promise<User | null>
     create(data: CreateUserDto): Promise<User>
     update(id: string, data: Partial<User>): Promise<User>
+    delete(id: string): Promise<void>
 }
 
 // repositories/prisma-user.repository.ts
@@ -135,55 +190,258 @@ export class PrismaUserRepository implements UserRepository {
     async findById(id: string): Promise<User | null> {
         return this.prisma.user.findUnique({ where: { id } })
     }
+
+    async create(data: CreateUserDto): Promise<User> {
+        return this.prisma.user.create({ data })
+    }
     // ...
 }
 ```
 
----
+### Pattern 5: Response Envelope
 
-## Anti-Patterns
-
-### Don't: SQL crudo en services
+Wrap all API responses in a consistent structure. Clients should never guess the shape.
 
 ```typescript
-// ❌ MAL
-async function getUser(id: string) {
-    return db.query('SELECT * FROM users WHERE id = $1', [id])
+// ❌ BAD — inconsistent response shapes
+res.json(user)                           // GET returns raw object
+res.json({ users, total })               // LIST returns different shape
+res.json({ error: 'Not found' })         // Error is a plain string
+
+// ✅ GOOD — consistent envelope
+interface ApiResponse<T> {
+    data: T
+    meta?: { page: number; pageSize: number; total: number }
 }
 
-// ✅ BIEN — a través del repository
-async function getUser(id: string) {
-    return userRepository.findById(id)
+interface ApiError {
+    error: { code: string; message: string; details?: unknown }
+}
+
+// Helper functions
+function success<T>(res: Response, data: T, status = 200) {
+    return res.status(status).json({ data })
+}
+
+function paginated<T>(res: Response, data: T[], meta: PaginationMeta) {
+    return res.json({ data, meta })
 }
 ```
 
-### Don't: Try/catch en cada función
+### Pattern 6: Middleware Composition
+
+Compose middleware as arrays for readability and reuse.
 
 ```typescript
-// ❌ MAL — try/catch repetido en cada handler
-router.get('/users/:id', async (req, res) => {
-    try { ... } catch (error) { res.status(500).json({ error }) }
+// ❌ BAD — long chains of inline middleware
+router.post('/admin/users', authenticateToken, requireRole('admin'), rateLimit(10), validate(CreateUserSchema), handler)
+
+// ✅ GOOD — named compositions
+const adminOnly = [authenticateToken, requireRole('admin')]
+const withRateLimit = (max: number) => [authenticateToken, rateLimit({ windowMs: 60_000, max })]
+
+router.post('/admin/users', ...adminOnly, validate(CreateUserSchema), asyncHandler(userController.create))
+router.get('/search', ...withRateLimit(30), asyncHandler(searchController.query))
+```
+
+### Pattern 7: Async Handler Wrapper
+
+Eliminate repetitive try/catch in every route handler.
+
+```typescript
+// ❌ BAD — try/catch repeated in every handler
+router.get('/users/:id', async (req, res, next) => {
+    try {
+        const user = await userService.getById(req.params.id)
+        res.json({ data: user })
+    } catch (error) {
+        next(error)
+    }
 })
 
-// ✅ BIEN — wrapper o middleware centralizado
+// ✅ GOOD — wrapper catches and forwards to error middleware
 const asyncHandler = (fn: RequestHandler) =>
     (req: Request, res: Response, next: NextFunction) =>
         Promise.resolve(fn(req, res, next)).catch(next)
 
 router.get('/users/:id', asyncHandler(async (req, res) => {
     const user = await userService.getById(req.params.id)
-    res.json(user)
+    res.json({ data: user })
 }))
+```
+
+### Pattern 8: Pagination
+
+Always paginate list endpoints. Never return unbounded collections.
+
+```typescript
+const PaginationSchema = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(100).default(20),
+})
+
+router.get(
+    '/users',
+    validateQuery(PaginationSchema),
+    asyncHandler(async (req, res) => {
+        const { page, pageSize } = req.query as z.infer<typeof PaginationSchema>
+        const { items, total } = await userService.list({ page, pageSize })
+        res.json({
+            data: items,
+            meta: { page, pageSize, total, totalPages: Math.ceil(total / pageSize) },
+        })
+    }),
+)
+```
+
+### Pattern 9: API Versioning
+
+Prefix routes by version. Keep old versions working until clients migrate.
+
+```typescript
+// ❌ BAD — no versioning, breaking changes affect everyone
+app.use('/api/users', userRoutes)
+
+// ✅ GOOD — versioned routes
+import { userRoutesV1 } from './v1/user.routes'
+import { userRoutesV2 } from './v2/user.routes'
+
+app.use('/api/v1/users', userRoutesV1)
+app.use('/api/v2/users', userRoutesV2)
+
+// Version via header (alternative approach)
+function apiVersion(version: string) {
+    return (req: Request, res: Response, next: NextFunction) => {
+        if (req.headers['api-version'] !== version) return next('route')
+        next()
+    }
+}
+```
+
+### Pattern 10: Rate Limiting
+
+Protect endpoints from abuse. Apply different limits by route sensitivity.
+
+```typescript
+import rateLimit from 'express-rate-limit'
+
+// Global limiter — generous
+const globalLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 500,
+    standardHeaders: true,
+    legacyHeaders: false,
+})
+
+// Auth limiter — strict
+const authLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 10,
+    message: { error: { code: 'RATE_LIMITED', message: 'Too many attempts, try again later' } },
+})
+
+app.use('/api', globalLimiter)
+app.use('/api/auth/login', authLimiter)
+app.use('/api/auth/register', authLimiter)
+```
+
+### Pattern 11: CORS Configuration
+
+Be explicit about allowed origins. Never use `*` in production.
+
+```typescript
+import cors from 'cors'
+
+// ❌ BAD — allows everything
+app.use(cors())
+
+// ✅ GOOD — explicit allow-list
+const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') ?? []
+
+app.use(cors({
+    origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+            callback(null, true)
+        } else {
+            callback(new Error('Not allowed by CORS'))
+        }
+    },
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+    credentials: true,
+    maxAge: 86400, // preflight cache 24h
+}))
+```
+
+---
+
+## Anti-Patterns
+
+### Don't: Raw SQL in Services
+
+```typescript
+// ❌ BAD — service coupled to raw SQL
+async function getUser(id: string) {
+    return db.query('SELECT * FROM users WHERE id = $1', [id])
+}
+
+// ✅ GOOD — through the repository
+async function getUser(id: string) {
+    return userRepository.findById(id)
+}
+```
+
+### Don't: Leaking Internal State in Responses
+
+```typescript
+// ❌ BAD — exposes password hash and internal fields
+res.json(user)
+
+// ✅ GOOD — explicit response shape
+const { password, internalNotes, ...safeUser } = user
+res.json({ data: safeUser })
+
+// ✅ BETTER — DTO/serializer function
+function toUserResponse(user: User): UserResponse {
+    return { id: user.id, email: user.email, name: user.name, createdAt: user.createdAt }
+}
+res.json({ data: toUserResponse(user) })
+```
+
+### Don't: God Router Files
+
+```typescript
+// ❌ BAD — one file with 50+ routes
+// routes/index.ts with ALL endpoints
+
+// ✅ GOOD — split by domain
+// routes/user.routes.ts
+// routes/product.routes.ts
+// routes/order.routes.ts
+app.use('/api/v1/users', userRoutes)
+app.use('/api/v1/products', productRoutes)
+app.use('/api/v1/orders', orderRoutes)
 ```
 
 ---
 
 ## Quick Reference
 
-| Capa          | Responsabilidad                          |
-| ------------- | ---------------------------------------- |
-| Routes        | Definir paths y métodos HTTP             |
-| Controllers   | Parsear request, delegar, enviar response |
-| Services      | Lógica de negocio                        |
-| Repositories  | Acceso a datos                           |
-| Middleware     | Cross-cutting concerns (auth, logging)   |
+| Layer        | Responsibility                                    |
+| ------------ | ------------------------------------------------- |
+| Routes       | Define paths, HTTP methods, attach middleware      |
+| Controllers  | Parse request, delegate to service, send response  |
+| Services     | Business logic, orchestration                      |
+| Repositories | Data access, query building                        |
+| Middleware   | Cross-cutting concerns (auth, logging, validation) |
+| Schemas      | Request/response validation with Zod               |
+| Errors       | Domain error classes, centralized handler           |
+
+| Concern       | Pattern                          |
+| ------------- | -------------------------------- |
+| Validation    | Zod schemas + `validate()` middleware |
+| Error handling| `AppError` subclasses + `errorHandler` middleware |
+| Async safety  | `asyncHandler` wrapper           |
+| Pagination    | Query params with Zod + `meta` envelope |
+| Rate limiting | `express-rate-limit` per-route   |
+| CORS          | Explicit origin allow-list       |
+| Versioning    | URL prefix (`/api/v1/...`)       |

--- a/skills/roles/backend-node/testing/SKILL.md
+++ b/skills/roles/backend-node/testing/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: backend-node-testing
 description: >
-  Patrones de testing para backend Node.js: unit tests, integration tests, mocking y test doubles.
-  Trigger: Al escribir tests, mockear dependencias, testear APIs, configurar test suites.
+  Testing patterns for Node.js backends: unit tests, integration tests, mocking, test doubles, and API testing with Vitest.
+  Trigger: When writing tests, mocking dependencies, testing APIs, or configuring test suites.
+globs:
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/tests/**"
+  - "**/__tests__/**"
+  - "**/vitest.config.*"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,50 +16,86 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Escribes tests unitarios o de integración para backend
-- Necesitas mockear servicios externos, DB o APIs
-- Configuras test suites con Vitest o Jest
-- Testeas endpoints HTTP
+- Writing unit or integration tests for a Node.js backend
+- Mocking external services, databases, or APIs
+- Configuring test suites with Vitest
+- Testing HTTP endpoints with Supertest
+- Setting up test databases or factories
+- Defining coverage strategies
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Test lo que importa — comportamiento, no implementación
+### Pattern 1: Test Behavior, Not Implementation
+
+Test observable outcomes. If the implementation changes but the behavior stays the same, the test should still pass.
 
 ```typescript
-// ❌ MAL — testea implementación interna
+// ❌ BAD — tests internal implementation details
 it('should call bcrypt.hash with rounds=10', async () => {
     await userService.register(dto)
     expect(bcrypt.hash).toHaveBeenCalledWith(dto.password, 10)
 })
 
-// ✅ BIEN — testea comportamiento observable
+// ✅ GOOD — tests observable behavior
 it('should create user with hashed password (not plaintext)', async () => {
     const result = await userService.register(dto)
     const saved = await userRepository.findById(result.id)
     expect(saved?.password).not.toBe(dto.password)
+    expect(saved?.password).toBeDefined()
 })
 ```
 
-### Pattern 2: Test doubles claros
+```typescript
+// ❌ BAD — asserting on internal method calls
+it('should call logger.info twice', async () => {
+    await orderService.place(orderDto)
+    expect(logger.info).toHaveBeenCalledTimes(2)
+})
+
+// ✅ GOOD — assert on the result
+it('should return the created order with status pending', async () => {
+    const order = await orderService.place(orderDto)
+    expect(order.status).toBe('pending')
+    expect(order.items).toHaveLength(2)
+})
+```
+
+### Pattern 2: Clear Test Doubles
+
+Know the difference: **stub** returns data, **spy** records calls, **mock** = stub + spy with assertions.
 
 ```typescript
-// Stub: retorna datos predefinidos
+import { vi } from 'vitest'
+
+// Stub — returns predefined data
 const userRepository: UserRepository = {
-    findById: vi.fn().mockResolvedValue({ id: '1', name: 'Test' }),
+    findById: vi.fn().mockResolvedValue({ id: '1', name: 'Test', email: 'test@test.com' }),
     findByEmail: vi.fn().mockResolvedValue(null),
     create: vi.fn().mockImplementation(async (data) => ({ id: '1', ...data })),
     update: vi.fn(),
+    delete: vi.fn(),
 }
 
-// El service recibe el stub por constructor (DI)
+// Inject stub via constructor (Dependency Injection)
 const userService = new UserService(userRepository)
 ```
 
-### Pattern 3: Integration tests con supertest
+```typescript
+// ❌ BAD — mocking the module you're testing
+vi.mock('./user.service')
+
+// ✅ GOOD — mock only the dependencies, test the real service
+const mockRepo = { findById: vi.fn(), create: vi.fn() } as unknown as UserRepository
+const service = new UserService(mockRepo)
+```
+
+### Pattern 3: Integration Tests with Supertest
+
+Test the full HTTP layer: routing, middleware, validation, and response shape.
 
 ```typescript
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
@@ -67,14 +109,22 @@ describe('POST /api/users', () => {
         app = await createApp({ database: 'test' })
     })
 
+    afterAll(async () => {
+        await cleanupTestDatabase()
+    })
+
     it('should create a user and return 201', async () => {
         const response = await request(app)
             .post('/api/users')
-            .send({ email: 'test@test.com', password: 'secure123', name: 'Test' })
+            .send({ email: 'test@test.com', password: 'secure123', name: 'Test User' })
 
         expect(response.status).toBe(201)
-        expect(response.body).toHaveProperty('id')
-        expect(response.body.email).toBe('test@test.com')
+        expect(response.body.data).toMatchObject({
+            email: 'test@test.com',
+            name: 'Test User',
+        })
+        expect(response.body.data).toHaveProperty('id')
+        expect(response.body.data).not.toHaveProperty('password')
     })
 
     it('should return 400 for invalid email', async () => {
@@ -83,11 +133,22 @@ describe('POST /api/users', () => {
             .send({ email: 'not-an-email', password: 'secure123', name: 'Test' })
 
         expect(response.status).toBe(400)
+        expect(response.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('should return 409 for duplicate email', async () => {
+        const payload = { email: 'dupe@test.com', password: 'secure123', name: 'Test' }
+        await request(app).post('/api/users').send(payload)
+        const response = await request(app).post('/api/users').send(payload)
+
+        expect(response.status).toBe(409)
     })
 })
 ```
 
-### Pattern 4: Arrange-Act-Assert
+### Pattern 4: Arrange-Act-Assert (AAA)
+
+Every test follows three clear phases. Separate them with comments or blank lines.
 
 ```typescript
 it('should throw NotFoundError when user does not exist', async () => {
@@ -98,28 +159,323 @@ it('should throw NotFoundError when user does not exist', async () => {
     await expect(userService.getById('nonexistent'))
         .rejects.toThrow(NotFoundError)
 })
+
+it('should update user name', async () => {
+    // Arrange
+    const existing = { id: '1', name: 'Old', email: 'a@b.com' }
+    userRepository.findById.mockResolvedValue(existing)
+    userRepository.update.mockResolvedValue({ ...existing, name: 'New' })
+
+    // Act
+    const result = await userService.updateName('1', 'New')
+
+    // Assert
+    expect(result.name).toBe('New')
+    expect(userRepository.update).toHaveBeenCalledWith('1', { name: 'New' })
+})
+```
+
+### Pattern 5: Test Database Management
+
+Use transactions or truncation to isolate tests. Never leave dirty state.
+
+```typescript
+// ❌ BAD — leaves dirty data, tests leak into each other
+it('creates user', async () => {
+    await db.users.create({ email: 'test@test.com', name: 'Test', password: 'hashed' })
+    // no cleanup — affects other tests
+})
+
+// ✅ GOOD — transaction rollback strategy
+import { beforeEach } from 'vitest'
+
+let tx: PrismaClient
+
+beforeEach(async () => {
+    // Start a transaction that will be rolled back
+    tx = await startTestTransaction()
+})
+
+afterEach(async () => {
+    await rollbackTestTransaction(tx)
+})
+
+// ✅ GOOD — truncate between tests
+beforeEach(async () => {
+    await db.$executeRaw`TRUNCATE TABLE users, orders, products CASCADE`
+})
+```
+
+```typescript
+// Helper for test transaction isolation
+export async function withTestTransaction<T>(
+    prisma: PrismaClient,
+    fn: (tx: PrismaClient) => Promise<T>,
+): Promise<void> {
+    try {
+        await prisma.$transaction(async (tx) => {
+            await fn(tx as PrismaClient)
+            throw new Error('__ROLLBACK__')
+        })
+    } catch (e) {
+        if ((e as Error).message !== '__ROLLBACK__') throw e
+    }
+}
+```
+
+### Pattern 6: Factory Pattern for Test Data
+
+Use factories to generate realistic test data without boilerplate. [fishery](https://github.com/thoughtbot/fishery) is a great library for this.
+
+```typescript
+import { Factory } from 'fishery'
+
+// Define a factory
+const userFactory = Factory.define<User>(({ sequence }) => ({
+    id: `user-${sequence}`,
+    email: `user${sequence}@test.com`,
+    name: `Test User ${sequence}`,
+    password: 'hashed-password',
+    createdAt: new Date(),
+    role: 'user',
+}))
+
+// Usage in tests
+it('should list only active users', async () => {
+    // Arrange — readable, minimal boilerplate
+    const active = userFactory.build({ role: 'user' })
+    const admin = userFactory.build({ role: 'admin' })
+    userRepository.findAll.mockResolvedValue([active, admin])
+
+    // Act
+    const result = await userService.listByRole('user')
+
+    // Assert
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe(active.id)
+})
+
+// Build multiple
+const users = userFactory.buildList(5)
+
+// Build with traits (if using fishery transient params)
+const userWithOrders = userFactory.build({ role: 'premium' })
+```
+
+```typescript
+// ❌ BAD — inline object literals everywhere
+it('test 1', async () => {
+    const user = { id: '1', email: 'a@b.com', name: 'Test', password: 'x', createdAt: new Date(), role: 'user' }
+    // ...
+})
+it('test 2', async () => {
+    const user = { id: '2', email: 'b@c.com', name: 'Test2', password: 'x', createdAt: new Date(), role: 'admin' }
+    // ...
+})
+
+// ✅ GOOD — factories keep tests focused on what matters
+it('test 1', async () => {
+    const user = userFactory.build()
+    // ...
+})
+it('test 2', async () => {
+    const admin = userFactory.build({ role: 'admin' })
+    // ...
+})
+```
+
+### Pattern 7: Snapshot Testing for API Responses
+
+Use snapshots to catch unexpected changes in response shape. Update snapshots intentionally.
+
+```typescript
+it('should return user profile in expected shape', async () => {
+    const response = await request(app)
+        .get('/api/users/1')
+        .set('Authorization', `Bearer ${token}`)
+
+    expect(response.status).toBe(200)
+    // Snapshot catches any accidental shape changes
+    expect(response.body).toMatchSnapshot()
+})
+
+// For dynamic fields, use inline snapshots with matchers
+it('should return created user with dynamic fields', async () => {
+    const response = await request(app)
+        .post('/api/users')
+        .send(validPayload)
+
+    expect(response.body.data).toMatchObject({
+        id: expect.any(String),
+        email: 'test@test.com',
+        name: 'Test',
+        createdAt: expect.any(String),
+    })
+})
+```
+
+```typescript
+// ❌ BAD — snapshot includes timestamps and IDs that always change
+expect(response.body).toMatchSnapshot()
+// This snapshot will break on every run
+
+// ✅ GOOD — mask dynamic fields
+expect(response.body).toMatchSnapshot({
+    data: {
+        id: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+    },
+})
+```
+
+### Pattern 8: Test Coverage Strategy
+
+Don't chase 100%. Cover the right things.
+
+```typescript
+// vitest.config.ts
+export default defineConfig({
+    test: {
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.ts'],
+            exclude: [
+                'src/**/*.d.ts',
+                'src/**/*.test.ts',
+                'src/**/index.ts',        // barrel files
+                'src/generated/**',        // auto-generated code
+            ],
+            thresholds: {
+                statements: 80,
+                branches: 75,
+                functions: 80,
+                lines: 80,
+            },
+        },
+    },
+})
+```
+
+**What to prioritize:**
+
+| Priority | What to test                         | Why                              |
+| -------- | ------------------------------------ | -------------------------------- |
+| High     | Business logic in services           | Core value, most bugs live here  |
+| High     | Validation schemas                   | Prevents bad data entering system|
+| Medium   | API endpoints (integration)          | Verifies the full HTTP contract  |
+| Medium   | Error paths and edge cases           | Most overlooked, most impactful  |
+| Low      | Simple CRUD repositories             | Low logic, high maintenance cost |
+| Low      | DTOs and type mappings               | TypeScript already validates     |
+
+### Pattern 9: Contract Testing Basics
+
+Verify your API honors its contract. Useful when multiple consumers depend on response shape.
+
+```typescript
+import { describe, it, expect } from 'vitest'
+
+// Define the contract — what consumers expect
+const UserResponseContract = z.object({
+    data: z.object({
+        id: z.string(),
+        email: z.string().email(),
+        name: z.string(),
+        createdAt: z.string().datetime(),
+    }),
+})
+
+describe('User API Contract', () => {
+    it('GET /api/users/:id should match the contract', async () => {
+        const response = await request(app)
+            .get('/api/users/1')
+            .set('Authorization', `Bearer ${token}`)
+
+        expect(response.status).toBe(200)
+
+        // If this fails, you're breaking a consumer contract
+        const parsed = UserResponseContract.safeParse(response.body)
+        expect(parsed.success).toBe(true)
+    })
+
+    it('LIST /api/users should return array matching contract', async () => {
+        const response = await request(app).get('/api/users')
+
+        const ListContract = z.object({
+            data: z.array(UserResponseContract.shape.data),
+            meta: z.object({ page: z.number(), total: z.number() }),
+        })
+
+        expect(ListContract.safeParse(response.body).success).toBe(true)
+    })
+})
 ```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: Tests acoplados a la DB real sin cleanup
+### Don't: Test Everything Through the HTTP Layer
 
 ```typescript
-// ❌ MAL — deja datos sucios
-it('creates user', async () => {
-    await db.users.create({ email: 'test@test.com', ... })
-    // no cleanup — afecta otros tests
+// ❌ BAD — testing business logic via HTTP (slow, brittle)
+it('should reject password shorter than 8 chars', async () => {
+    const res = await request(app).post('/api/users').send({ ...dto, password: '123' })
+    expect(res.status).toBe(400)
 })
 
-// ✅ BIEN — transacción que se revierte
-it('creates user', async () => {
-    await db.$transaction(async (tx) => {
-        const user = await userService.register(dto, tx)
-        expect(user).toBeDefined()
-        throw new Error('rollback') // fuerza rollback
-    }).catch(() => {})
+// ✅ GOOD — test the schema directly (fast, focused)
+it('should reject password shorter than 8 chars', () => {
+    const result = CreateUserSchema.safeParse({ ...dto, password: '123' })
+    expect(result.success).toBe(false)
+})
+```
+
+### Don't: Share Mutable State Across Tests
+
+```typescript
+// ❌ BAD — shared mutable state causes flaky tests
+let sharedUser: User
+
+beforeAll(async () => {
+    sharedUser = await createUser()
+})
+
+it('test 1 modifies shared user', async () => {
+    await userService.updateName(sharedUser.id, 'Changed')
+})
+
+it('test 2 depends on original name — FLAKY', async () => {
+    const user = await userService.getById(sharedUser.id)
+    expect(user.name).toBe('Original') // fails because test 1 mutated it
+})
+
+// ✅ GOOD — each test creates its own data
+it('test 1', async () => {
+    const user = userFactory.build()
+    // ...
+})
+it('test 2', async () => {
+    const user = userFactory.build()
+    // ...
+})
+```
+
+### Don't: Skip Error Path Tests
+
+```typescript
+// ❌ BAD — only testing the happy path
+describe('UserService', () => {
+    it('should create user', async () => { /* ... */ })
+    it('should get user', async () => { /* ... */ })
+})
+
+// ✅ GOOD — also test failure cases
+describe('UserService', () => {
+    it('should create user', async () => { /* ... */ })
+    it('should throw ConflictError for duplicate email', async () => { /* ... */ })
+    it('should throw NotFoundError for missing user', async () => { /* ... */ })
+    it('should throw ForbiddenError when non-admin updates role', async () => { /* ... */ })
 })
 ```
 
@@ -127,8 +483,17 @@ it('creates user', async () => {
 
 ## Quick Reference
 
-| Tipo            | Qué testea                       | Velocidad | Mocks         |
-| --------------- | -------------------------------- | --------- | ------------- |
-| Unit test       | Una función/clase aislada        | Rápido    | Todo mockeado |
-| Integration     | Endpoint completo con DB         | Medio     | Solo externos |
-| E2E             | Flujo completo del usuario       | Lento     | Nada          |
+| Test Type    | What It Tests                    | Speed  | Mocks            |
+| ------------ | -------------------------------- | ------ | ---------------- |
+| Unit         | Single function/class in isolation | Fast  | All dependencies |
+| Integration  | Full endpoint with real DB        | Medium | Only externals   |
+| Contract     | Response shape matches spec       | Fast   | Depends          |
+| E2E          | Complete user flow                | Slow   | Nothing          |
+
+| Tool        | Purpose                                      |
+| ----------- | -------------------------------------------- |
+| Vitest      | Test runner, assertions, mocking             |
+| Supertest   | HTTP assertions for Express/Fastify          |
+| fishery     | Test data factories                          |
+| @faker-js   | Realistic fake data generation               |
+| v8 coverage | Built-in Vitest coverage provider            |

--- a/skills/roles/devops/cicd/SKILL.md
+++ b/skills/roles/devops/cicd/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: devops-cicd
 description: >
-  Patrones de CI/CD, Dockerfiles, pipelines y deployment para Azure DevOps y herramientas comunes.
-  Trigger: Al crear pipelines, escribir Dockerfiles, configurar deploys, definir stages de CI/CD.
+  CI/CD pipeline patterns: GitHub Actions, Azure Pipelines, Dockerfiles, deployment strategies, and environment management.
+  Trigger: When creating pipelines, writing Dockerfiles, configuring deployments, or defining CI/CD stages.
+globs:
+  - "**/Dockerfile*"
+  - "**/.github/workflows/**"
+  - "**/azure-pipelines*.yml"
+  - "**/docker-compose*.yml"
+  - "**/.dockerignore"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,18 +16,19 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Creas o modificas pipelines de CI/CD (Azure Pipelines, GitHub Actions)
-- Escribes o revisas Dockerfiles
-- Configuras estrategias de deployment
-- Diseñas la infraestructura de ambientes
+- Creating or modifying CI/CD pipelines (GitHub Actions, Azure Pipelines)
+- Writing or reviewing Dockerfiles
+- Configuring deployment strategies (blue-green, canary, rolling)
+- Designing environment promotion workflows
+- Setting up caching, artifacts, or matrix builds
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Pipeline con stages claras
+### Pattern 1: Pipeline with Clear Stages (Azure Pipelines)
 
 ```yaml
 # azure-pipelines.yml
@@ -59,7 +66,54 @@ stages:
                 - script: echo "Deploy to production"
 ```
 
-### Pattern 2: Dockerfile multi-stage
+### Pattern 2: Pipeline with Clear Stages (GitHub Actions)
+
+```yaml
+# .github/workflows/ci.yml
+name: CI/CD
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test -- --coverage
+
+  build:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: myapp:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Deploy to production"
+```
+
+### Pattern 3: Multi-stage Dockerfile
 
 ```dockerfile
 # Stage 1: Build
@@ -70,7 +124,7 @@ RUN npm ci --only=production && npm cache clean --force
 COPY . .
 RUN npm run build
 
-# Stage 2: Runtime (imagen mínima)
+# Stage 2: Runtime (minimal image)
 FROM node:20-alpine AS runtime
 WORKDIR /app
 RUN addgroup -g 1001 appgroup && adduser -u 1001 -G appgroup -s /bin/sh -D appuser
@@ -83,22 +137,26 @@ HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:3000/heal
 CMD ["node", "dist/index.js"]
 ```
 
-### Pattern 3: Secrets nunca en el repo
+### Pattern 4: Secrets — Never in the Repo
 
 ```yaml
-# ✅ BIEN — variables de grupo o Azure Key Vault
+# ✅ GOOD — Azure DevOps variable groups or Key Vault
 variables:
-  - group: production-secrets  # referencia a variable group en Azure DevOps
+  - group: production-secrets
 
-# ❌ MAL — secrets hardcoded
+# ✅ GOOD — GitHub Actions secrets
+env:
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+# ❌ BAD — hardcoded secrets
 variables:
-  DB_PASSWORD: 'my-secret-password'  # NUNCA hacer esto
+  DB_PASSWORD: 'my-secret-password'  # NEVER do this
 ```
 
-### Pattern 4: Health checks obligatorios
+### Pattern 5: Health Check Endpoints
 
 ```typescript
-// health.ts — endpoint estándar
+// health.ts — standard liveness and readiness probes
 app.get('/health', (_req, res) => {
     res.json({
         status: 'ok',
@@ -109,7 +167,7 @@ app.get('/health', (_req, res) => {
 
 app.get('/ready', async (_req, res) => {
     try {
-        await db.$queryRaw`SELECT 1`  // verificar DB
+        await db.$queryRaw`SELECT 1` // verify database connection
         res.json({ status: 'ready' })
     } catch {
         res.status(503).json({ status: 'not ready' })
@@ -117,43 +175,233 @@ app.get('/ready', async (_req, res) => {
 })
 ```
 
+### Pattern 6: Caching Strategies
+
+```yaml
+# GitHub Actions — npm cache
+- uses: actions/setup-node@v4
+  with:
+    node-version: 20
+    cache: 'npm'
+
+# GitHub Actions — Docker layer caching with BuildKit
+- uses: docker/build-push-action@v5
+  with:
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+
+# Azure Pipelines — cache task
+- task: Cache@2
+  inputs:
+    key: 'npm | "$(Agent.OS)" | package-lock.json'
+    path: $(npm_config_cache)
+    restoreKeys: |
+      npm | "$(Agent.OS)"
+```
+
+### Pattern 7: Matrix Builds
+
+```yaml
+# GitHub Actions — test across multiple versions
+jobs:
+  test:
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [18, 20, 22]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test
+```
+
+### Pattern 8: Artifact Management
+
+```yaml
+# GitHub Actions — upload/download build artifacts
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 5
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - run: echo "Deploy from artifact"
+```
+
+### Pattern 9: Container Registry Push
+
+```yaml
+# GitHub Actions — build and push to GHCR
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest
+```
+
+### Pattern 10: Environment Promotion
+
+```yaml
+# GitHub Actions — staging → production with manual approval
+jobs:
+  deploy-staging:
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deploy to staging"
+
+  deploy-production:
+    needs: deploy-staging
+    environment:
+      name: production
+      url: https://myapp.com
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deploy to production"
+```
+
+Configure environment protection rules in GitHub Settings → Environments → production → Required reviewers.
+
+### Pattern 11: Rollback Strategy
+
+```yaml
+# GitHub Actions — rollback on failure
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy new version
+        id: deploy
+        run: |
+          kubectl set image deployment/myapp myapp=myapp:${{ github.sha }}
+          kubectl rollout status deployment/myapp --timeout=120s
+
+      - name: Rollback on failure
+        if: failure() && steps.deploy.outcome == 'failure'
+        run: |
+          kubectl rollout undo deployment/myapp
+          echo "::error::Deployment failed — rolled back to previous version"
+```
+
 ---
 
 ## Anti-Patterns
 
-### Don't: latest como tag de imagen
+### Don't: Use `latest` as Image Tag
 
 ```dockerfile
-# ❌ MAL — no reproducible
+# ❌ BAD — not reproducible, breaks caching
 FROM node:latest
 
-# ✅ BIEN — versión explícita
+# ✅ GOOD — explicit version, deterministic builds
 FROM node:20.11-alpine
 ```
 
-### Don't: Pipeline sin fail-fast
+### Don't: Pipeline Without Fail-Fast
 
 ```yaml
-# ❌ MAL — sigue desplegando aunque los tests fallen
+# ❌ BAD — deploys even if tests fail
 stages:
   - stage: Deploy
-    # sin dependsOn ni condition
+    # no dependsOn or condition
 
-# ✅ BIEN — deploy solo si validate pasa
+# ✅ GOOD — deploy only when validation passes
 stages:
   - stage: Deploy
     dependsOn: Validate
     condition: succeeded()
 ```
 
+### Don't: Install Dev Dependencies in Production Image
+
+```dockerfile
+# ❌ BAD — image includes test/build tools
+RUN npm install
+
+# ✅ GOOD — production dependencies only
+RUN npm ci --only=production
+```
+
+### Don't: Run Containers as Root
+
+```dockerfile
+# ❌ BAD — runs as root (security risk)
+CMD ["node", "dist/index.js"]
+
+# ✅ GOOD — non-root user
+RUN adduser -D appuser
+USER appuser
+CMD ["node", "dist/index.js"]
+```
+
+### Don't: Skip .dockerignore
+
+```
+# .dockerignore — always include one
+node_modules
+.git
+.env*
+dist
+*.md
+coverage
+.github
+```
+
+### Don't: Hardcode Environment-Specific Values
+
+```yaml
+# ❌ BAD — environment baked into pipeline
+- run: curl https://api.production.myapp.com/deploy
+
+# ✅ GOOD — use environment variables
+- run: curl ${{ vars.DEPLOY_URL }}/deploy
+```
+
 ---
 
 ## Quick Reference
 
-| Situación                     | Acción                                             |
-| ----------------------------- | -------------------------------------------------- |
-| Secret necesario en pipeline  | Variable group o Key Vault, NUNCA en código        |
-| Imagen Docker grande          | Multi-stage build + alpine base                    |
-| Pipeline tarda mucho          | Paralelizar jobs independientes, cachear deps      |
-| Deploy falló                  | Rollback automático + revisar health checks        |
-| Nuevo ambiente                | Reproducir con IaC, no configurar manualmente      |
+| Situation                      | Action                                                 |
+| ------------------------------ | ------------------------------------------------------ |
+| Secret needed in pipeline      | Variable group, Key Vault, or GitHub Secrets — NEVER in code |
+| Docker image too large         | Multi-stage build + alpine base + .dockerignore        |
+| Pipeline is slow               | Parallelize independent jobs, cache dependencies       |
+| Deployment failed              | Automatic rollback + check health endpoints            |
+| New environment needed         | Reproduce with IaC — never configure manually          |
+| Need to test multiple versions | Matrix builds with `fail-fast: true`                   |
+| Build artifacts needed later   | Upload/download artifacts between jobs                 |
+| Push image to registry         | Authenticate → build → tag with SHA → push             |
+| Promote across environments    | staging → manual approval → production                 |
+| Rollback required              | `kubectl rollout undo` or redeploy previous SHA        |

--- a/skills/roles/devops/monitoring/SKILL.md
+++ b/skills/roles/devops/monitoring/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: devops-monitoring
 description: >
-  Patrones de observabilidad, logging estructurado y alertas para servicios en producción.
-  Trigger: Al configurar logging, métricas, alertas, o diagnosticar problemas en producción.
+  Observability patterns: structured logging, metrics, distributed tracing, alerting, and dashboard design for production services.
+  Trigger: When configuring logging, metrics, alerts, or diagnosing production issues.
+globs:
+  - "**/monitoring/**"
+  - "**/observability/**"
+  - "**/logging/**"
+  - "**/prometheus*"
+  - "**/grafana/**"
+  - "**/*telemetry*"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,94 +17,425 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Configuras logging en una aplicación
-- Defines métricas y alertas
-- Diagnosticas problemas en producción
-- Diseñas dashboards de observabilidad
+- Configuring structured logging in an application
+- Defining metrics, alerts, or SLOs
+- Diagnosing production issues
+- Setting up distributed tracing (OpenTelemetry)
+- Designing observability dashboards
+- Writing alerting rules or runbooks
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Logging estructurado (JSON)
+### Pattern 1: Structured Logging (JSON)
+
+#### TypeScript (pino)
 
 ```typescript
-// ❌ MAL — logs no parseables
+// ❌ BAD — unstructured, unparseable by log aggregators
 console.log('User created: ' + user.email)
 
-// ✅ BIEN — JSON estructurado, parseable por cualquier sistema
+// ✅ GOOD — structured JSON, parseable by any log system
 import pino from 'pino'
 
-const logger = pino({ level: 'info' })
+const logger = pino({
+    level: process.env.LOG_LEVEL || 'info',
+    formatters: {
+        level: (label) => ({ level: label }),
+    },
+    // Redact sensitive fields automatically
+    redact: ['req.headers.authorization', 'password', 'token'],
+})
 
 logger.info({ userId: user.id, email: user.email }, 'User created')
-// Output: {"level":30,"time":1234,"userId":"abc","email":"x@y.com","msg":"User created"}
+// Output: {"level":"info","time":1234,"userId":"abc","email":"x@y.com","msg":"User created"}
 ```
 
-### Pattern 2: Request ID para trazabilidad
+#### Python (structlog)
+
+```python
+# ❌ BAD — print statements, no structure
+print(f"User created: {user.email}")
+
+# ✅ GOOD — structured logging with structlog
+import structlog
+
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.JSONRenderer(),
+    ],
+)
+
+logger = structlog.get_logger()
+logger.info("user_created", user_id=user.id, email=user.email)
+# Output: {"event":"user_created","user_id":"abc","email":"x@y.com","level":"info","timestamp":"2024-..."}
+```
+
+### Pattern 2: Log Levels Strategy
+
+Use consistent log levels across all services:
+
+| Level   | When to Use                                        | Example                              |
+| ------- | -------------------------------------------------- | ------------------------------------ |
+| `fatal` | Process cannot continue, about to crash            | Database connection pool exhausted   |
+| `error` | Operation failed, requires attention               | Payment processing failed            |
+| `warn`  | Unexpected but recoverable, may need investigation | Retry attempt 3/5 for external API   |
+| `info`  | Normal business events worth recording             | Order placed, user signed up         |
+| `debug` | Detailed diagnostic info for troubleshooting       | Cache hit/miss, query timing         |
+| `trace` | Very fine-grained, only in dev or targeted debug   | Function entry/exit, variable values |
+
+```typescript
+// ❌ BAD — everything at the same level
+logger.info('Error processing payment')  // This is an error, not info
+logger.error('User logged in')           // This is info, not error
+
+// ✅ GOOD — correct levels with context
+logger.error({ orderId, error: err.message, stack: err.stack }, 'Payment processing failed')
+logger.info({ userId, method: 'oauth' }, 'User authenticated')
+```
+
+### Pattern 3: Request ID for Traceability
 
 ```typescript
 // middleware/request-id.ts
 import { randomUUID } from 'node:crypto'
 
 export function requestId(req: Request, res: Response, next: NextFunction) {
-    const id = req.headers['x-request-id'] as string || randomUUID()
+    const id = (req.headers['x-request-id'] as string) || randomUUID()
     req.requestId = id
     res.setHeader('x-request-id', id)
     next()
 }
 
-// En cada log incluir el request ID
+// Include request ID in every log within that request
 logger.info({ requestId: req.requestId, path: req.path }, 'Request received')
 ```
 
-### Pattern 3: Métricas RED (Rate, Errors, Duration)
+### Pattern 4: OpenTelemetry Setup (Traces + Metrics + Logs)
+
+```typescript
+// instrumentation.ts — load BEFORE any other imports
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
+import { Resource } from '@opentelemetry/resources'
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
+
+const sdk = new NodeSDK({
+    resource: new Resource({
+        [ATTR_SERVICE_NAME]: 'my-service',
+        [ATTR_SERVICE_VERSION]: '1.0.0',
+    }),
+    traceExporter: new OTLPTraceExporter({
+        url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318/v1/traces',
+    }),
+    metricReader: new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter(),
+        exportIntervalMillis: 15000,
+    }),
+    instrumentations: [getNodeAutoInstrumentations()],
+})
+
+sdk.start()
+
+// Graceful shutdown
+process.on('SIGTERM', () => sdk.shutdown())
+```
+
+#### Python (OpenTelemetry)
+
+```python
+# otel_setup.py
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+
+resource = Resource.create({"service.name": "my-service", "service.version": "1.0.0"})
+
+# Traces
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(provider)
+
+tracer = trace.get_tracer(__name__)
+
+# Usage
+with tracer.start_as_current_span("process_order") as span:
+    span.set_attribute("order.id", order_id)
+    # ... business logic
+```
+
+### Pattern 5: Prometheus Metric Types
+
+```typescript
+import { Counter, Gauge, Histogram, Registry } from 'prom-client'
+
+const register = new Registry()
+
+// Counter — monotonically increasing (requests, errors)
+const httpRequestsTotal = new Counter({
+    name: 'http_requests_total',
+    help: 'Total HTTP requests',
+    labelNames: ['method', 'route', 'status'],
+    registers: [register],
+})
+
+// Gauge — value that goes up and down (connections, queue size)
+const activeConnections = new Gauge({
+    name: 'active_connections',
+    help: 'Number of active connections',
+    registers: [register],
+})
+
+// Histogram — distribution of values (latency, request size)
+const httpRequestDuration = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method', 'route'],
+    buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5],
+    registers: [register],
+})
+
+// Middleware to record metrics
+app.use((req, res, next) => {
+    const end = httpRequestDuration.startTimer({ method: req.method, route: req.path })
+    res.on('finish', () => {
+        end()
+        httpRequestsTotal.inc({ method: req.method, route: req.path, status: res.statusCode })
+    })
+    next()
+})
+
+// Expose metrics endpoint for Prometheus scraping
+app.get('/metrics', async (_req, res) => {
+    res.set('Content-Type', register.contentType)
+    res.end(await register.metrics())
+})
+```
+
+### Pattern 6: RED Metrics (Rate, Errors, Duration)
+
+For every service, measure these three things — they cover ~80% of production issues:
+
+| Metric   | What It Measures              | Prometheus Example                          |
+| -------- | ----------------------------- | ------------------------------------------- |
+| Rate     | Requests per second           | `rate(http_requests_total[5m])`             |
+| Errors   | Error percentage (4xx, 5xx)   | `rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m])` |
+| Duration | Latency (p50, p95, p99)       | `histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))` |
+
+### Pattern 7: Alerting Rules
+
+```yaml
+# prometheus/alerts.yml
+groups:
+  - name: service-alerts
+    rules:
+      # ✅ GOOD — actionable, scoped, with clear threshold and window
+      - alert: HighErrorRate
+        expr: |
+          rate(http_requests_total{status=~"5.."}[5m])
+          / rate(http_requests_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate above 5% for {{ $labels.service }}"
+          runbook: "https://wiki.internal/runbooks/high-error-rate"
+
+      - alert: HighLatencyP95
+        expr: |
+          histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) > 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 latency above 2s for {{ $labels.service }}"
+
+      # ❌ BAD — too generic, no context, no runbook
+      - alert: HighCPU
+        expr: node_cpu_seconds_total > 80
+        annotations:
+          summary: "CPU is high"
+```
+
+### Pattern 8: Actionable Alerts Checklist
+
+Every alert MUST have:
+
+1. **Clear condition** — what metric, what threshold, what time window
+2. **Severity level** — critical (page someone) vs warning (check next business day)
+3. **Runbook link** — step-by-step instructions for the on-call engineer
+4. **Context in annotations** — which service, which environment, current value
 
 ```
-Para cada servicio, medir:
-- Rate:     requests por segundo
-- Errors:   porcentaje de errores (4xx, 5xx)
-- Duration: latencia (p50, p95, p99)
+✅ GOOD alert:
+  "Error rate > 5% on POST /api/payments for 5 minutes in production"
+  → Action: Check payment service logs, verify payment provider status
+  → Runbook: https://wiki.internal/runbooks/payments-errors
 
-Estas tres métricas cubren el 80% de los problemas en producción.
-```
-
-### Pattern 4: Alertas accionables
-
-```
-✅ BUENA alerta:
-  "Error rate > 5% en /api/payments durante 5 minutos"
-  → Acción clara: revisar logs de payments, verificar dependencia de pago
-
-❌ MALA alerta:
+❌ BAD alert:
   "CPU > 80%"
-  → Demasiado genérica, puede no ser un problema real
+  → Too generic. CPU spikes during deployments are normal. No runbook.
+```
+
+### Pattern 9: SLI/SLO Basics
+
+```
+SLI (Service Level Indicator) — the metric you measure
+  Example: "Percentage of requests completing in < 200ms"
+
+SLO (Service Level Objective) — the target for that metric
+  Example: "99.9% of requests complete in < 200ms over 30 days"
+
+Error Budget = 1 - SLO
+  Example: 0.1% of requests (roughly 43 minutes/month) can be slow
+```
+
+```yaml
+# Example SLO definition (tracked in Prometheus/Grafana)
+# SLI: latency
+- record: sli:latency:success_rate
+  expr: |
+    sum(rate(http_request_duration_seconds_bucket{le="0.2"}[5m]))
+    / sum(rate(http_request_duration_seconds_count[5m]))
+
+# Alert when error budget is burning too fast
+- alert: ErrorBudgetBurnRate
+  expr: sli:latency:success_rate < 0.999
+  for: 1h
+  labels:
+    severity: warning
+```
+
+### Pattern 10: Grafana Dashboard Patterns
+
+Structure dashboards in layers:
+
+1. **Service overview** — RED metrics for all services at a glance
+2. **Service detail** — deep dive into one service (endpoints, dependencies, resources)
+3. **Infrastructure** — nodes, pods, database, cache
+
+```json
+// Grafana dashboard panel example (JSON model snippet)
+{
+  "title": "Request Rate by Status",
+  "type": "timeseries",
+  "targets": [
+    {
+      "expr": "sum(rate(http_requests_total[5m])) by (status)",
+      "legendFormat": "{{status}}"
+    }
+  ]
+}
+```
+
+### Pattern 11: Distributed Tracing Context Propagation
+
+```typescript
+// When calling downstream services, propagate trace context
+import { context, propagation } from '@opentelemetry/api'
+
+async function callDownstream(url: string) {
+    const headers: Record<string, string> = {}
+    // Inject current trace context into outgoing headers
+    propagation.inject(context.active(), headers)
+
+    const response = await fetch(url, { headers })
+    return response.json()
+}
 ```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: Loguear datos sensibles
+### Don't: Log Sensitive Data
 
 ```typescript
-// ❌ MAL
+// ❌ BAD — leaks credentials into log aggregator
 logger.info({ password: user.password, token }, 'Auth attempt')
 
-// ✅ BIEN — redactar datos sensibles
+// ✅ GOOD — redact sensitive fields
 logger.info({ userId: user.id, hasToken: !!token }, 'Auth attempt')
+```
+
+### Don't: Use String Interpolation in Log Messages
+
+```typescript
+// ❌ BAD — prevents log aggregation (every message is unique)
+logger.info(`User ${userId} placed order ${orderId}`)
+
+// ✅ GOOD — static message + structured fields (aggregatable)
+logger.info({ userId, orderId }, 'Order placed')
+```
+
+### Don't: High-Cardinality Labels
+
+```typescript
+// ❌ BAD — userId as label creates millions of time series, kills Prometheus
+const counter = new Counter({
+    name: 'requests_total',
+    labelNames: ['userId'],  // unbounded cardinality
+})
+
+// ✅ GOOD — bounded labels only
+const counter = new Counter({
+    name: 'requests_total',
+    labelNames: ['method', 'route', 'status'],  // finite set of values
+})
+```
+
+### Don't: Alert on Symptoms Without Context
+
+```
+❌ BAD: Alert on "disk usage > 80%" with no follow-up
+✅ GOOD: Alert on "disk usage > 80% AND growth rate suggests full in < 4h"
+         with a runbook link explaining how to expand or clean up
+```
+
+### Don't: Ignore Log Correlation
+
+```typescript
+// ❌ BAD — logs from different services can't be correlated
+logger.info('Processing order')
+
+// ✅ GOOD — include traceId, spanId, requestId for cross-service correlation
+logger.info({
+    traceId: span.spanContext().traceId,
+    spanId: span.spanContext().spanId,
+    requestId: req.requestId,
+    orderId,
+}, 'Processing order')
 ```
 
 ---
 
 ## Quick Reference
 
-| Pilar           | Herramientas comunes                    |
-| --------------- | --------------------------------------- |
-| Logs            | Pino, Winston → ELK, Azure Monitor     |
-| Métricas        | Prometheus, Azure App Insights          |
-| Traces          | OpenTelemetry, Jaeger, Zipkin           |
-| Alertas         | Grafana Alerts, Azure Monitor Alerts    |
-| Dashboards      | Grafana, Azure Dashboards               |
+| Pillar      | Tools                                          |
+| ----------- | ---------------------------------------------- |
+| Logs        | Pino, structlog → ELK, Loki, Azure Monitor    |
+| Metrics     | Prometheus, prom-client, Azure App Insights    |
+| Traces      | OpenTelemetry, Jaeger, Zipkin, Tempo           |
+| Alerts      | Grafana Alerts, Alertmanager, Azure Monitor    |
+| Dashboards  | Grafana, Azure Dashboards, Datadog             |
+
+| Situation                       | Action                                              |
+| ------------------------------- | --------------------------------------------------- |
+| Can't find a request across services | Add request ID middleware + propagate in headers |
+| Prometheus OOM / high cardinality    | Audit labels — remove unbounded values (userId, IP) |
+| Alert fatigue (too many alerts)      | Consolidate, increase thresholds, require runbooks  |
+| No idea where latency comes from    | Add distributed tracing with OpenTelemetry          |
+| Need to define reliability targets  | Start with SLI/SLO on the most critical endpoint    |
+| Logs are unreadable                 | Switch to structured JSON logging (pino / structlog)|
+| Metrics endpoint not working        | Expose `/metrics` with prom-client, verify scrape config |

--- a/skills/roles/frontend/nextjs/SKILL.md
+++ b/skills/roles/frontend/nextjs/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: frontend-nextjs
 description: >
-  Patrones Next.js App Router: Server Components, Client Components, Server Actions, layouts y caching.
-  Trigger: Al crear páginas, layouts, server actions, al optimizar fetching, al decidir use client.
+  Next.js App Router patterns: Server Components, Client Components, Server Actions, routing, caching, and streaming.
+  Trigger: When creating pages, layouts, server actions, optimizing data fetching, or deciding component boundaries.
+globs:
+  - "**/app/**/*.tsx"
+  - "**/app/**/*.ts"
+  - "**/middleware.ts"
+  - "**/next.config.*"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,88 +15,429 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when you:
 
-- Creas o modificas páginas, layouts o segmentos de ruta
-- Decides si un componente debe ser Server o Client Component
-- Implementas mutaciones o formularios con Server Actions
-- Optimizas data fetching o configuras caché
+- Create or modify pages, layouts, or route segments
+- Decide whether a component should be a Server or Client Component
+- Implement mutations or forms with Server Actions
+- Optimize data fetching or configure caching/revalidation
+- Set up middleware, parallel routes, or intercepting routes
+- Configure metadata for SEO
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Server Components por defecto
+### Pattern 1: Server Components by default
+
+Every component in the `app/` directory is a Server Component unless you add `'use client'`. Fetch data directly — no API layer needed.
 
 ```typescript
 // app/dashboard/page.tsx
+// ✅ GOOD — Server Component, async data fetching at the top
 import { getUser } from '@/features/auth/services/userService'
 
 export default async function DashboardPage() {
-    const user = await getUser()
-    return <DashboardView user={user} />
+  const user = await getUser()
+  return <DashboardView user={user} />
 }
 ```
 
-### Pattern 2: `use client` SOLO cuando es necesario
+```typescript
+// ❌ BAD — unnecessary client-side fetching
+'use client'
+import { useState, useEffect } from 'react'
 
-Razones válidas: `useState`, `useEffect`, event handlers, browser APIs.
+export default function DashboardPage() {
+  const [user, setUser] = useState(null)
+  useEffect(() => {
+    fetch('/api/user').then(r => r.json()).then(setUser)
+  }, [])
+  return user ? <DashboardView user={user} /> : <Spinner />
+}
+```
+
+### Pattern 2: `'use client'` only when required
+
+Valid reasons: `useState`, `useEffect`, event handlers, browser APIs, third-party client libraries.
 
 ```typescript
 'use client'
 import { useState } from 'react'
 
+// ✅ GOOD — needs state for interactivity
 export function SearchBar({ onSearch }: { onSearch: (q: string) => void }) {
-    const [query, setQuery] = useState('')
-    return <input value={query} onChange={e => setQuery(e.target.value)} />
+  const [query, setQuery] = useState('')
+  return (
+    <input
+      value={query}
+      onChange={e => setQuery(e.target.value)}
+      onKeyDown={e => e.key === 'Enter' && onSearch(query)}
+    />
+  )
 }
 ```
 
-### Pattern 3: Server Actions para mutaciones
+**Key rule**: Push `'use client'` as far down the tree as possible. Keep the page/layout as Server Components and only wrap the interactive leaf.
 
 ```typescript
-"use server";
-import { revalidatePath } from "next/cache";
-
-export async function createPost(formData: FormData): Promise<ActionResult> {
-  const title = formData.get("title") as string;
-  await db.posts.create({ title });
-  revalidatePath("/posts");
-  return { success: true };
+// ✅ GOOD — Server Component page with a small Client island
+// app/products/page.tsx (Server Component)
+export default async function ProductsPage() {
+  const products = await getProducts()
+  return (
+    <div>
+      <h1>Products</h1>
+      <SearchBar onSearch={handleSearch} />  {/* Client Component */}
+      <ProductGrid products={products} />     {/* Server Component */}
+    </div>
+  )
 }
 ```
 
-### Pattern 4: Segmentos de carga/error
+### Pattern 3: App Router file conventions
 
 ```
 app/
+  layout.tsx       — Root layout (wraps entire app, renders once)
+  page.tsx         — Home page (/)
+  loading.tsx      — Suspense fallback for the route segment
+  error.tsx        — Error boundary for the route segment (must be 'use client')
+  not-found.tsx    — Custom 404 UI (triggered by notFound())
+  template.tsx     — Like layout but remounts on navigation (rare)
+  route.ts         — API Route Handler (GET, POST, etc.)
+  
   dashboard/
-    page.tsx       ← página principal
-    loading.tsx    ← skeleton de carga (Suspense automático)
-    error.tsx      ← boundary de error
-    layout.tsx     ← layout persistente del segmento
+    page.tsx       — /dashboard
+    loading.tsx    — Skeleton while dashboard loads
+    error.tsx      — Error UI for dashboard segment
+    layout.tsx     — Persistent layout for dashboard section
+
+  @modal/          — Parallel route (named slot)
+    (.)photo/[id]/ — Intercepting route
+      page.tsx
+```
+
+### Pattern 4: Server Actions for mutations
+
+```typescript
+// ✅ GOOD — Server Action in a separate file
+// app/posts/actions.ts
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+export async function createPost(formData: FormData): Promise<ActionResult> {
+  const title = formData.get("title") as string
+
+  if (!title || title.length < 3) {
+    return { success: false, error: "Title must be at least 3 characters" }
+  }
+
+  await db.posts.create({ data: { title } })
+  revalidatePath("/posts")
+  return { success: true }
+}
+```
+
+```typescript
+// ❌ BAD — using an API route for a simple mutation
+// app/api/posts/route.ts
+export async function POST(req: Request) {
+  const body = await req.json()
+  await db.posts.create({ data: body })
+  return Response.json({ ok: true })
+}
+// Then calling fetch('/api/posts', { method: 'POST' }) from client
+// This is unnecessary indirection when Server Actions exist
+```
+
+**When to use Route Handlers vs Server Actions:**
+
+| Use case                        | Choose              |
+| ------------------------------- | ------------------- |
+| Form submissions / mutations    | Server Action       |
+| Webhooks from external services | Route Handler       |
+| Public API consumed by others   | Route Handler       |
+| Client-side data mutation       | Server Action       |
+| File uploads with progress      | Route Handler       |
+
+### Pattern 5: Streaming with Suspense
+
+Wrap slow parts of the page in Suspense so the shell renders immediately.
+
+```typescript
+// app/dashboard/page.tsx
+// ✅ GOOD — shell renders instantly, slow sections stream in
+import { Suspense } from 'react'
+
+export default function DashboardPage() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <Suspense fallback={<StatsSkeleton />}>
+        <StatsPanel />  {/* async Server Component — can be slow */}
+      </Suspense>
+      <Suspense fallback={<FeedSkeleton />}>
+        <ActivityFeed />  {/* async Server Component — can be slow */}
+      </Suspense>
+    </div>
+  )
+}
+
+async function StatsPanel() {
+  const stats = await getStats() // slow query
+  return <StatsGrid stats={stats} />
+}
+```
+
+```typescript
+// ❌ BAD — no Suspense boundaries, entire page waits for slowest query
+export default async function DashboardPage() {
+  const stats = await getStats()      // 2s
+  const feed = await getActivityFeed() // 3s — total: 5s before anything renders
+  return (
+    <div>
+      <StatsGrid stats={stats} />
+      <Feed items={feed} />
+    </div>
+  )
+}
+```
+
+### Pattern 6: Caching and revalidation strategies
+
+```typescript
+// Time-based revalidation (ISR)
+// Revalidate this fetch every 60 seconds
+const data = await fetch('https://api.example.com/data', {
+  next: { revalidate: 60 }
+})
+
+// Tag-based revalidation
+const posts = await fetch('https://api.example.com/posts', {
+  next: { tags: ['posts'] }
+})
+
+// In a Server Action after mutation:
+import { revalidateTag, revalidatePath } from 'next/cache'
+
+export async function createPost() {
+  "use server"
+  await db.posts.create(...)
+  revalidateTag('posts')      // invalidate all fetches tagged 'posts'
+  revalidatePath('/posts')    // revalidate a specific path
+}
+```
+
+```typescript
+// ❌ BAD — no-store on everything "just in case"
+const data = await fetch(url, { cache: 'no-store' }) // kills all caching benefits
+
+// ✅ GOOD — opt out of cache only when data must be real-time
+const balance = await fetch(url, { cache: 'no-store' }) // user balance — must be fresh
+```
+
+### Pattern 7: Metadata API for SEO
+
+```typescript
+// Static metadata
+// app/about/page.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'About Us',
+  description: 'Learn about our company',
+  openGraph: { title: 'About Us', description: 'Learn about our company' },
+}
+
+// Dynamic metadata
+// app/posts/[slug]/page.tsx
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const post = await getPost(params.slug)
+  return {
+    title: post.title,
+    description: post.excerpt,
+    openGraph: { images: [post.coverImage] },
+  }
+}
+```
+
+### Pattern 8: Parallel routes
+
+Render multiple pages simultaneously in the same layout using named slots.
+
+```typescript
+// app/dashboard/layout.tsx
+export default function DashboardLayout({
+  children,
+  analytics,
+  notifications,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode    // @analytics/page.tsx
+  notifications: React.ReactNode // @notifications/page.tsx
+}) {
+  return (
+    <div className="grid grid-cols-3">
+      <main className="col-span-2">{children}</main>
+      <aside>
+        {analytics}
+        {notifications}
+      </aside>
+    </div>
+  )
+}
+```
+
+### Pattern 9: Intercepting routes for modals
+
+Show a modal on navigation but full page on direct URL access.
+
+```
+app/
+  feed/
+    page.tsx                    — /feed
+    @modal/
+      (..)photo/[id]/page.tsx   — intercepts /photo/[id] when navigating from /feed
+  photo/
+    [id]/
+      page.tsx                  — /photo/[id] (direct access — full page)
+```
+
+### Pattern 10: Middleware
+
+```typescript
+// middleware.ts (project root)
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('session')
+
+  // Redirect unauthenticated users
+  if (!token && request.nextUrl.pathname.startsWith('/dashboard')) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/settings/:path*'],
+}
+```
+
+```typescript
+// ❌ BAD — heavy logic in middleware (it runs on EVERY matched request at the edge)
+export function middleware(request: NextRequest) {
+  const user = await db.users.findOne(...) // NO — can't do DB queries in edge middleware
+  // Keep middleware thin: check cookies/headers, redirect, rewrite
+}
+```
+
+### Pattern 11: loading.tsx and error.tsx segments
+
+```typescript
+// app/dashboard/loading.tsx
+// Automatically wraps page.tsx in a Suspense boundary
+export default function DashboardLoading() {
+  return <DashboardSkeleton />
+}
+```
+
+```typescript
+// app/dashboard/error.tsx
+// Must be a Client Component
+'use client'
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div>
+      <h2>Something went wrong</h2>
+      <p>{error.message}</p>
+      <button onClick={reset}>Try again</button>
+    </div>
+  )
+}
 ```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: fetch en cliente cuando puede hacerse en servidor
+### Don't: Client-side fetch when Server Components can do it
 
 ```typescript
-// ❌ MAL
+// ❌ BAD — useEffect fetch in a Client Component
 'use client'
 export function ProductList() {
-    const [products, setProducts] = useState([])
-    useEffect(() => {
-        fetch('/api/products').then(r => r.json()).then(setProducts)
-    }, [])
+  const [products, setProducts] = useState([])
+  useEffect(() => {
+    fetch('/api/products').then(r => r.json()).then(setProducts)
+  }, [])
+  return products.map(p => <ProductCard key={p.id} product={p} />)
 }
 
-// ✅ BIEN — Server Component
+// ✅ GOOD — Server Component fetches directly
 export default async function ProductList() {
-    const products = await fetchProducts()
-    return products.map(p => <ProductCard key={p.id} product={p} />)
+  const products = await getProducts()
+  return products.map(p => <ProductCard key={p.id} product={p} />)
+}
+```
+
+### Don't: `'use client'` at the page level
+
+```typescript
+// ❌ BAD — entire page is a Client Component
+'use client'
+export default function SettingsPage() { ... }
+
+// ✅ GOOD — page is Server Component, only interactive parts are Client
+export default async function SettingsPage() {
+  const settings = await getSettings()
+  return (
+    <div>
+      <h1>Settings</h1>
+      <SettingsForm defaultValues={settings} /> {/* 'use client' */}
+    </div>
+  )
+}
+```
+
+### Don't: Await sequential fetches without streaming
+
+```typescript
+// ❌ BAD — waterfall: total time = sum of all fetches
+export default async function Page() {
+  const user = await getUser()          // 1s
+  const posts = await getPosts()        // 1s
+  const comments = await getComments()  // 1s → total: 3s
+}
+
+// ✅ GOOD — parallel fetches
+export default async function Page() {
+  const [user, posts, comments] = await Promise.all([
+    getUser(),
+    getPosts(),
+    getComments(),
+  ]) // total: ~1s (max of all three)
+}
+
+// ✅ BETTER — Suspense streaming (each section renders independently)
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<UserSkeleton />}><UserSection /></Suspense>
+      <Suspense fallback={<PostsSkeleton />}><PostsSection /></Suspense>
+    </>
+  )
 }
 ```
 
@@ -99,10 +445,19 @@ export default async function ProductList() {
 
 ## Quick Reference
 
-| Pregunta                    | Decisión                     |
-| --------------------------- | ---------------------------- |
-| ¿Necesita estado o eventos? | `use client`                 |
-| ¿Solo muestra datos?        | Server Component             |
-| ¿Muta datos / formularios?  | Server Action                |
-| ¿Loading UX?                | `loading.tsx` en el segmento |
-| ¿Error boundary por ruta?   | `error.tsx` en el segmento   |
+| Question                            | Decision                                      |
+| ----------------------------------- | --------------------------------------------- |
+| Needs state or event handlers?      | `'use client'`                                |
+| Only displays data?                 | Server Component                              |
+| Mutates data / form submission?     | Server Action                                 |
+| Loading UX for a route?             | `loading.tsx` in the segment                  |
+| Error boundary per route?           | `error.tsx` in the segment (must be 'use client') |
+| Custom 404?                         | `not-found.tsx` + `notFound()` call           |
+| SEO metadata?                       | `export metadata` or `generateMetadata()`     |
+| Protect routes?                     | `middleware.ts` with matcher                  |
+| Multiple panels in one layout?      | Parallel routes (`@slot`)                     |
+| Modal on nav, full page on direct?  | Intercepting routes (`(.)`, `(..)`)           |
+| Cache API response?                 | `fetch()` with `next: { revalidate, tags }`   |
+| Invalidate after mutation?          | `revalidatePath()` or `revalidateTag()`       |
+| External webhook / public API?      | Route Handler (`route.ts`)                    |
+| Slow section in a page?             | Wrap in `<Suspense>` for streaming            |

--- a/skills/roles/frontend/react/SKILL.md
+++ b/skills/roles/frontend/react/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: frontend-react
 description: >
-  Patrones React: componentes, hooks, estado y composición para proyectos feature-based.
-  Trigger: Al crear componentes React, hooks personalizados, manejar estado o diseñar UI patterns.
+  React component patterns: hooks, state management, composition, performance, and TypeScript integration.
+  Trigger: When creating React components, custom hooks, managing state, or designing UI patterns.
+globs:
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/hooks/**"
+  - "**/components/**"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,131 +15,494 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when you:
 
-- Creas o refactorizas componentes React
-- Implementas custom hooks
-- Diseñas el flujo de estado de una feature
-- Organizas la estructura de componentes dentro de una feature
+- Create or refactor React components
+- Implement custom hooks
+- Design state flow for a feature
+- Organize component structure within a feature
+- Need to decide on performance optimizations (memoization, code splitting)
+- Work with TypeScript generics in component APIs
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Componentes presentacionales sin efectos
+### Pattern 1: Presentational components without side effects
+
+Components that only receive props and render UI. No state, no effects, no logic.
 
 ```typescript
+// ✅ GOOD — pure presentational component
 interface UserCardProps {
-    name: string
-    email: string
-    onEdit: () => void
+  name: string
+  email: string
+  onEdit: () => void
 }
 
 export function UserCard({ name, email, onEdit }: UserCardProps) {
-    return (
-        <div className="card">
-            <h3>{name}</h3>
-            <p>{email}</p>
-            <button onClick={onEdit}>Editar</button>
-        </div>
-    )
+  return (
+    <div className="card">
+      <h3>{name}</h3>
+      <p>{email}</p>
+      <button onClick={onEdit}>Edit</button>
+    </div>
+  )
 }
 ```
 
-### Pattern 2: Custom hooks para encapsular lógica
+```typescript
+// ❌ BAD — side effects inside a presentational component
+export function UserCard({ name, email, onEdit }: UserCardProps) {
+  console.log("rendered") // side effect in render
+  localStorage.setItem("lastViewed", name) // side effect in render
+  return (
+    <div className="card">
+      <h3>{name}</h3>
+      <p>{email}</p>
+    </div>
+  )
+}
+```
+
+### Pattern 2: Custom hooks to encapsulate logic
+
+Extract reusable or complex logic into custom hooks. The component stays thin.
 
 ```typescript
+// ✅ GOOD — logic in hook, component only renders
 export function useUserSession() {
-    const [user, setUser] = useState<User | null>(null)
-    const [isLoading, setIsLoading] = useState(true)
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
-    useEffect(() => {
-        fetchCurrentUser()
-            .then(setUser)
-            .finally(() => setIsLoading(false))
-    }, [])
+  useEffect(() => {
+    fetchCurrentUser()
+      .then(setUser)
+      .finally(() => setIsLoading(false))
+  }, [])
 
-    return { user, isLoading }
+  return { user, isLoading }
 }
 
 export function UserDashboard() {
-    const { user, isLoading } = useUserSession()
-    if (isLoading) return <Skeleton />
-    return <UserProfile user={user} />
+  const { user, isLoading } = useUserSession()
+  if (isLoading) return <Skeleton />
+  return <UserProfile user={user} />
 }
 ```
 
-### Pattern 3: Estado lo más cerca posible de donde se usa
+```typescript
+// ❌ BAD — all logic inlined in the component
+export function UserDashboard() {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchCurrentUser()
+      .then(setUser)
+      .catch(e => setError(e.message))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  // 150+ lines of mixed logic and JSX...
+}
+```
+
+### Pattern 3: State as close as possible to where it's used
 
 ```typescript
-// ❌ MAL — estado global para algo local
-// store.ts → selectedTab (solo lo usa el componente Tabs)
+// ❌ BAD — global state for something local
+// store.ts → selectedTab (only used by the Tabs component)
 
-// ✅ BIEN — estado local al componente
+// ✅ GOOD — local state in the component that owns it
 export function Tabs({ items }: TabsProps) {
-    const [selected, setSelected] = useState(items[0].id)
-    return (...)
+  const [selected, setSelected] = useState(items[0].id)
+  return (
+    <div>
+      {items.map(item => (
+        <button key={item.id} onClick={() => setSelected(item.id)}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
 }
 ```
 
-### Pattern 4: Props drilling → Context o composición
+### Pattern 4: Props drilling — use Context or composition
 
-Si el prop drilling supera 2 niveles, usa Context o composición.
+When prop drilling exceeds 2 levels, prefer composition (children) or Context.
 
 ```typescript
+// ❌ BAD — drilling user through 3+ levels
+<Grandparent user={user}>
+  <Parent user={user}>
+    <Child user={user} />
+  </Parent>
+</Grandparent>
+
+// ✅ GOOD — composition with children
 export function UserPage({ user }: { user: User }) {
-    return (
-        <UserLayout>
-            <UserHeader user={user} />
-            <UserContent user={user} />
-        </UserLayout>
-    )
+  return (
+    <UserLayout>
+      <UserHeader user={user} />
+      <UserContent user={user} />
+    </UserLayout>
+  )
 }
+
+// ✅ GOOD — Context for deeply shared state
+const UserContext = createContext<User | null>(null)
+
+export function useUser() {
+  const ctx = useContext(UserContext)
+  if (!ctx) throw new Error("useUser must be used within UserProvider")
+  return ctx
+}
+```
+
+### Pattern 5: React 19 — `use` for async data
+
+```typescript
+// ✅ GOOD — React 19 `use` with Suspense
+import { use, Suspense } from 'react'
+
+function UserProfile({ userPromise }: { userPromise: Promise<User> }) {
+  const user = use(userPromise)
+  return <h1>{user.name}</h1>
+}
+
+export function UserPage() {
+  const userPromise = fetchUser() // starts fetching immediately
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <UserProfile userPromise={userPromise} />
+    </Suspense>
+  )
+}
+```
+
+### Pattern 6: React 19 — Actions and useActionState
+
+```typescript
+// ✅ GOOD — useActionState for form mutations
+import { useActionState } from 'react'
+
+function CreatePostForm() {
+  const [state, formAction, isPending] = useActionState(createPost, {
+    error: null,
+  })
+
+  return (
+    <form action={formAction}>
+      <input name="title" required />
+      {state.error && <p className="error">{state.error}</p>}
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Creating..." : "Create"}
+      </button>
+    </form>
+  )
+}
+```
+
+### Pattern 7: useOptimistic for instant UI feedback
+
+```typescript
+// ✅ GOOD — optimistic update while mutation is in flight
+import { useOptimistic } from 'react'
+
+function TodoList({ todos, addTodo }: Props) {
+  const [optimisticTodos, addOptimistic] = useOptimistic(
+    todos,
+    (current, newTodo: Todo) => [...current, { ...newTodo, pending: true }]
+  )
+
+  async function handleAdd(formData: FormData) {
+    const title = formData.get("title") as string
+    addOptimistic({ id: crypto.randomUUID(), title, pending: true })
+    await addTodo(title)
+  }
+
+  return (
+    <form action={handleAdd}>
+      <input name="title" />
+      <ul>
+        {optimisticTodos.map(t => (
+          <li key={t.id} style={{ opacity: t.pending ? 0.5 : 1 }}>{t.title}</li>
+        ))}
+      </ul>
+    </form>
+  )
+}
+```
+
+### Pattern 8: Suspense boundaries and Error Boundaries
+
+```typescript
+// ✅ GOOD — granular Suspense boundaries
+export function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <ErrorBoundary fallback={<p>Failed to load stats</p>}>
+        <Suspense fallback={<StatsSkeleton />}>
+          <StatsPanel />
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary fallback={<p>Failed to load feed</p>}>
+        <Suspense fallback={<FeedSkeleton />}>
+          <ActivityFeed />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  )
+}
+```
+
+```typescript
+// ❌ BAD — single Suspense wrapping everything (one slow component blocks all)
+<Suspense fallback={<FullPageSpinner />}>
+  <StatsPanel />
+  <ActivityFeed />
+  <Notifications />
+</Suspense>
+```
+
+### Pattern 9: Code splitting with React.lazy
+
+```typescript
+// ✅ GOOD — lazy load heavy components
+const AdminPanel = lazy(() => import('./AdminPanel'))
+const ChartView = lazy(() => import('./ChartView'))
+
+export function App() {
+  return (
+    <Suspense fallback={<Spinner />}>
+      {isAdmin && <AdminPanel />}
+      {showCharts && <ChartView />}
+    </Suspense>
+  )
+}
+```
+
+### Pattern 10: key prop to reset component state
+
+```typescript
+// ✅ GOOD — key change forces full remount and state reset
+export function ChatPage({ conversationId }: Props) {
+  return <ChatPanel key={conversationId} id={conversationId} />
+}
+
+// ❌ BAD — useEffect to "reset" state manually
+export function ChatPanel({ id }: Props) {
+  const [messages, setMessages] = useState<Message[]>([])
+  useEffect(() => {
+    setMessages([]) // manual reset — fragile and easy to miss fields
+  }, [id])
+}
+```
+
+### Pattern 11: Controlled vs Uncontrolled inputs
+
+```typescript
+// ✅ Controlled — when you need real-time access to value
+function SearchBar() {
+  const [query, setQuery] = useState('')
+  return <input value={query} onChange={e => setQuery(e.target.value)} />
+}
+
+// ✅ Uncontrolled — when you only need value on submit (simpler, better perf)
+function LoginForm() {
+  const formRef = useRef<HTMLFormElement>(null)
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const data = new FormData(formRef.current!)
+    login(data.get("email") as string, data.get("password") as string)
+  }
+  return (
+    <form ref={formRef} onSubmit={handleSubmit}>
+      <input name="email" />
+      <input name="password" type="password" />
+      <button type="submit">Login</button>
+    </form>
+  )
+}
+```
+
+### Pattern 12: forwardRef for reusable primitives
+
+```typescript
+// ✅ GOOD — exposes ref for parent to control focus, scroll, etc.
+import { forwardRef, type ComponentPropsWithoutRef } from 'react'
+
+interface InputProps extends ComponentPropsWithoutRef<'input'> {
+  label: string
+  error?: string
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, ...rest }, ref) => (
+    <div>
+      <label>{label}</label>
+      <input ref={ref} {...rest} />
+      {error && <span className="error">{error}</span>}
+    </div>
+  )
+)
+Input.displayName = 'Input'
+```
+
+### Pattern 13: useCallback and useMemo — when to use and when NOT to
+
+```typescript
+// ✅ USE useMemo — expensive computation
+const sorted = useMemo(
+  () => items.toSorted((a, b) => a.price - b.price),
+  [items]
+)
+
+// ✅ USE useCallback — stable reference passed to memoized child
+const handleDelete = useCallback((id: string) => {
+  setItems(prev => prev.filter(item => item.id !== id))
+}, [])
+
+return <MemoizedList items={sorted} onDelete={handleDelete} />
+```
+
+```typescript
+// ❌ BAD — useMemo for trivial operations (overhead > benefit)
+const fullName = useMemo(() => `${first} ${last}`, [first, last])
+
+// ❌ BAD — useCallback when the child is NOT memoized (no benefit)
+const handleClick = useCallback(() => {
+  setOpen(true)
+}, [])
+return <button onClick={handleClick}>Open</button> // button re-renders anyway
+```
+
+**Rule of thumb**: Only memoize when you can prove the cost of re-computation or re-render is real. Profile first, optimize second.
+
+### Pattern 14: TypeScript generic components
+
+```typescript
+// ✅ GOOD — generic Select component works with any item type
+interface SelectProps<T> {
+  items: T[]
+  value: T
+  onChange: (item: T) => void
+  getLabel: (item: T) => string
+  getKey: (item: T) => string
+}
+
+export function Select<T>({ items, value, onChange, getLabel, getKey }: SelectProps<T>) {
+  return (
+    <select
+      value={getKey(value)}
+      onChange={e => {
+        const item = items.find(i => getKey(i) === e.target.value)
+        if (item) onChange(item)
+      }}
+    >
+      {items.map(item => (
+        <option key={getKey(item)} value={getKey(item)}>
+          {getLabel(item)}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+// Usage — TypeScript infers T as Country
+<Select
+  items={countries}
+  value={selected}
+  onChange={setSelected}
+  getLabel={c => c.name}
+  getKey={c => c.code}
+/>
 ```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: Efectos secundarios en render
+### Don't: Side effects during render
 
 ```typescript
-// ❌ MAL
+// ❌ BAD — runs on every render, blocks paint
 export function List({ items }: ListProps) {
-    localStorage.setItem('lastItems', JSON.stringify(items))
-    return <ul>{items.map(i => <li key={i.id}>{i.name}</li>)}</ul>
+  localStorage.setItem('lastItems', JSON.stringify(items))
+  return <ul>{items.map(i => <li key={i.id}>{i.name}</li>)}</ul>
 }
 
-// ✅ BIEN
+// ✅ GOOD — effect runs after render, with dependency tracking
 export function List({ items }: ListProps) {
-    useEffect(() => {
-        localStorage.setItem('lastItems', JSON.stringify(items))
-    }, [items])
-    return <ul>{items.map(i => <li key={i.id}>{i.name}</li>)}</ul>
+  useEffect(() => {
+    localStorage.setItem('lastItems', JSON.stringify(items))
+  }, [items])
+  return <ul>{items.map(i => <li key={i.id}>{i.name}</li>)}</ul>
 }
 ```
 
-### Don't: Componentes con demasiadas responsabilidades
+### Don't: Components with too many responsibilities
 
 ```typescript
-// ❌ MAL — hace fetch, parsea, valida y renderiza
-export function UserDashboard() { ... /* 200 líneas */ }
+// ❌ BAD — fetches, parses, validates, and renders all in one (200+ lines)
+export function UserDashboard() { ... }
 
-// ✅ BIEN — separado
+// ✅ GOOD — separated concerns
 export function UserDashboard() {
-    const { user, isLoading } = useUserSession()
-    return isLoading ? <DashboardSkeleton /> : <DashboardLayout user={user} />
+  const { user, isLoading } = useUserSession()
+  return isLoading ? <DashboardSkeleton /> : <DashboardLayout user={user} />
 }
+```
+
+### Don't: Array index as key for dynamic lists
+
+```typescript
+// ❌ BAD — index keys break state when items reorder or delete
+{items.map((item, index) => <TodoItem key={index} item={item} />)}
+
+// ✅ GOOD — stable unique ID
+{items.map(item => <TodoItem key={item.id} item={item} />)}
+```
+
+### Don't: Derive state that can be computed
+
+```typescript
+// ❌ BAD — syncing derived state with useEffect
+const [items, setItems] = useState<Item[]>([])
+const [filteredItems, setFilteredItems] = useState<Item[]>([])
+
+useEffect(() => {
+  setFilteredItems(items.filter(i => i.active))
+}, [items])
+
+// ✅ GOOD — compute during render
+const [items, setItems] = useState<Item[]>([])
+const filteredItems = items.filter(i => i.active)
 ```
 
 ---
 
 ## Quick Reference
 
-| Patrón                     | Cuándo aplicar                                 |
-| -------------------------- | ---------------------------------------------- |
-| Componente presentacional  | Estado no necesario → solo props               |
-| Custom hook                | Lógica reutilizable o compleja → extraer       |
-| useState local             | Estado de 1 componente                         |
-| Context                    | Estado compartido en 3+ niveles de profundidad |
-| Composición sobre herencia | Siempre en React                               |
+| Pattern                    | When to apply                                         |
+| -------------------------- | ----------------------------------------------------- |
+| Presentational component   | No state needed — props in, JSX out                   |
+| Custom hook                | Reusable or complex logic — extract from component    |
+| Local useState             | State owned by a single component                     |
+| Context                    | State shared across 3+ levels deep                    |
+| Composition over inherit.  | Always in React                                       |
+| `use` (React 19)           | Read a Promise or Context in render                   |
+| `useActionState`           | Form mutations with pending + error state             |
+| `useOptimistic`            | Instant UI feedback while mutation is in flight       |
+| Suspense boundary          | Async component loading — granular per section        |
+| Error Boundary             | Catch render errors — wrap per independent section    |
+| React.lazy                 | Code split heavy/conditional components               |
+| key prop reset             | Force remount when identity changes (e.g. chat ID)    |
+| forwardRef                 | Reusable primitives that expose DOM ref               |
+| useMemo                    | Expensive computations — profile first                |
+| useCallback                | Stable ref for memoized children — profile first      |
+| Generic components         | Reusable UI that works with multiple data types       |

--- a/skills/roles/python/api-design/SKILL.md
+++ b/skills/roles/python/api-design/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: python-api
 description: >
-  Patrones de diseño de APIs con Python: FastAPI, estructura de proyecto, validación y testing.
-  Trigger: Al crear endpoints, diseñar la estructura del proyecto Python, implementar validación o tests.
+  Python API design patterns with FastAPI: project structure, validation, dependency injection, error handling, and async patterns.
+  Trigger: When creating endpoints, designing project structure, implementing validation, or configuring FastAPI.
+globs:
+  - "**/*.py"
+  - "**/requirements*.txt"
+  - "**/pyproject.toml"
+  - "**/Pipfile"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,48 +15,82 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Creas o modificas endpoints en FastAPI/Flask/Django
-- Diseñas la estructura de un proyecto Python backend
-- Implementas validación de datos con Pydantic
-- Escribes tests para la API
+- Creating or modifying endpoints in FastAPI
+- Designing a Python backend project structure
+- Implementing data validation with Pydantic
+- Configuring dependency injection, middleware, or error handling
+- Setting up async database access with SQLAlchemy
+- Adding pagination, CORS, or API versioning
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Estructura por dominio
+### Pattern 1: Domain-based project structure
 
 ```
 src/
-├── main.py                  # entry point
-├── config.py                # settings con pydantic-settings
-├── dependencies.py          # dependency injection
+├── main.py                  # entry point, lifespan, app factory
+├── config.py                # settings via pydantic-settings
+├── dependencies.py          # shared dependency injection
 ├── users/
 │   ├── __init__.py
-│   ├── router.py            # endpoints
-│   ├── service.py           # lógica de negocio
-│   ├── repository.py        # acceso a datos
+│   ├── router.py            # endpoints (thin — delegates to service)
+│   ├── service.py           # business logic
+│   ├── repository.py        # data access layer
 │   ├── schemas.py           # Pydantic models (request/response)
-│   └── models.py            # ORM models (SQLAlchemy/Prisma)
+│   └── models.py            # ORM models (SQLAlchemy)
 ├── products/
 │   ├── ...
 └── shared/
-    ├── errors.py            # excepciones de dominio
-    └── middleware.py         # cross-cutting concerns
+    ├── errors.py            # domain exceptions
+    ├── middleware.py         # cross-cutting concerns
+    ├── pagination.py         # reusable pagination schemas
+    └── database.py           # engine, session factory
 ```
 
-### Pattern 2: Schemas de entrada/salida con Pydantic
+### Pattern 2: Settings with pydantic-settings
 
 ```python
-from pydantic import BaseModel, EmailStr, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+    )
+
+    database_url: str
+    redis_url: str = "redis://localhost:6379"
+    debug: bool = False
+    allowed_origins: list[str] = ["http://localhost:3000"]
+    api_v1_prefix: str = "/api/v1"
+```
+
+```python
+# ❌ BAD — hardcoded config scattered across modules
+DATABASE_URL = "postgresql://localhost/mydb"
+
+# ✅ GOOD — centralized, validated, env-driven
+settings = Settings()  # reads from .env + environment
+```
+
+### Pattern 3: Input/output schemas with Pydantic
+
+```python
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from datetime import datetime
+
+# Request schema — only what the client sends
 class CreateUserRequest(BaseModel):
     email: EmailStr
     password: str = Field(min_length=8)
     name: str = Field(min_length=2, max_length=100)
 
+# Response schema — only what the client receives
 class UserResponse(BaseModel):
     id: str
     email: str
@@ -59,9 +98,57 @@ class UserResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+# Update schema — partial updates with Optional fields
+class UpdateUserRequest(BaseModel):
+    name: str | None = Field(None, min_length=2, max_length=100)
+    email: EmailStr | None = None
 ```
 
-### Pattern 3: Router delgado — lógica en service
+```python
+# ❌ BAD — reusing the same model for input and output
+class User(BaseModel):
+    id: str
+    email: str
+    password: str  # leaks password in responses!
+
+# ✅ GOOD — separate request/response schemas
+class CreateUserRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8)
+
+class UserResponse(BaseModel):
+    id: str
+    email: str
+    # password is never exposed
+```
+
+### Pattern 4: Discriminated unions for polymorphic responses
+
+```python
+from typing import Annotated, Literal, Union
+from pydantic import BaseModel, Discriminator, Tag
+
+class CardPayment(BaseModel):
+    type: Literal["card"] = "card"
+    card_last_four: str
+    amount: int
+
+class BankTransfer(BaseModel):
+    type: Literal["bank_transfer"] = "bank_transfer"
+    bank_name: str
+    amount: int
+
+PaymentResponse = Annotated[
+    Union[
+        Annotated[CardPayment, Tag("card")],
+        Annotated[BankTransfer, Tag("bank_transfer")],
+    ],
+    Discriminator("type"),
+]
+```
+
+### Pattern 5: Thin router — logic lives in service
 
 ```python
 # users/router.py
@@ -79,7 +166,26 @@ async def create_user(
     return await service.register(dto)
 ```
 
-### Pattern 4: Dependency Injection con FastAPI
+```python
+# ❌ BAD — business logic inside the router
+@router.post("/users/")
+async def create_user(dto: CreateUserRequest, db: Session = Depends(get_db)):
+    existing = db.query(User).filter(User.email == dto.email).first()
+    if existing:
+        raise HTTPException(409, "Email exists")
+    hashed = bcrypt.hash(dto.password)
+    user = User(email=dto.email, password=hashed)
+    db.add(user)
+    db.commit()
+    return user
+
+# ✅ GOOD — router delegates everything
+@router.post("/users/", response_model=UserResponse, status_code=201)
+async def create_user(dto: CreateUserRequest, service: UserService = Depends()):
+    return await service.register(dto)
+```
+
+### Pattern 6: Dependency injection with FastAPI
 
 ```python
 # dependencies.py
@@ -90,8 +196,8 @@ from .config import Settings
 def get_settings() -> Settings:
     return Settings()
 
-async def get_db(settings: Settings = Depends(get_settings)) -> AsyncSession:
-    async with async_session(settings.database_url) as session:
+async def get_db(settings: Settings = Depends(get_settings)) -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_factory(settings.database_url)() as session:
         yield session
 
 # users/service.py
@@ -106,41 +212,270 @@ class UserService:
         return await self.repository.create(dto)
 ```
 
+### Pattern 7: Domain exceptions with centralized handler
+
+```python
+# shared/errors.py
+class DomainError(Exception):
+    """Base class for all domain errors."""
+    def __init__(self, detail: str, code: str = "DOMAIN_ERROR"):
+        self.detail = detail
+        self.code = code
+
+class NotFoundError(DomainError):
+    def __init__(self, detail: str = "Resource not found"):
+        super().__init__(detail=detail, code="NOT_FOUND")
+
+class ConflictError(DomainError):
+    def __init__(self, detail: str = "Resource already exists"):
+        super().__init__(detail=detail, code="CONFLICT")
+
+class ForbiddenError(DomainError):
+    def __init__(self, detail: str = "Forbidden"):
+        super().__init__(detail=detail, code="FORBIDDEN")
+```
+
+```python
+# main.py — register exception handlers
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from shared.errors import NotFoundError, ConflictError, DomainError
+
+def register_exception_handlers(app: FastAPI) -> None:
+    status_map = {
+        NotFoundError: 404,
+        ConflictError: 409,
+        ForbiddenError: 403,
+    }
+
+    @app.exception_handler(DomainError)
+    async def domain_error_handler(request: Request, exc: DomainError) -> JSONResponse:
+        status = status_map.get(type(exc), 400)
+        return JSONResponse(
+            status_code=status,
+            content={"error": exc.code, "detail": exc.detail},
+        )
+```
+
+```python
+# ❌ BAD — raising HTTPException from service layer
+class UserService:
+    async def get_by_id(self, user_id: str) -> User:
+        user = await self.repo.find_by_id(user_id)
+        if not user:
+            raise HTTPException(404, "Not found")  # couples service to HTTP
+        return user
+
+# ✅ GOOD — raise domain exception, handler maps to HTTP
+class UserService:
+    async def get_by_id(self, user_id: str) -> User:
+        user = await self.repo.find_by_id(user_id)
+        if not user:
+            raise NotFoundError(f"User {user_id} not found")
+        return user
+```
+
+### Pattern 8: Lifespan events and app factory
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup: initialize resources
+    engine = create_async_engine(settings.database_url)
+    app.state.db_engine = engine
+    yield
+    # Shutdown: clean up resources
+    await engine.dispose()
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="My API",
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+    register_exception_handlers(app)
+    app.include_router(users_router, prefix="/api/v1")
+    return app
+```
+
+```python
+# ❌ BAD — using deprecated @app.on_event
+@app.on_event("startup")
+async def startup():
+    ...
+
+# ✅ GOOD — use lifespan context manager
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # startup
+    yield
+    # shutdown
+```
+
+### Pattern 9: Background tasks
+
+```python
+from fastapi import BackgroundTasks
+
+@router.post("/users/", status_code=201)
+async def create_user(
+    dto: CreateUserRequest,
+    service: UserService = Depends(),
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+):
+    user = await service.register(dto)
+    background_tasks.add_task(send_welcome_email, user.email)
+    return user
+```
+
+### Pattern 10: Pagination
+
+```python
+# shared/pagination.py
+from pydantic import BaseModel, Field
+from typing import Generic, TypeVar, Sequence
+
+T = TypeVar("T")
+
+class PaginationParams(BaseModel):
+    page: int = Field(1, ge=1)
+    size: int = Field(20, ge=1, le=100)
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.size
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: Sequence[T]
+    total: int
+    page: int
+    size: int
+    pages: int
+```
+
+```python
+# Usage in router
+@router.get("/", response_model=PaginatedResponse[UserResponse])
+async def list_users(
+    params: PaginationParams = Depends(),
+    service: UserService = Depends(),
+):
+    return await service.list_users(params)
+```
+
+### Pattern 11: CORS configuration
+
+```python
+from fastapi.middleware.cors import CORSMiddleware
+
+def create_app() -> FastAPI:
+    app = FastAPI(...)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return app
+```
+
+```python
+# ❌ BAD — allow_origins=["*"] with allow_credentials=True
+# This is rejected by browsers and is a security risk
+
+# ✅ GOOD — explicit origin list from settings
+allow_origins=settings.allowed_origins  # ["https://myapp.com"]
+```
+
+### Pattern 12: API versioning via router prefix
+
+```python
+# main.py
+from fastapi import FastAPI, APIRouter
+
+v1_router = APIRouter(prefix="/api/v1")
+v1_router.include_router(users_v1.router)
+v1_router.include_router(products_v1.router)
+
+v2_router = APIRouter(prefix="/api/v2")
+v2_router.include_router(users_v2.router)
+
+app.include_router(v1_router)
+app.include_router(v2_router)
+```
+
+### Pattern 13: Async SQLAlchemy session
+
+```python
+# shared/database.py
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+engine = create_async_engine(settings.database_url, echo=settings.debug)
+async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+```
+
+```python
+# ❌ BAD — forgetting to commit/rollback
+async def get_db():
+    session = async_session_factory()
+    yield session  # no commit, no rollback, no close
+
+# ✅ GOOD — context manager with commit/rollback
+async def get_db():
+    async with async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+```
+
+### Pattern 14: OpenAPI customization
+
+```python
+app = FastAPI(
+    title="My Service",
+    version="1.0.0",
+    description="User management API",
+    docs_url="/api/docs",
+    redoc_url="/api/redoc",
+    openapi_url="/api/openapi.json",
+    openapi_tags=[
+        {"name": "users", "description": "User management operations"},
+        {"name": "products", "description": "Product catalog"},
+    ],
+)
+```
+
 ---
 
 ## Anti-Patterns
 
-### Don't: Lógica de negocio en el router
-
-```python
-# ❌ MAL — router hace todo
-@router.post("/users/")
-async def create_user(dto: CreateUserRequest, db: Session = Depends(get_db)):
-    existing = db.query(User).filter(User.email == dto.email).first()
-    if existing:
-        raise HTTPException(409, "Email exists")
-    hashed = bcrypt.hash(dto.password)
-    user = User(email=dto.email, password=hashed)
-    db.add(user)
-    db.commit()
-    return user
-
-# ✅ BIEN — router delega
-@router.post("/users/")
-async def create_user(dto: CreateUserRequest, service: UserService = Depends()):
-    return await service.register(dto)
-```
-
 ### Don't: Bare except
 
 ```python
-# ❌ MAL
+# ❌ BAD — swallows all errors silently
 try:
     result = await risky_operation()
 except:
     pass
 
-# ✅ BIEN
+# ✅ GOOD — catch specific exceptions, log, re-raise if needed
 try:
     result = await risky_operation()
 except SpecificError as e:
@@ -148,14 +483,46 @@ except SpecificError as e:
     raise
 ```
 
+### Don't: Use sync DB calls in async endpoints
+
+```python
+# ❌ BAD — blocks the event loop
+@router.get("/users/{user_id}")
+async def get_user(user_id: str, db: Session = Depends(get_sync_db)):
+    return db.query(User).get(user_id)
+
+# ✅ GOOD — use async session
+@router.get("/users/{user_id}")
+async def get_user(user_id: str, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+```
+
+### Don't: Return ORM models directly
+
+```python
+# ❌ BAD — leaks internal fields and breaks if ORM changes
+@router.get("/users/{user_id}")
+async def get_user(user_id: str, db: AsyncSession = Depends(get_db)):
+    return await db.get(User, user_id)
+
+# ✅ GOOD — return a response schema
+@router.get("/users/{user_id}", response_model=UserResponse)
+async def get_user(user_id: str, service: UserService = Depends()):
+    return await service.get_by_id(user_id)
+```
+
 ---
 
 ## Quick Reference
 
-| Capa          | Responsabilidad                          | Archivo       |
-| ------------- | ---------------------------------------- | ------------- |
-| Router        | Definir endpoints, parsear HTTP          | `router.py`   |
-| Service       | Lógica de negocio                        | `service.py`  |
-| Repository    | Acceso a datos (ORM)                     | `repository.py` |
-| Schemas       | Validación entrada/salida (Pydantic)     | `schemas.py`  |
-| Models        | Definición de tablas (SQLAlchemy)        | `models.py`   |
+| Layer      | Responsibility                        | File            |
+| ---------- | ------------------------------------- | --------------- |
+| Router     | Define endpoints, parse HTTP          | `router.py`     |
+| Service    | Business logic, orchestration         | `service.py`    |
+| Repository | Data access (ORM queries)             | `repository.py` |
+| Schemas    | Input/output validation (Pydantic)    | `schemas.py`    |
+| Models     | Table definitions (SQLAlchemy)        | `models.py`     |
+| Config     | Settings from environment             | `config.py`     |
+| Errors     | Domain exceptions                     | `errors.py`     |
+| Database   | Engine, session factory               | `database.py`   |

--- a/skills/roles/python/testing/SKILL.md
+++ b/skills/roles/python/testing/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: python-testing
 description: >
-  Patrones de testing para Python: pytest, fixtures, mocking y test de APIs.
-  Trigger: Al escribir tests en Python, configurar pytest, mockear dependencias, testear endpoints.
+  Python testing patterns with pytest: fixtures, mocking, API testing, factories, parametrize, and async test strategies.
+  Trigger: When writing tests, configuring pytest, mocking dependencies, or testing FastAPI endpoints.
+globs:
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/tests/**"
+  - "**/conftest.py"
+  - "**/pytest.ini"
+  - "**/pyproject.toml"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,20 +17,38 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Escribes tests con pytest
-- Necesitas mockear servicios o dependencias externas
-- Testeas endpoints de FastAPI/Flask
-- Configuras fixtures y factories
+- Writing tests with pytest
+- Mocking services or external dependencies
+- Testing FastAPI endpoints
+- Configuring fixtures, factories, or conftest.py
+- Setting up async tests with anyio or pytest-asyncio
+- Managing test databases with transaction rollback
+- Writing parametrized or property-based tests
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Fixtures para setup reutilizable
+### Pattern 1: conftest.py organization
+
+Keep conftest.py files scoped to their directory. Place shared fixtures in the root `tests/conftest.py` and domain-specific fixtures in subdirectories.
+
+```
+tests/
+├── conftest.py              # shared: app, client, db, settings overrides
+├── users/
+│   ├── conftest.py          # user-specific: sample_user, user_factory
+│   ├── test_router.py
+│   └── test_service.py
+├── products/
+│   ├── conftest.py
+│   └── test_router.py
+```
 
 ```python
+# tests/conftest.py — shared fixtures
 import pytest
 from httpx import AsyncClient, ASGITransport
 from main import create_app
@@ -38,17 +63,45 @@ async def client(app):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
+```
 
+```python
+# ❌ BAD — one massive conftest.py with 50 fixtures for all domains
+# ✅ GOOD — split conftest.py per domain, share only cross-cutting fixtures at root
+```
+
+### Pattern 2: Fixtures for reusable setup
+
+```python
 @pytest.fixture
 def sample_user() -> dict:
     return {
         "email": "test@example.com",
-        "password": "secure123",
+        "password": "secure12345",
         "name": "Test User",
     }
+
+@pytest.fixture
+async def created_user(client: AsyncClient, sample_user: dict) -> dict:
+    """Create a user and return the response data."""
+    response = await client.post("/api/users", json=sample_user)
+    assert response.status_code == 201
+    return response.json()
 ```
 
-### Pattern 2: Test de endpoint completo
+```python
+# ❌ BAD — repeating setup in every test
+async def test_get_user(client):
+    await client.post("/api/users", json={"email": "a@b.com", ...})
+    await client.post("/api/users", json={"email": "a@b.com", ...})  # duplicated
+
+# ✅ GOOD — use fixtures for setup, tests stay focused on assertions
+async def test_get_user(client, created_user):
+    response = await client.get(f"/api/users/{created_user['id']}")
+    assert response.status_code == 200
+```
+
+### Pattern 3: Full endpoint test
 
 ```python
 import pytest
@@ -61,7 +114,7 @@ async def test_create_user_returns_201(client: AsyncClient, sample_user: dict):
     data = response.json()
     assert data["email"] == sample_user["email"]
     assert "id" in data
-    assert "password" not in data  # nunca exponer el password
+    assert "password" not in data  # never expose the password
 
 @pytest.mark.anyio
 async def test_create_user_duplicate_returns_409(client: AsyncClient, sample_user: dict):
@@ -71,7 +124,7 @@ async def test_create_user_duplicate_returns_409(client: AsyncClient, sample_use
     assert response.status_code == 409
 ```
 
-### Pattern 3: Mocking con dependency override
+### Pattern 4: Mocking with dependency overrides
 
 ```python
 from unittest.mock import AsyncMock
@@ -90,7 +143,17 @@ def app_with_mocks(mock_user_service):
     app.dependency_overrides.clear()
 ```
 
-### Pattern 4: Arrange-Act-Assert
+```python
+# ❌ BAD — patching internal imports instead of using DI
+@patch("users.service.UserRepository")
+async def test_register(mock_repo):
+    ...  # fragile, breaks on refactor
+
+# ✅ GOOD — override the dependency via FastAPI's DI system
+app.dependency_overrides[UserService] = lambda: mock_service
+```
+
+### Pattern 5: Arrange-Act-Assert (AAA)
 
 ```python
 async def test_get_user_raises_not_found():
@@ -104,35 +167,350 @@ async def test_get_user_raises_not_found():
         await service.get_by_id("nonexistent")
 ```
 
+```python
+# ❌ BAD — test does setup, action, and assertion all interleaved
+async def test_something(client):
+    user = await client.post("/users", json=data)
+    assert user.status_code == 201
+    updated = await client.patch(f"/users/{user.json()['id']}", json={"name": "New"})
+    assert updated.status_code == 200
+    deleted = await client.delete(f"/users/{user.json()['id']}")
+    assert deleted.status_code == 204
+    # This is testing 3 different things in one test
+
+# ✅ GOOD — one test, one behavior, clear AAA sections
+async def test_update_user_name(client, created_user):
+    # Arrange — done by fixture
+
+    # Act
+    response = await client.patch(
+        f"/api/users/{created_user['id']}",
+        json={"name": "Updated Name"},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["name"] == "Updated Name"
+```
+
+### Pattern 6: Parametrize for multiple cases
+
+```python
+import pytest
+
+@pytest.mark.parametrize("invalid_email", [
+    "",
+    "not-an-email",
+    "@missing-local.com",
+    "missing-domain@",
+])
+@pytest.mark.anyio
+async def test_create_user_rejects_invalid_email(client: AsyncClient, invalid_email: str):
+    response = await client.post("/api/users", json={
+        "email": invalid_email,
+        "password": "secure12345",
+        "name": "Test",
+    })
+    assert response.status_code == 422
+
+@pytest.mark.parametrize("password,expected_status", [
+    ("short", 422),         # too short
+    ("a" * 8, 201),         # minimum valid
+    ("a" * 128, 201),       # long but valid
+])
+@pytest.mark.anyio
+async def test_create_user_password_validation(client, password, expected_status):
+    response = await client.post("/api/users", json={
+        "email": "valid@example.com",
+        "password": password,
+        "name": "Test",
+    })
+    assert response.status_code == expected_status
+```
+
+### Pattern 7: Test data factories with polyfactory
+
+```python
+from polyfactory.factories.pydantic_factory import ModelFactory
+from users.schemas import CreateUserRequest, UserResponse
+
+class UserRequestFactory(ModelFactory):
+    __model__ = CreateUserRequest
+
+class UserResponseFactory(ModelFactory):
+    __model__ = UserResponse
+
+# Usage in tests
+def test_user_factory():
+    user = UserRequestFactory.build()
+    assert user.email  # random valid email
+    assert len(user.password) >= 8
+
+    # Override specific fields
+    custom = UserRequestFactory.build(name="Alice")
+    assert custom.name == "Alice"
+
+    # Generate a batch
+    users = UserRequestFactory.batch(size=10)
+    assert len(users) == 10
+```
+
+```python
+# ❌ BAD — hardcoded test data everywhere
+def test_a():
+    user = {"email": "a@b.com", "password": "12345678", "name": "Test"}
+
+def test_b():
+    user = {"email": "a@b.com", "password": "12345678", "name": "Test"}  # duplicated
+
+# ✅ GOOD — factories generate valid data, override only what matters
+def test_a():
+    user = UserRequestFactory.build()
+
+def test_b():
+    user = UserRequestFactory.build(email="specific@test.com")
+```
+
+### Pattern 8: Async test configuration
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"  # or use markers: @pytest.mark.anyio
+testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+```
+
+```python
+# With anyio (recommended — works with both asyncio and trio)
+import pytest
+
+@pytest.mark.anyio
+async def test_async_operation():
+    result = await some_async_function()
+    assert result is not None
+
+# With pytest-asyncio
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_operation():
+    result = await some_async_function()
+    assert result is not None
+```
+
+### Pattern 9: Test database with transaction rollback
+
+```python
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+@pytest.fixture
+async def db_session(app) -> AsyncGenerator[AsyncSession, None]:
+    """Each test runs in a transaction that is rolled back after."""
+    async with app.state.db_engine.begin() as conn:
+        session = AsyncSession(bind=conn)
+        yield session
+        await session.rollback()
+
+@pytest.fixture
+async def client(app, db_session):
+    """Override the db dependency so all requests use the test transaction."""
+    app.dependency_overrides[get_db] = lambda: db_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+```
+
+```python
+# ❌ BAD — tests leave data behind, causing flaky failures
+@pytest.fixture
+async def db_session():
+    session = async_session_factory()
+    yield session
+    await session.close()  # data persists!
+
+# ✅ GOOD — wrap in transaction, rollback after each test
+@pytest.fixture
+async def db_session():
+    async with engine.begin() as conn:
+        session = AsyncSession(bind=conn)
+        yield session
+        await session.rollback()
+```
+
+### Pattern 10: monkeypatch patterns
+
+```python
+def test_external_api_failure(monkeypatch):
+    """Simulate an external API being down."""
+    async def mock_fetch(*args, **kwargs):
+        raise ConnectionError("Service unavailable")
+
+    monkeypatch.setattr("users.service.fetch_external_profile", mock_fetch)
+
+    with pytest.raises(ServiceUnavailableError):
+        await service.enrich_profile("user-123")
+
+def test_settings_override(monkeypatch):
+    """Override environment variable for a single test."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///test.db")
+    settings = Settings()
+    assert "test.db" in settings.database_url
+```
+
+```python
+# ❌ BAD — modifying global state without cleanup
+import mymodule
+original = mymodule.API_KEY
+mymodule.API_KEY = "test-key"
+# ... test ...
+mymodule.API_KEY = original  # easy to forget
+
+# ✅ GOOD — monkeypatch auto-reverts after test
+def test_with_api_key(monkeypatch):
+    monkeypatch.setattr("mymodule.API_KEY", "test-key")
+    # automatically reverted after test
+```
+
+### Pattern 11: Coverage configuration
+
+```toml
+# pyproject.toml
+[tool.coverage.run]
+source = ["src"]
+omit = ["*/tests/*", "*/migrations/*"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.",
+]
+```
+
+### Pattern 12: Property-based testing with Hypothesis
+
+```python
+from hypothesis import given, strategies as st
+
+@given(name=st.text(min_size=2, max_size=100))
+def test_user_name_round_trips(name: str):
+    """Any valid name should be accepted and returned unchanged."""
+    request = CreateUserRequest(
+        email="test@example.com",
+        password="secure12345",
+        name=name,
+    )
+    assert request.name == name
+
+@given(password=st.text(max_size=7))
+def test_short_password_rejected(password: str):
+    """Passwords under 8 chars should always fail validation."""
+    with pytest.raises(ValidationError):
+        CreateUserRequest(
+            email="test@example.com",
+            password=password,
+            name="Test",
+        )
+```
+
+### Pattern 13: Testing background tasks
+
+```python
+from unittest.mock import patch, AsyncMock
+
+@pytest.mark.anyio
+async def test_welcome_email_sent_after_registration(client, sample_user):
+    with patch("users.router.send_welcome_email", new_callable=AsyncMock) as mock_email:
+        response = await client.post("/api/users", json=sample_user)
+
+        assert response.status_code == 201
+        mock_email.assert_called_once_with(sample_user["email"])
+```
+
 ---
 
 ## Anti-Patterns
 
-### Don't: Tests que dependen de orden de ejecución
+### Don't: Tests that depend on execution order
 
 ```python
-# ❌ MAL — test_b depende de que test_a haya corrido antes
+# ❌ BAD — test_b depends on test_a having run first
+created_id = None
+
 def test_a():
     global created_id
     created_id = create_user()
 
 def test_b():
-    user = get_user(created_id)  # falla si test_a no corrió
+    user = get_user(created_id)  # fails if test_a didn't run
 
-# ✅ BIEN — cada test es independiente
-def test_get_user(client, sample_user):
-    create_response = client.post("/users", json=sample_user)
+# ✅ GOOD — each test is independent
+async def test_get_user(client, sample_user):
+    create_response = await client.post("/users", json=sample_user)
     user_id = create_response.json()["id"]
-    response = client.get(f"/users/{user_id}")
+    response = await client.get(f"/users/{user_id}")
     assert response.status_code == 200
+```
+
+### Don't: Test implementation details
+
+```python
+# ❌ BAD — asserting on internal method calls
+async def test_register_calls_hash(mock_repo):
+    await service.register(dto)
+    mock_repo._internal_hash.assert_called_once()  # fragile
+
+# ✅ GOOD — assert on observable behavior
+async def test_register_creates_user(client, sample_user):
+    response = await client.post("/api/users", json=sample_user)
+    assert response.status_code == 201
+    assert response.json()["email"] == sample_user["email"]
+```
+
+### Don't: Ignore test isolation
+
+```python
+# ❌ BAD — shared mutable state between tests
+cache = {}
+
+def test_a():
+    cache["key"] = "value"
+
+def test_b():
+    assert cache.get("key") is None  # FAILS — polluted by test_a
+
+# ✅ GOOD — use fixtures that reset state
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
 ```
 
 ---
 
 ## Quick Reference
 
-| Tipo            | Qué testea                       | Velocidad | Fixture          |
-| --------------- | -------------------------------- | --------- | ---------------- |
-| Unit test       | Función/clase aislada            | Rápido    | Mocks            |
-| Integration     | Endpoint + DB                    | Medio     | Test DB + client |
-| E2E             | Flujo completo                   | Lento     | App real         |
+| Type            | What it tests                    | Speed  | Fixture                |
+| --------------- | -------------------------------- | ------ | ---------------------- |
+| Unit test       | Isolated function/class          | Fast   | Mocks                  |
+| Integration     | Endpoint + DB                    | Medium | Test DB + client       |
+| E2E             | Full flow                        | Slow   | Real app               |
+| Property-based  | Invariants over random input     | Medium | Hypothesis strategies  |
+
+| Tool            | Purpose                          | When to use                          |
+| --------------- | -------------------------------- | ------------------------------------ |
+| `monkeypatch`   | Override attrs/env vars          | External config, globals             |
+| `dependency_overrides` | Replace FastAPI deps      | Service/repo mocking in integration  |
+| `AsyncMock`     | Mock async callables             | Async services and repos             |
+| `polyfactory`   | Generate valid test data         | When you need varied realistic data  |
+| `parametrize`   | Run same test with many inputs   | Validation, edge cases               |
+| `hypothesis`    | Property-based random testing    | Invariants, serialization roundtrips |

--- a/skills/shared/architecture/SKILL.md
+++ b/skills/shared/architecture/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: architecture
 description: >
-  Clean Architecture y estructura feature-based para proyectos TypeScript.
-  Trigger: Al diseñar la estructura de una feature, al definir módulos, al revisar dependencias entre capas.
+  Clean Architecture and feature-based structure for any language or framework.
+  Trigger: When designing feature structure, defining modules, reviewing layer dependencies, or organizing code.
+globs:
+  - "src/**"
+  - "app/**"
+  - "internal/**"
+  - "pkg/**"
+  - "lib/**"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,12 +16,13 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Diseñas o revisas la estructura de un feature o módulo
-- Analizas dependencias entre capas (ui → domain → data)
-- Detectas o corregías cross-feature imports
-- Defines dónde va un nuevo componente, hook, servicio o adapter
+- Designing or reviewing the structure of a feature or module
+- Analyzing dependencies between layers (UI → Domain → Data)
+- Detecting or fixing cross-feature imports
+- Deciding where a new component, service, handler, or adapter belongs
+- Setting up a new project or microservice structure
 
 ---
 
@@ -23,85 +30,216 @@ Carga este skill cuando:
 
 ### Pattern 1: Scope Rule — Global vs Local
 
-Un componente/función es **global** si es usado por 2+ features.  
-Un componente/función es **local** si es usado por 1 sola feature.
+A component/function is **global** if used by 2+ features.
+A component/function is **local** if used by 1 feature only.
 
 ```
-shared/          ← global (2+ features lo usan)
-  components/Button.tsx
-  hooks/useDebounce.ts
+shared/              ← global (used by 2+ features)
+  utils/
+  contracts/
 
 features/
-  auth/          ← local a auth
-    components/LoginForm.tsx
-    hooks/useAuth.ts
-    services/authService.ts
+  auth/              ← local to auth
+    handlers/
+    services/
+    repository/
+  checkout/          ← local to checkout
+    handlers/
+    services/
+    repository/
 ```
 
 ### Pattern 2: No Cross-Feature Imports
 
+Features must NEVER import directly from other features.
+
 ```typescript
-// ❌ MAL — auth importa directo de dashboard
+// ❌ BAD — auth imports directly from dashboard
 import { DashboardLayout } from "../dashboard/components/DashboardLayout";
 
-// ✅ BIEN — usa el shared/ global o comunicación vía props/context
+// ✅ GOOD — use shared module or communicate via contracts
 import { DashboardLayout } from "@/shared/layouts/DashboardLayout";
 ```
 
-### Pattern 3: La estructura grita la funcionalidad
+```python
+# ❌ BAD — orders imports directly from users feature
+from features.users.services import get_user_profile
+
+# ✅ GOOD — use shared contract or dependency injection
+from shared.contracts import UserService
+```
+
+```java
+// ❌ BAD — checkout package imports from inventory internals
+import com.app.features.inventory.internal.StockCalculator;
+
+// ✅ GOOD — depend on the public API of inventory
+import com.app.features.inventory.api.InventoryService;
+```
+
+```go
+// ❌ BAD — orders package imports billing internals
+import "myapp/features/billing/internal/calculator"
+
+// ✅ GOOD — import the public package
+import "myapp/features/billing"
+```
+
+### Pattern 3: Screaming Architecture — Structure Reveals Intent
+
+The folder structure should scream what the application DOES, not what framework it uses.
 
 ```
+# ❌ BAD — screams "framework"
+controllers/
+models/
+views/
+helpers/
+
+# ✅ GOOD — screams "business domain"
 features/
-  checkout/          ← el nombre dice TODO
-    components/
-      CheckoutForm.tsx
-      OrderSummary.tsx
-    hooks/
-      useCheckout.ts
+  checkout/
+    handlers/
     services/
-      checkoutService.ts
-    index.ts         ← barrel export (API pública de la feature)
+    repository/
+    models/
+  auth/
+    handlers/
+    services/
+    repository/
+    models/
 ```
 
-### Pattern 4: Capas y dirección de dependencias
+### Pattern 4: Layers and Dependency Direction
 
 ```
-UI Layer          → Domain Layer → Data Layer
-components/        services/        repositories/
-hooks/             entities/        adapters/
-pages/
+UI / Handlers Layer  →  Domain Layer  →  Data Layer
+  controllers/           services/        repositories/
+  handlers/              entities/        adapters/
+  views/                 use_cases/       gateways/
 
-Regla: Las capas externas NUNCA importan las internas directamente.
-Las capas internas (domain) no saben nada de UI ni Data.
+Rule: Outer layers depend on inner layers. NEVER the reverse.
+Domain layer knows NOTHING about UI, HTTP, databases, or frameworks.
 ```
 
----
+```python
+# ❌ BAD — domain layer depends on Flask (framework)
+class OrderService:
+    def create_order(self, request: flask.Request):
+        ...
 
-## Code Examples
+# ✅ GOOD — domain layer uses plain data structures
+class OrderService:
+    def create_order(self, items: list[OrderItem], customer_id: str) -> Order:
+        ...
+```
 
-### Barrel Export (index.ts por feature)
+```java
+// ❌ BAD — domain depends on Spring annotations
+public class InvoiceService {
+    @Autowired private JdbcTemplate db;
+    public Invoice create(HttpServletRequest req) { ... }
+}
+
+// ✅ GOOD — domain depends on abstractions only
+public class InvoiceService {
+    private final InvoiceRepository repository;
+    public InvoiceService(InvoiceRepository repository) {
+        this.repository = repository;
+    }
+    public Invoice create(CreateInvoiceCommand cmd) { ... }
+}
+```
+
+### Pattern 5: Barrel Exports — Public API per Feature
+
+Each feature exposes a public API. Internal details are hidden.
 
 ```typescript
 // features/auth/index.ts
 export { LoginForm } from "./components/LoginForm";
 export { useAuth } from "./hooks/useAuth";
 export type { AuthUser } from "./types";
-// No exportar implementaciones internas
+// Do NOT export internal implementations
 ```
 
-### Clean Adapter
+```python
+# features/auth/__init__.py
+from .services import AuthService
+from .models import AuthUser
+# Do NOT expose internal repository implementations
+```
+
+```go
+// features/auth/auth.go — exported functions are the public API
+package auth
+
+func NewService(repo UserRepository) *Service { ... }
+func (s *Service) Authenticate(email, password string) (*User, error) { ... }
+// unexported helpers stay private automatically
+```
+
+### Pattern 6: Clean Adapter Pattern
+
+Adapters implement contracts defined by the domain. The domain never knows the concrete implementation.
 
 ```typescript
-// adapters/api-client/index.ts
-import type { ApiClient } from "../../core/contracts/api-client.contract";
+// core/contracts/storage.contract.ts
+export interface StorageAdapter {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
 
-export class FetchApiClient implements ApiClient {
-  constructor(private readonly baseUrl: string) {}
-
-  async get<T>(path: string): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`);
-    return response.json();
+// adapters/redis-storage.ts
+export class RedisStorageAdapter implements StorageAdapter {
+  constructor(private readonly client: RedisClient) {}
+  async get(key: string): Promise<string | null> {
+    return this.client.get(key);
   }
+  async set(key: string, value: string): Promise<void> {
+    await this.client.set(key, value);
+  }
+}
+```
+
+```python
+# core/contracts.py
+from abc import ABC, abstractmethod
+
+class StorageAdapter(ABC):
+    @abstractmethod
+    def get(self, key: str) -> str | None: ...
+    @abstractmethod
+    def set(self, key: str, value: str) -> None: ...
+
+# adapters/redis_storage.py
+class RedisStorageAdapter(StorageAdapter):
+    def __init__(self, client):
+        self._client = client
+    def get(self, key: str) -> str | None:
+        return self._client.get(key)
+    def set(self, key: str, value: str) -> None:
+        self._client.set(key, value)
+```
+
+```go
+// core/contracts.go
+type StorageAdapter interface {
+    Get(key string) (string, error)
+    Set(key string, value string) error
+}
+
+// adapters/redis.go
+type RedisStorage struct {
+    client *redis.Client
+}
+
+func (r *RedisStorage) Get(key string) (string, error) {
+    return r.client.Get(ctx, key).Result()
+}
+
+func (r *RedisStorage) Set(key string, value string) error {
+    return r.client.Set(ctx, key, value, 0).Err()
 }
 ```
 
@@ -109,32 +247,79 @@ export class FetchApiClient implements ApiClient {
 
 ## Anti-Patterns
 
-### Don't: Lógica de negocio en componentes UI
+### Don't: Business Logic in UI/Handler Layer
 
 ```typescript
-// ❌ MAL
-function ProductCard({ productId }: { productId: string }) {
-    const [product, setProduct] = useState(null)
-    useEffect(() => {
-        fetch(`/api/products/${productId}`).then(r => r.json()).then(setProduct)
-    }, [productId])
-    const discount = product ? product.price * 0.15 : 0  // ← lógica de negocio aquí
-    return <div>{discount}</div>
+// ❌ BAD — discount calculation in a UI component
+function ProductCard({ product }) {
+  const discount = product.price * 0.15; // business logic here
+  return <div>{discount}</div>;
 }
 
-// ✅ BIEN
-function ProductCard({ product }: { product: Product }) {
-    return <div>{product.discountedPrice}</div>  // ← solo presentación
+// ✅ GOOD — UI only presents
+function ProductCard({ product }) {
+  return <div>{product.discountedPrice}</div>;
 }
+```
+
+```python
+# ❌ BAD — business logic in HTTP handler
+@app.route("/orders", methods=["POST"])
+def create_order():
+    total = sum(item["price"] * item["qty"] for item in request.json["items"])
+    tax = total * 0.21
+    # ... 50 more lines of business logic
+    return jsonify({"total": total + tax})
+
+# ✅ GOOD — handler delegates to domain service
+@app.route("/orders", methods=["POST"])
+def create_order():
+    cmd = CreateOrderCommand.from_dict(request.json)
+    order = order_service.create(cmd)
+    return jsonify(order.to_dict())
+```
+
+### Don't: Framework Lock-in in Domain
+
+```java
+// ❌ BAD — domain entity tied to JPA
+@Entity @Table(name = "users")
+public class User {
+    @Id @GeneratedValue private Long id;
+    @Column private String name;
+}
+
+// ✅ GOOD — plain domain entity + separate persistence mapping
+public class User {
+    private final String id;
+    private final String name;
+    public User(String id, String name) { ... }
+}
+// JPA mapping lives in the data layer, not in domain
+```
+
+### Don't: God Modules
+
+```
+# ❌ BAD — one file/module does everything
+utils.py (2000 lines: auth, email, payments, formatting, logging)
+
+# ✅ GOOD — cohesive, focused modules
+auth/service.py
+email/sender.py
+payments/gateway.py
+formatting/currency.py
 ```
 
 ---
 
 ## Quick Reference
 
-| Pregunta                                    | Regla                                              |
-| ------------------------------------------- | -------------------------------------------------- |
-| ¿Este componente va en shared/ o features/? | 1 feature → local; 2+ features → global            |
-| ¿Puedo importar desde otra feature?         | No — usa shared/ o comunica vía props              |
-| ¿Dónde va la lógica de negocio?             | En services/ o domain/ never en components/        |
-| ¿Qué exporta un barrel?                     | Solo la API pública — no implementaciones internas |
+| Question                                 | Rule                                                |
+| ---------------------------------------- | --------------------------------------------------- |
+| Does this belong in shared/ or features/? | 1 feature → local; 2+ features → shared            |
+| Can I import from another feature?       | No — use shared/ or communicate via contracts       |
+| Where does business logic go?            | In services/ or domain/ — NEVER in handlers or UI   |
+| What should a barrel export expose?      | Only the public API — never internal implementations |
+| Can domain depend on a framework?        | No — domain depends only on abstractions            |
+| When to create an abstraction?           | After 2+ concrete use cases — not before            |

--- a/skills/shared/code-quality/SKILL.md
+++ b/skills/shared/code-quality/SKILL.md
@@ -1,8 +1,19 @@
 ---
 name: code-quality
 description: >
-  Patrones de calidad de código TypeScript: naming, funciones puras, tipos y convenciones.
-  Trigger: Al escribir o revisar TypeScript/JavaScript, al hacer code review, refactoring.
+  Code quality patterns: naming, pure functions, type safety, contracts, and conventions for any language.
+  Trigger: When writing or reviewing code, during code review, refactoring, or defining conventions.
+globs:
+  - "src/**"
+  - "app/**"
+  - "internal/**"
+  - "pkg/**"
+  - "lib/**"
+  - "**/*.ts"
+  - "**/*.py"
+  - "**/*.java"
+  - "**/*.go"
+  - "**/*.cs"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,61 +21,120 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Escribes o revisas TypeScript
-- Haces code review o refactoring
-- Defines nombres de variables, funciones o clases
-- Identificas efectos secundarios ocultos
+- Writing or reviewing code in any language
+- Doing code review or refactoring
+- Naming variables, functions, classes, or modules
+- Identifying hidden side effects
+- Defining or enforcing coding conventions
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Nombres que documentan
+### Pattern 1: Names That Document
+
+Names should reveal intent. If a name requires a comment, the name is wrong.
 
 ```typescript
-// ❌ MAL
-const d = new Date()
-const fn = (x: string) => x.split(' ')
+// ❌ BAD
+const d = new Date();
+const fn = (x: string) => x.split(" ");
 function doStuff(data: any) { ... }
 
-// ✅ BIEN
-const createdAt = new Date()
-const splitBySpace = (text: string) => text.split(' ')
+// ✅ GOOD
+const createdAt = new Date();
+const splitBySpace = (text: string) => text.split(" ");
 function parseUserInput(rawInput: string): ParsedInput { ... }
 ```
 
-### Pattern 2: Sin `any` — tipos explícitos siempre
+```python
+# ❌ BAD
+def proc(d, f):
+    return [f(x) for x in d if x]
+
+# ✅ GOOD
+def filter_and_transform(items: list[Item], transform: Callable[[Item], Result]) -> list[Result]:
+    return [transform(item) for item in items if item.is_active]
+```
+
+```java
+// ❌ BAD
+List<String> list1 = getList();
+void handle(Object o) { ... }
+
+// ✅ GOOD
+List<String> activeUserEmails = getActiveUserEmails();
+void processPayment(PaymentRequest request) { ... }
+```
+
+```go
+// ❌ BAD
+func do(s string) string { ... }
+
+// ✅ GOOD
+func sanitizeHTML(raw string) string { ... }
+```
+
+### Pattern 2: No Untyped Data — Explicit Types Always
+
+Every language has a way to express types or contracts. Use them.
 
 ```typescript
-// ❌ MAL
+// ❌ BAD
 function processData(data: any): any { ... }
 
-// ✅ BIEN
+// ✅ GOOD
 function processData(data: UserInput): ProcessedResult { ... }
 
-// ✅ Si el tipo es complejo, usa unknown + type guard
+// ✅ When type is unknown at compile time, use guards
 function processData(data: unknown): ProcessedResult {
-    if (!isUserInput(data)) throw new TypeError('...')
-    // ahora TypeScript sabe que es UserInput
+  if (!isUserInput(data)) throw new TypeError("Invalid input");
+  // TypeScript now knows it's UserInput
 }
 ```
 
-### Pattern 3: Funciones pequeñas y puras
+```python
+# ❌ BAD
+def calculate_total(items):
+    return sum(i["price"] for i in items)
 
-Una función hace UNA cosa. Sin efectos secundarios ocultos.
+# ✅ GOOD
+def calculate_total(items: list[LineItem]) -> Decimal:
+    return sum(item.price for item in items)
+```
+
+```java
+// ❌ BAD
+public Object process(Map data) { ... }
+
+// ✅ GOOD
+public InvoiceResult process(InvoiceRequest request) { ... }
+```
+
+```go
+// ❌ BAD
+func process(data interface{}) interface{} { ... }
+
+// ✅ GOOD
+func process(data InvoiceRequest) (InvoiceResult, error) { ... }
+```
+
+### Pattern 3: Small, Pure Functions
+
+A function does ONE thing. No hidden side effects. Easy to test.
 
 ```typescript
-// ❌ MAL — hace 3 cosas: valida, transforma y guarda
+// ❌ BAD — does 3 things: validates, transforms, and saves
 function handleUserData(raw: string) {
   const valid = raw.length > 0;
   const user = JSON.parse(raw);
   db.save(user);
 }
 
-// ✅ BIEN — separadas y testeables
-function validateRawUser(raw: string): boolean {
+// ✅ GOOD — separated and testable
+function isValidInput(raw: string): boolean {
   return raw.length > 0;
 }
 function parseUser(raw: string): User {
@@ -75,46 +145,254 @@ async function saveUser(user: User): Promise<void> {
 }
 ```
 
-### Pattern 4: Contratos primero (interfaces antes que implementaciones)
+```python
+# ❌ BAD — validates, parses, emails, and logs all in one
+def register_user(form_data):
+    if not form_data.get("email"):
+        raise ValueError("no email")
+    user = User(email=form_data["email"], name=form_data["name"])
+    db.session.add(user)
+    db.session.commit()
+    send_welcome_email(user.email)
+    logger.info(f"User {user.id} registered")
+    return user
+
+# ✅ GOOD — each step is a separate, testable function
+def validate_registration(form_data: dict) -> RegistrationInput:
+    ...
+
+def create_user(input: RegistrationInput) -> User:
+    ...
+
+def send_welcome_email(email: str) -> None:
+    ...
+```
+
+```go
+// ❌ BAD — does validation + business logic + persistence
+func CreateOrder(w http.ResponseWriter, r *http.Request) {
+    var req OrderRequest
+    json.NewDecoder(r.Body).Decode(&req)
+    if req.Total <= 0 { http.Error(w, "bad total", 400); return }
+    tax := req.Total * 0.21
+    db.Exec("INSERT INTO orders ...")
+    json.NewEncoder(w).Encode(map[string]float64{"total": req.Total + tax})
+}
+
+// ✅ GOOD — handler delegates to focused functions
+func (h *OrderHandler) Create(w http.ResponseWriter, r *http.Request) {
+    req, err := decodeOrderRequest(r)
+    if err != nil { respondError(w, http.StatusBadRequest, err); return }
+    order, err := h.service.CreateOrder(req)
+    if err != nil { respondError(w, http.StatusInternalServerError, err); return }
+    respondJSON(w, http.StatusCreated, order)
+}
+```
+
+### Pattern 4: Contracts First — Interfaces Before Implementations
+
+Define what you need BEFORE deciding how to build it.
 
 ```typescript
-// Primero el contrato
+// First the contract
 export interface StorageAdapter {
-    get(key: string): Promise<string | null>
-    set(key: string, value: string): Promise<void>
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
 }
 
-// Luego la implementación
+// Then the implementation
 export class LocalStorageAdapter implements StorageAdapter {
-    async get(key: string): Promise<string | null> { ... }
-    async set(key: string, value: string): Promise<void> { ... }
+  async get(key: string): Promise<string | null> { ... }
+  async set(key: string, value: string): Promise<void> { ... }
 }
+```
+
+```python
+# First the contract
+from abc import ABC, abstractmethod
+
+class NotificationSender(ABC):
+    @abstractmethod
+    def send(self, recipient: str, message: str) -> None: ...
+
+# Then the implementation
+class EmailSender(NotificationSender):
+    def send(self, recipient: str, message: str) -> None:
+        self._smtp_client.send_email(to=recipient, body=message)
+```
+
+```java
+// First the contract
+public interface PaymentGateway {
+    PaymentResult charge(Money amount, PaymentMethod method);
+}
+
+// Then the implementation
+public class StripeGateway implements PaymentGateway {
+    @Override
+    public PaymentResult charge(Money amount, PaymentMethod method) { ... }
+}
+```
+
+```go
+// First the contract
+type Logger interface {
+    Info(msg string, fields ...Field)
+    Error(msg string, err error, fields ...Field)
+}
+
+// Then the implementation
+type ZapLogger struct { logger *zap.Logger }
+
+func (z *ZapLogger) Info(msg string, fields ...Field) { ... }
+func (z *ZapLogger) Error(msg string, err error, fields ...Field) { ... }
+```
+
+### Pattern 5: Guard Clauses — Early Returns Over Deep Nesting
+
+```python
+# ❌ BAD — deep nesting
+def process_order(order):
+    if order is not None:
+        if order.is_valid():
+            if order.has_items():
+                return calculate_total(order)
+            else:
+                raise ValueError("No items")
+        else:
+            raise ValueError("Invalid order")
+    else:
+        raise ValueError("No order")
+
+# ✅ GOOD — guard clauses with early returns
+def process_order(order):
+    if order is None:
+        raise ValueError("No order")
+    if not order.is_valid():
+        raise ValueError("Invalid order")
+    if not order.has_items():
+        raise ValueError("No items")
+    return calculate_total(order)
+```
+
+```go
+// ❌ BAD
+func getUser(id string) (*User, error) {
+    if id != "" {
+        user, err := db.Find(id)
+        if err == nil {
+            if user != nil {
+                return user, nil
+            }
+        }
+        return nil, err
+    }
+    return nil, errors.New("empty id")
+}
+
+// ✅ GOOD
+func getUser(id string) (*User, error) {
+    if id == "" {
+        return nil, errors.New("empty id")
+    }
+    user, err := db.Find(id)
+    if err != nil {
+        return nil, fmt.Errorf("finding user %s: %w", id, err)
+    }
+    if user == nil {
+        return nil, ErrNotFound
+    }
+    return user, nil
+}
+```
+
+### Pattern 6: Don't Repeat Yourself — But Don't Abstract Prematurely Either
+
+```typescript
+// ❌ BAD — same validation in 3 places
+if (text.length > 0 && text.trim() !== "") { ... }
+
+// ✅ GOOD — extract once
+function isNonEmpty(text: string): boolean {
+  return text.length > 0 && text.trim() !== "";
+}
+```
+
+```python
+# ❌ BAD — premature abstraction with 1 use case
+class BaseRepository(Generic[T]):
+    def find_by_id(self, id: str) -> T: ...
+    def find_all(self) -> list[T]: ...
+    def save(self, entity: T) -> None: ...
+    def delete(self, id: str) -> None: ...
+
+# ✅ GOOD — just implement what you need now
+class UserRepository:
+    def find_by_email(self, email: str) -> User | None: ...
+    def save(self, user: User) -> None: ...
+# Extract a base class only when you have 2+ repositories with shared behavior
 ```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: Non-null assertions sin contexto
+### Don't: Non-null Assertions Without Context
 
 ```typescript
-// ❌ MAL
+// ❌ BAD
 const value = map.get(key)!;
 
-// ✅ BIEN
+// ✅ GOOD
 const value = map.get(key);
 if (!value) throw new Error(`Key not found: ${key}`);
 ```
 
-### Don't: Duplicar lógica
+### Don't: Swallow Errors Silently
 
-```typescript
-// ❌ MAL — misma validación en 3 lugares
-if (text.length > 0 && text.trim() !== '') { ... }
+```python
+# ❌ BAD
+try:
+    process_payment()
+except Exception:
+    pass  # total silence
 
-// ✅ BIEN — extraer una vez
-function isNonEmpty(text: string): boolean {
-    return text.length > 0 && text.trim() !== ''
+# ✅ GOOD
+try:
+    process_payment()
+except PaymentError as e:
+    logger.error("Payment failed", exc_info=e)
+    raise
+```
+
+### Don't: Boolean Parameters That Change Behavior
+
+```java
+// ❌ BAD — what does `true` mean here?
+generateReport(data, true, false, true);
+
+// ✅ GOOD — use named parameters, enums, or config objects
+generateReport(data, new ReportOptions(
+    includeHeader: true,
+    landscape: false,
+    colorized: true
+));
+```
+
+### Don't: Magic Numbers and Strings
+
+```go
+// ❌ BAD
+if retries > 3 {
+    time.Sleep(5 * time.Second)
+}
+
+// ✅ GOOD
+const maxRetries = 3
+const retryBackoff = 5 * time.Second
+
+if retries > maxRetries {
+    time.Sleep(retryBackoff)
 }
 ```
 
@@ -122,10 +400,14 @@ function isNonEmpty(text: string): boolean {
 
 ## Quick Reference
 
-| Regla                                | Ejemplo                                       |
-| ------------------------------------ | --------------------------------------------- |
-| Sin `any`                            | Usa tipos explícitos o `unknown` + type guard |
-| Nombres descriptivos                 | `createUserSession` no `doStuff`              |
-| Una función = una responsabilidad    | Si tiene "y" en el nombre → separar           |
-| Contratos antes que implementaciones | `interface X` → `class Y implements X`        |
-| No duplicar lógica                   | Extraer a función o utility                   |
+| Rule                                   | Example                                                |
+| -------------------------------------- | ------------------------------------------------------ |
+| No untyped data                        | Use explicit types, `unknown` + guard, or generics     |
+| Descriptive names                      | `createUserSession` not `doStuff`                      |
+| One function = one responsibility      | If the name has "and" → split it                       |
+| Contracts before implementations       | `interface X` → `class Y implements X`                 |
+| Don't repeat logic                     | Extract to a utility function                          |
+| Guard clauses over deep nesting        | Early returns keep code flat and readable              |
+| No magic numbers                       | Define constants with meaningful names                 |
+| No boolean params that change behavior | Use enums, config objects, or separate functions       |
+| Abstract after 2+ concrete cases       | Don't create `Base<T>` for a single use case           |

--- a/skills/shared/debug/SKILL.md
+++ b/skills/shared/debug/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: debug
 description: >
-  Workflow sistemático de debugging: diagnóstico, aislamiento, fix y verificación.
-  Trigger: Al diagnosticar errores, excepciones, comportamiento inesperado o tests que fallan.
+  Systematic debugging workflow: diagnose, isolate, fix, and verify. Language-agnostic.
+  Trigger: When diagnosing errors, exceptions, unexpected behavior, or failing tests.
+globs:
+  - "**/*.test.*"
+  - "**/*_test.*"
+  - "**/*Test.*"
+  - "**/*.spec.*"
+  - "**/*.log"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,57 +16,136 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- Un error aparece en runtime o tests
-- El comportamiento del sistema es inesperado
-- Necesitas aislar la causa raíz antes de proponer el fix
-- Un test falla y no está claro por qué
+- A runtime error or test failure occurs
+- System behavior is unexpected or inconsistent
+- You need to isolate the root cause before proposing a fix
+- A test fails and the reason is not immediately clear
+- Debugging production issues with limited information
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Reproducir antes de fijar
+### Pattern 1: Reproduce Before You Fix
 
-Antes de cambiar cualquier código, **reproduce el error de forma aislada**:
+Before changing ANY code, **reproduce the error in isolation**:
 
-1. ¿El error ocurre siempre o intermitentemente?
-2. ¿Qué input lo provoca?
-3. ¿Qué versión de Node/deps está activa?
+1. Does the error happen consistently or intermittently?
+2. What input triggers it?
+3. What environment/runtime/dependency version is active?
+4. Can you write a failing test that demonstrates it?
 
-### Pattern 2: Narrowing sistemático
+```python
+# ✅ GOOD — write a failing test FIRST
+def test_order_total_with_negative_discount():
+    """Reproduces bug #342: negative discount causes overflow"""
+    order = Order(items=[Item(price=100, qty=1)], discount=-50)
+    # This should raise, but currently returns 150 (the bug)
+    with pytest.raises(ValueError, match="Discount cannot be negative"):
+        order.calculate_total()
+```
+
+```go
+// ✅ GOOD — failing test first
+func TestParseDate_InvalidFormat(t *testing.T) {
+    // Reproduces: panic on malformed date string
+    _, err := ParseDate("not-a-date")
+    if err == nil {
+        t.Fatal("expected error for invalid date format")
+    }
+}
+```
+
+### Pattern 2: Systematic Narrowing
 
 ```
-Error observado
-    └── ¿En qué capa ocurre? (UI / Domain / Data / Infra)
-            └── ¿Qué función exacta falla? (stack trace)
-                    └── ¿Con qué input? (log de parámetros)
-                            └── Causa raíz identificada
+Observed error
+    └── Which layer? (UI / Domain / Data / Infrastructure)
+            └── Which function exactly? (stack trace)
+                    └── With what input? (log parameters)
+                            └── Root cause identified
 ```
 
-### Pattern 3: Fix mínimo — no refactor durante debug
+#### Binary Search Debugging
+
+When you can't find the source, use binary search:
+
+1. Find the last known good state (commit, input, config)
+2. Find the first known bad state
+3. Bisect between them
+
+```bash
+# Git bisect is your friend
+git bisect start
+git bisect bad HEAD
+git bisect good v1.2.0
+# Git will checkout midpoints — test each one
+```
+
+### Pattern 3: Minimal Fix — No Refactoring During Debug
 
 ```
-❌ MAL: "Ya que estoy debuggeando, refactorizo también"
+❌ BAD: "While I'm debugging, let me also refactor this module"
 
-✅ BIEN:
-  1. Fix mínimo que arregla el bug
-  2. Test que verifica el fix
-  3. Commit del fix
-  4. Refactor en PR separado si es necesario
+✅ GOOD:
+  1. Minimal fix that resolves the bug
+  2. Test that verifies the fix
+  3. Commit the fix
+  4. Refactor in a separate PR if needed
+```
+
+### Pattern 4: Read the Error Message — All of It
+
+```
+❌ BAD: "I got a NullPointerException" → immediately starts guessing
+
+✅ GOOD: Read the FULL stack trace:
+  - Which line exactly?
+  - What was null?
+  - What called the method?
+  - Is there a "Caused by" further down the trace?
+```
+
+### Pattern 5: Check the Boundaries First
+
+Most bugs live at boundaries: between modules, between systems, between data formats.
+
+```typescript
+// ❌ BAD — debugging deep inside the algorithm
+// when the real bug is in the INPUT
+
+// ✅ GOOD — log/validate inputs at the boundary first
+function processOrder(raw: unknown): OrderResult {
+  console.log("[processOrder] input:", JSON.stringify(raw));
+  const order = OrderSchema.parse(raw); // fails HERE → input is wrong
+  return calculateResult(order);
+}
+```
+
+```python
+# ✅ GOOD — validate at the boundary
+def handle_webhook(payload: dict) -> None:
+    logger.debug("Webhook payload: %s", payload)
+    # Validate first — most bugs are bad input
+    event = WebhookEvent.model_validate(payload)
+    process_event(event)
 ```
 
 ---
 
 ## Code Examples
 
-### Type-safe error handling
+### Type-Safe Error Handling (TypeScript)
 
 ```typescript
 async function fetchData<T>(url: string, schema: ZodSchema<T>): Promise<T> {
   try {
     const response = await fetch(url);
+    if (!response.ok) {
+      throw new HttpError(response.status, `HTTP ${response.status}: ${url}`);
+    }
     const json = await response.json();
     return schema.parse(json);
   } catch (error) {
@@ -75,13 +160,84 @@ async function fetchData<T>(url: string, schema: ZodSchema<T>): Promise<T> {
 }
 ```
 
-### Structured error logging
+### Structured Error Handling (Python)
 
-```typescript
-function logError(context: string, error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? error.stack : undefined;
-  console.error(`[${context}] ${message}`, stack ? `\n${stack}` : '');
+```python
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class AppError(Exception):
+    message: str
+    context: dict
+    original: Exception | None = None
+
+def fetch_user(user_id: str) -> User:
+    try:
+        response = http_client.get(f"/users/{user_id}")
+        response.raise_for_status()
+        return User.model_validate(response.json())
+    except httpx.HTTPStatusError as e:
+        raise AppError(
+            message=f"Failed to fetch user {user_id}",
+            context={"user_id": user_id, "status": e.response.status_code},
+            original=e,
+        )
+    except ValidationError as e:
+        raise AppError(
+            message=f"Invalid user data for {user_id}",
+            context={"user_id": user_id, "errors": e.errors()},
+            original=e,
+        )
+```
+
+### Error Wrapping (Go)
+
+```go
+func GetUser(ctx context.Context, id string) (*User, error) {
+    row := db.QueryRowContext(ctx, "SELECT id, name FROM users WHERE id = $1", id)
+    var user User
+    if err := row.Scan(&user.ID, &user.Name); err != nil {
+        if errors.Is(err, sql.ErrNoRows) {
+            return nil, fmt.Errorf("user %s not found: %w", id, ErrNotFound)
+        }
+        return nil, fmt.Errorf("querying user %s: %w", id, err)
+    }
+    return &user, nil
+}
+
+// Caller can check specific errors:
+// if errors.Is(err, ErrNotFound) { ... }
+```
+
+### Structured Logging (Java)
+
+```java
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OrderService {
+    private static final Logger log = LoggerFactory.getLogger(OrderService.class);
+
+    public Order createOrder(CreateOrderRequest request) {
+        log.info("Creating order for customer={} items={}",
+            request.getCustomerId(), request.getItems().size());
+        try {
+            Order order = processOrder(request);
+            log.info("Order created orderId={} total={}", order.getId(), order.getTotal());
+            return order;
+        } catch (InsufficientStockException e) {
+            log.warn("Insufficient stock for order customer={} item={}",
+                request.getCustomerId(), e.getItemId());
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected error creating order customer={}",
+                request.getCustomerId(), e);
+            throw e;
+        }
+    }
 }
 ```
 
@@ -89,22 +245,90 @@ function logError(context: string, error: unknown): void {
 
 ## Anti-Patterns
 
-### Don't: Suprimir errores silenciosamente
+### Don't: Swallow Errors Silently
 
 ```typescript
-// ❌ MAL
+// ❌ BAD
 try {
   await riskyOperation();
 } catch {
-  /* silencio total */
+  /* total silence */
 }
 
-// ✅ BIEN
+// ✅ GOOD
 try {
   await riskyOperation();
 } catch (error) {
-  logError('riskyOperation', error);
-  // decidir: re-throw, fallback, o log
+  logger.error("riskyOperation failed", { error });
+  // decide: re-throw, fallback, or notify
+}
+```
+
+```python
+# ❌ BAD
+try:
+    process()
+except Exception:
+    pass
+
+# ✅ GOOD
+try:
+    process()
+except SpecificError as e:
+    logger.warning("Process failed, using fallback", exc_info=e)
+    return fallback_value
+```
+
+### Don't: Log and Throw (Double Handling)
+
+```java
+// ❌ BAD — logs the error AND throws it → duplicate log entries
+try {
+    doSomething();
+} catch (Exception e) {
+    log.error("Failed", e);
+    throw e; // caller will also log it
+}
+
+// ✅ GOOD — either log OR throw, not both
+try {
+    doSomething();
+} catch (Exception e) {
+    throw new ServiceException("Operation failed", e);
+    // let the caller/global handler log it
+}
+```
+
+### Don't: Catch Generic Exceptions
+
+```python
+# ❌ BAD — catches everything including KeyboardInterrupt
+try:
+    process()
+except Exception:
+    return None
+
+# ✅ GOOD — catch specific exceptions
+try:
+    process()
+except (ConnectionError, TimeoutError) as e:
+    logger.warning("Network issue: %s", e)
+    return None
+```
+
+### Don't: Use Print Debugging in Production Code
+
+```go
+// ❌ BAD — fmt.Println left in production code
+func ProcessPayment(amount float64) error {
+    fmt.Println("DEBUG: amount is", amount)
+    // ...
+}
+
+// ✅ GOOD — use structured logging
+func ProcessPayment(amount float64) error {
+    log.Info("processing payment", slog.Float64("amount", amount))
+    // ...
 }
 ```
 
@@ -112,10 +336,15 @@ try {
 
 ## Quick Reference
 
-| Situación                      | Acción                                              |
-| ------------------------------ | --------------------------------------------------- |
-| Error de validación (Zod)      | Schema no matchea → revisar el contrato             |
-| Error de red / timeout         | Verificar URL, CORS, conectividad                   |
-| Test falla intermitentemente   | Race condition → revisar async/await y cleanup       |
-| Error solo en producción       | Verificar env vars, feature flags, datos reales      |
-| Stack trace apunta a node_modules | Versión de dependencia → revisar lockfile          |
+| Situation                          | Action                                               |
+| ---------------------------------- | ---------------------------------------------------- |
+| Validation error                   | Schema mismatch → check the contract/input           |
+| Network error / timeout            | Verify URL, connectivity, DNS, firewall, TLS         |
+| Test fails intermittently          | Race condition → check async, shared state, cleanup  |
+| Error only in production           | Check env vars, feature flags, real data differences |
+| Stack trace points to dependencies | Dependency version mismatch → check lockfile         |
+| Error at system boundary           | Log raw input/output → validate at the edge          |
+| Cannot reproduce locally           | Match environment exactly: OS, runtime, data, config |
+| Null/nil pointer                   | Trace backwards: who should have set this value?     |
+| Off-by-one error                   | Check loop bounds, array indices, pagination offsets |
+| Memory leak                        | Check unclosed resources, growing collections, caches|

--- a/skills/shared/performance/SKILL.md
+++ b/skills/shared/performance/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: performance
 description: >
-  Análisis y optimización de performance: bundle size, rendering, caché y estrategias de optimización.
-  Trigger: Al optimizar bundle, analizar renders innecesarios, mejorar tiempo de respuesta.
+  Performance analysis and optimization patterns: profiling, caching, query optimization, and resource management.
+  Trigger: When optimizing response times, reducing resource usage, fixing N+1 queries, or analyzing bottlenecks.
+globs:
+  - "src/**"
+  - "app/**"
+  - "internal/**"
+  - "**/*.sql"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,95 +15,348 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- El bundle de la app es mayor de lo esperado
-- Hay renders innecesarios o freezes en la UI
-- El tiempo de respuesta de la API es demasiado alto
-- Necesitas optimizar queries o data fetching
+- API response time is too high
+- Database queries are slow or excessive
+- Memory or CPU usage is abnormally high
+- Bundle size is larger than expected (frontend)
+- UI renders are slow or janky (frontend)
+- You need to decide on a caching strategy
+- System doesn't scale under load
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Medir antes de optimizar
+### Pattern 1: Measure Before You Optimize
 
 ```
-Hipótesis → Medir → Identificar bottleneck → Optimizar → Verificar mejora
+Hypothesis → Measure → Identify bottleneck → Optimize → Verify improvement
 
-❌ MAL: optimizar sin datos
-✅ BIEN: medir primero, optimizar el bottleneck real
+❌ BAD: Optimize without data — guessing where the problem is
+✅ GOOD: Profile first, optimize the REAL bottleneck
 ```
 
-### Pattern 2: Code splitting y lazy loading
+**Profiling tools by context:**
+
+| Context         | Tools                                                    |
+| --------------- | -------------------------------------------------------- |
+| SQL queries     | `EXPLAIN ANALYZE`, query logs, slow query log            |
+| Python          | `cProfile`, `py-spy`, `memory_profiler`                  |
+| Go              | `pprof` (CPU, memory, goroutines, mutex)                 |
+| Java/.NET       | JProfiler, dotTrace, VisualVM, `async-profiler`          |
+| Node.js         | `--prof`, `clinic.js`, Chrome DevTools                   |
+| Frontend        | Lighthouse, Chrome DevTools Performance tab              |
+| HTTP APIs       | `k6`, `wrk`, `ab`, `vegeta`                              |
+
+### Pattern 2: Fix N+1 Queries
+
+The single most common backend performance problem.
+
+```python
+# ❌ BAD — N+1: 1 query for orders + N queries for users
+orders = Order.objects.all()
+for order in orders:
+    print(order.user.name)  # each access triggers a separate query
+
+# ✅ GOOD — eager loading: 2 queries total
+orders = Order.objects.select_related("user").all()
+for order in orders:
+    print(order.user.name)  # already loaded
+```
+
+```java
+// ❌ BAD — N+1 with JPA
+List<Order> orders = orderRepository.findAll();
+for (Order order : orders) {
+    order.getUser().getName(); // lazy load → N extra queries
+}
+
+// ✅ GOOD — fetch join
+@Query("SELECT o FROM Order o JOIN FETCH o.user")
+List<Order> findAllWithUsers();
+```
 
 ```typescript
-// ✅ BIEN — lazy load de componentes pesados
-import dynamic from 'next/dynamic'
+// ❌ BAD — N+1 in a GraphQL resolver or API handler
+const orders = await db.query("SELECT * FROM orders");
+for (const order of orders) {
+  order.user = await db.query("SELECT * FROM users WHERE id = $1", [order.userId]);
+}
 
-const HeavyChart = dynamic(() => import('./HeavyChart'), {
-    loading: () => <ChartSkeleton />,
-    ssr: false,  // solo si realmente es browser-only
+// ✅ GOOD — batch load with a single query or DataLoader
+const orders = await db.query(`
+  SELECT o.*, u.name as user_name
+  FROM orders o
+  JOIN users u ON u.id = o.user_id
+`);
+```
+
+### Pattern 3: Caching Strategy
+
+Cache the RIGHT thing at the RIGHT level.
+
+```
+Level 1: Application memory (fastest, process-local, lost on restart)
+Level 2: Distributed cache — Redis/Memcached (shared across instances)
+Level 3: CDN / HTTP cache (edge, for static or semi-static content)
+Level 4: Database query cache (usually last resort)
+```
+
+```python
+# ✅ GOOD — cache expensive computation with TTL
+from functools import lru_cache
+import time
+
+@lru_cache(maxsize=256)
+def get_exchange_rate(currency: str) -> Decimal:
+    return external_api.fetch_rate(currency)
+
+# ✅ GOOD — Redis cache for shared state across instances
+async def get_user_profile(user_id: str) -> UserProfile:
+    cached = await redis.get(f"user:{user_id}")
+    if cached:
+        return UserProfile.model_validate_json(cached)
+    profile = await db.fetch_user_profile(user_id)
+    await redis.setex(f"user:{user_id}", 300, profile.model_dump_json())  # 5 min TTL
+    return profile
+```
+
+```go
+// ✅ GOOD — in-memory cache with expiration
+type Cache struct {
+    mu    sync.RWMutex
+    items map[string]cacheEntry
+}
+
+type cacheEntry struct {
+    value     interface{}
+    expiresAt time.Time
+}
+
+func (c *Cache) Get(key string) (interface{}, bool) {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    entry, ok := c.items[key]
+    if !ok || time.Now().After(entry.expiresAt) {
+        return nil, false
+    }
+    return entry.value, true
+}
+```
+
+**Cache invalidation rules:**
+- Use TTL (time-to-live) as the default strategy
+- Event-based invalidation for write-heavy data
+- NEVER cache without an expiration unless you have an explicit invalidation path
+
+### Pattern 4: Connection Pooling
+
+```python
+# ❌ BAD — new connection per request
+def get_user(user_id: str):
+    conn = psycopg2.connect(DATABASE_URL)  # expensive!
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+    return cursor.fetchone()
+
+# ✅ GOOD — connection pool
+from psycopg2.pool import ThreadedConnectionPool
+
+pool = ThreadedConnectionPool(minconn=5, maxconn=20, dsn=DATABASE_URL)
+
+def get_user(user_id: str):
+    conn = pool.getconn()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+        return cursor.fetchone()
+    finally:
+        pool.putconn(conn)
+```
+
+```java
+// ✅ GOOD — HikariCP connection pool (Spring Boot default)
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+```
+
+### Pattern 5: Database Query Optimization
+
+```sql
+-- ❌ BAD — full table scan
+SELECT * FROM orders WHERE YEAR(created_at) = 2024;
+
+-- ✅ GOOD — index-friendly range query
+SELECT * FROM orders
+WHERE created_at >= '2024-01-01' AND created_at < '2025-01-01';
+
+-- ❌ BAD — SELECT * when you only need 2 columns
+SELECT * FROM users;
+
+-- ✅ GOOD — select only what you need
+SELECT id, email FROM users;
+
+-- ✅ GOOD — add indexes for frequent queries
+CREATE INDEX idx_orders_customer_date ON orders (customer_id, created_at);
+```
+
+**Index rules of thumb:**
+- Index columns used in WHERE, JOIN ON, and ORDER BY
+- Composite indexes: put high-cardinality columns first
+- Don't over-index: each index slows down writes
+- Use `EXPLAIN ANALYZE` to verify the index is actually used
+
+### Pattern 6: Pagination — Never Load Everything
+
+```python
+# ❌ BAD — loads ALL records into memory
+def get_all_users():
+    return User.objects.all()  # 10 million rows? enjoy your OOM
+
+# ✅ GOOD — cursor-based pagination
+def get_users(after_id: str | None = None, limit: int = 50) -> list[User]:
+    query = User.objects.order_by("id")
+    if after_id:
+        query = query.filter(id__gt=after_id)
+    return list(query[:limit])
+```
+
+```go
+// ✅ GOOD — keyset pagination
+func GetUsers(ctx context.Context, afterID string, limit int) ([]User, error) {
+    query := "SELECT id, name FROM users WHERE id > $1 ORDER BY id LIMIT $2"
+    rows, err := db.QueryContext(ctx, query, afterID, limit)
+    // ...
+}
+```
+
+### Pattern 7: Async and Concurrency
+
+```python
+# ❌ BAD — sequential HTTP calls (3 seconds total)
+user = await fetch_user(user_id)        # 1s
+orders = await fetch_orders(user_id)    # 1s
+profile = await fetch_profile(user_id)  # 1s
+
+# ✅ GOOD — parallel calls (1 second total)
+user, orders, profile = await asyncio.gather(
+    fetch_user(user_id),
+    fetch_orders(user_id),
+    fetch_profile(user_id),
+)
+```
+
+```go
+// ✅ GOOD — parallel with errgroup
+g, ctx := errgroup.WithContext(ctx)
+var user *User
+var orders []Order
+
+g.Go(func() error {
+    var err error
+    user, err = fetchUser(ctx, userID)
+    return err
 })
+g.Go(func() error {
+    var err error
+    orders, err = fetchOrders(ctx, userID)
+    return err
+})
+
+if err := g.Wait(); err != nil {
+    return err
+}
 ```
 
-### Pattern 3: Memoización con criterio
-
 ```typescript
-// ✅ BIEN — memoizar solo cuando el cálculo es costoso y los inputs estables
-const processedData = useMemo(
-  () => expensiveTransformation(rawData),
-  [rawData], // solo si rawData cambia raramente
-);
+// ❌ BAD — sequential awaits
+const user = await fetchUser(userId);
+const orders = await fetchOrders(userId);
+const profile = await fetchProfile(userId);
 
-// ❌ MAL — memoizar operaciones triviales (overhead mayor que el cálculo)
-const name = useMemo(() => user.firstName + " " + user.lastName, [user]);
-```
-
-### Pattern 4: Server Components eliminan JS del cliente
-
-```typescript
-// ✅ BIEN — Server Component (zero JS al cliente)
-export default async function Dashboard() {
-    const data = await getData()
-    return <DashboardView data={data} />
-}
-
-// ❌ MAL — fetch en cliente + useEffect
-'use client'
-export function Dashboard() {
-    const [data, setData] = useState(null)
-    useEffect(() => { fetch('/api/data').then(...).then(setData) }, [])
-}
+// ✅ GOOD — parallel
+const [user, orders, profile] = await Promise.all([
+  fetchUser(userId),
+  fetchOrders(userId),
+  fetchProfile(userId),
+]);
 ```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: `use client` innecesario
+### Don't: Premature Optimization
 
-```typescript
-// ❌ MAL — todo el módulo se envía al cliente
-'use client'
-export function StaticHeader() {
-    return <header>Mi App</header>  // sin estado ni eventos
-}
+```
+❌ BAD: "Let me add Redis caching to every endpoint just in case"
+✅ GOOD: Profile → find the actual bottleneck → cache only what's slow
+```
 
-// ✅ BIEN — Server Component (zero JS al cliente)
-export function StaticHeader() {
-    return <header>Mi App</header>
+### Don't: Load Entire Datasets Into Memory
+
+```java
+// ❌ BAD — loads everything
+List<Transaction> all = transactionRepo.findAll(); // 5M rows → OutOfMemoryError
+
+// ✅ GOOD — stream or paginate
+try (Stream<Transaction> stream = transactionRepo.streamAll()) {
+    stream.filter(t -> t.getAmount() > 1000)
+          .forEach(this::processTransaction);
 }
+```
+
+### Don't: Ignore Resource Cleanup
+
+```go
+// ❌ BAD — response body never closed → connection leak
+resp, _ := http.Get(url)
+body, _ := io.ReadAll(resp.Body)
+
+// ✅ GOOD — always close resources
+resp, err := http.Get(url)
+if err != nil { return err }
+defer resp.Body.Close()
+body, err := io.ReadAll(resp.Body)
+```
+
+```python
+# ❌ BAD — file never closed
+data = open("large.csv").read()
+
+# ✅ GOOD — context manager ensures cleanup
+with open("large.csv") as f:
+    data = f.read()
+```
+
+### Don't: Cache Without Invalidation Strategy
+
+```
+❌ BAD: cache.set("user:123", user_data)  // no TTL, no invalidation → stale forever
+
+✅ GOOD: cache.setex("user:123", 300, user_data)  // 5 min TTL
+         # AND invalidate on write:
+         # on user update → cache.delete("user:123")
 ```
 
 ---
 
 ## Quick Reference
 
-| Problema             | Herramienta                                        |
-| -------------------- | -------------------------------------------------- |
-| Bundle grande        | `next build --analyze` (con @next/bundle-analyzer) |
-| Renders innecesarios | React DevTools Profiler                            |
-| API lenta            | Network tab + backend profiling                    |
-| Memory leak          | Verificar cleanup en useEffect → return () => {}   |
-| Queries lentas       | EXPLAIN ANALYZE + índices                          |
+| Problem                   | Tool / Approach                                     |
+| ------------------------- | --------------------------------------------------- |
+| Slow API response         | Profile → check queries, N+1, missing indexes       |
+| High memory usage         | Check unclosed resources, large collections, caching |
+| Slow database queries     | `EXPLAIN ANALYZE` → add indexes, fix N+1            |
+| High CPU usage            | CPU profiler → find hot paths                       |
+| Large frontend bundle     | Bundle analyzer → code split, lazy load, tree shake |
+| Slow UI rendering         | Performance profiler → reduce re-renders, virtualize |
+| Too many HTTP calls       | Batch requests, use DataLoader pattern, parallelize  |
+| Connection exhaustion     | Connection pooling, check for leaks                 |
+| Doesn't scale under load  | Load test → identify bottleneck → horizontal/vertical|

--- a/skills/shared/thinking/SKILL.md
+++ b/skills/shared/thinking/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: thinking
 description: >
-  Patrones de análisis cognitivo para descomponer problemas complejos antes de proponer soluciones.
-  Trigger: Al analizar un problema, al evaluar alternativas, al detectar riesgos o cuando el input es ambiguo.
+  Cognitive analysis patterns for decomposing complex problems before proposing solutions.
+  Trigger: When analyzing a problem, evaluating alternatives, assessing risks, or when input is ambiguous.
+globs:
+  - "**/*"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -10,70 +12,285 @@ metadata:
 
 ## When to Use
 
-Carga este skill cuando:
+Load this skill when:
 
-- El usuario describe un problema o feature sin definición clara
-- Hay múltiples alternativas posibles y necesitas evaluar pros/contras
-- Detectas riesgos ocultos en el enfoque propuesto
-- El scope parece más grande de lo necesario (posible overengineering)
+- The user describes a problem or feature without clear definition
+- There are multiple possible alternatives and you need to evaluate tradeoffs
+- You detect hidden risks in the proposed approach
+- The scope seems larger than necessary (possible overengineering)
+- A decision has long-term consequences that need analysis
+- The problem is ambiguous and needs decomposition before coding
 
 ---
 
 ## Critical Patterns
 
-### Pattern 1: Descomposición antes de solución
+### Pattern 1: Decompose Before You Solve
 
-Antes de proponer cualquier solución, define con precisión:
+Before proposing ANY solution, define precisely:
 
-1. **¿Cuál es el problema real?** (no el síntoma)
-2. **¿Qué supuestos se están haciendo?**
-3. **¿Qué riesgos existen en cada alternativa?**
-4. **¿Hay una solución más simple?**
-
-### Pattern 2: Priorizar simplicidad
+1. **What is the REAL problem?** (not the symptom)
+2. **What assumptions are being made?**
+3. **What risks exist in each alternative?**
+4. **Is there a simpler solution?**
 
 ```
-Complexidad innecesaria → deuda técnica
-Solución simple que funciona > solución elegante que no existe aún
+❌ BAD decomposition:
+   Problem: "The app is slow"
+   Solution: "Add Redis caching"
+
+✅ GOOD decomposition:
+   Symptom: "The app is slow"
+   Question: Where is it slow? → API response time
+   Question: Which endpoint? → GET /orders
+   Question: Why is it slow? → N+1 queries (profiler shows 200 queries per request)
+   Root cause: Missing JOIN in the orders query
+   Solution: Add eager loading → fix the query
+   Validation: Response time dropped from 2s to 50ms
 ```
 
-### Pattern 3: Validar antes de construir
+### Pattern 2: Decision Matrix for Technical Choices
+
+When choosing between alternatives, make the comparison EXPLICIT.
 
 ```
-idea → hipótesis → validación mínima → implementación
+Example: Choosing a message queue
+
+| Criteria          | Weight | RabbitMQ | Kafka   | SQS     |
+| ----------------- | ------ | -------- | ------- | ------- |
+| Throughput needed  | High   | Medium   | High    | Medium  |
+| Ordering guarantee | High   | Per-queue| Per-part| FIFO opt|
+| Ops complexity     | Medium | Medium   | High    | Low     |
+| Team familiarity   | High   | Low      | Medium  | High    |
+| Cost at our scale  | Medium | Self-host| Self-host| Pay/use|
+| ---------------------------------------- | ------- |
+| Winner for THIS context:                 | SQS     |
+
+WHY: Our throughput is moderate, team knows AWS well,
+and we don't want to operate infrastructure.
+Kafka would be overengineering at our current scale.
 ```
 
-No abstraer sin al menos 2 casos reales que lo requieran.
+```
+Example: Monolith vs Microservices
+
+| Criteria           | Weight | Monolith    | Microservices |
+| ------------------ | ------ | ----------- | ------------- |
+| Team size          | High   | 4 devs ✅   | 4 devs ❌     |
+| Deployment speed   | Medium | Fast ✅      | Complex ❌    |
+| Independent scaling| Low    | No ❌        | Yes ✅        |
+| Debugging ease     | High   | Easy ✅      | Distributed ❌|
+| ----------------------------------------- | ------------- |
+| Winner: Monolith — team is too small for microservices.
+| Revisit when team reaches 15+ developers.
+```
+
+### Pattern 3: Prioritize Simplicity
+
+```
+Unnecessary complexity → technical debt
+Simple solution that works > elegant solution that doesn't exist yet
+```
+
+The simplest solution that meets ALL requirements wins. Not the most "architecturally pure" one.
+
+```
+❌ BAD: "Let's build a plugin system with dynamic module loading
+        so we can add payment providers later"
+        (You have 1 payment provider and no plans for more)
+
+✅ GOOD: Implement Stripe directly. When a second provider appears,
+         THEN extract the interface.
+```
+
+**The Rule of Three:**
+- First time: just do it
+- Second time: note the duplication
+- Third time: NOW abstract
+
+### Pattern 4: Validate Before You Build
+
+```
+idea → hypothesis → minimal validation → implementation
+```
+
+Do NOT abstract without at least 2 real cases that require it.
+
+```
+❌ BAD thinking:
+   "We MIGHT need to support multiple databases in the future,
+    so let's build a database abstraction layer now"
+
+✅ GOOD thinking:
+   "We use PostgreSQL. If we ever need another DB, we'll abstract then.
+    Right now, the abstraction adds complexity with zero benefit."
+```
+
+### Pattern 5: Risk Assessment — Reversibility Matters
+
+Not all decisions are equal. Classify them:
+
+```
+Type 1 (One-way door): Hard/impossible to reverse
+  Examples: Database schema in production, public API contract,
+            choosing a primary language, data deletion
+  → Analyze carefully. Get team input. Prototype first.
+
+Type 2 (Two-way door): Easy to reverse
+  Examples: Library choice (can swap), internal API design,
+            folder structure, CI configuration
+  → Decide quickly. Move fast. Adjust later if needed.
+```
+
+```
+❌ BAD: Spending 2 weeks deciding between two logging libraries (Type 2)
+✅ GOOD: Pick one in 30 minutes, move on
+
+❌ BAD: Choosing the database in 30 minutes (Type 1)
+✅ GOOD: Benchmark, prototype, evaluate for 1-2 days
+```
+
+### Pattern 6: Scope Check — YAGNI
+
+Before adding ANY feature or abstraction, ask:
+
+1. Is someone asking for this RIGHT NOW?
+2. What is the cost of adding it LATER vs NOW?
+3. Am I building for a real requirement or an imagined future?
+
+```
+❌ BAD scope creep:
+   User asks: "Add a login page"
+   Agent builds: Login + registration + password reset + OAuth + 2FA + admin panel
+
+✅ GOOD scope control:
+   User asks: "Add a login page"
+   Agent: "I'll implement email/password login. Do you also need:
+           - Registration? (separate task)
+           - Password reset? (separate task)
+           - OAuth providers? (separate task)"
+```
+
+### Pattern 7: Structured Problem-Solving Template
+
+For any non-trivial problem, fill in this template mentally before coding:
+
+```
+## Problem
+[One sentence — what is actually broken or missing?]
+
+## Context
+[What do we know? What constraints exist?]
+
+## Assumptions
+[What are we taking for granted? Which could be wrong?]
+
+## Options
+1. [Option A] — Pros: ... Cons: ... Effort: ...
+2. [Option B] — Pros: ... Cons: ... Effort: ...
+3. [Do nothing] — Pros: ... Cons: ...
+
+## Recommendation
+[Which option and WHY]
+
+## Validation
+[How will we know this worked?]
+```
+
+**Concrete example:**
+
+```
+## Problem
+Users report checkout fails intermittently.
+
+## Context
+- Happens ~5% of the time
+- Only on orders with 10+ items
+- Started after last deployment (v2.4.1)
+
+## Assumptions
+- The payment provider is not the issue (their status page is green)
+- It's not a client-side issue (happens across browsers)
+
+## Options
+1. Rollback to v2.4.0 — Pros: immediate fix. Cons: loses new features.
+2. Debug and fix forward — Pros: keeps features. Cons: takes longer.
+3. Add retry logic — Pros: masks the issue. Cons: doesn't fix root cause.
+
+## Recommendation
+Option 2. The diff between v2.4.0 and v2.4.1 is small (3 files changed).
+Start by reviewing those changes.
+
+## Validation
+- Failing test that reproduces the bug
+- 0% failure rate in staging with 10+ item orders after the fix
+```
 
 ---
 
 ## Anti-Patterns
 
-### Don't: Saltar directo a la solución
+### Don't: Jump Straight to Code
 
 ```
-❌ Usuario: "necesito autenticación"
-   Agente: "Aquí está el código de autenticación..."
+❌ User: "I need authentication"
+   Agent: "Here's the auth code..."
 
-✅ Usuario: "necesito autenticación"
-   Agente: "¿Qué tipo? ¿Session-based, JWT, OAuth? ¿Quién es el usuario?"
+✅ User: "I need authentication"
+   Agent: "What type? Session-based, JWT, OAuth?
+           Who are the users? What's the security requirement?
+           Do you need role-based access?"
 ```
 
-### Don't: Abstraer prematuramente
+### Don't: Abstract Prematurely
 
 ```
-❌ Crear BaseRepository<T> cuando solo tienes un caso de uso
+❌ Create BaseRepository<T> when you only have one use case
 
-✅ Implementar directamente, extraer abstracción al segundo caso real
+✅ Implement directly. Extract an abstraction at the second real case.
+```
+
+### Don't: Confuse Effort with Progress
+
+```
+❌ "I spent 3 days building a perfect config system"
+   (But the actual feature isn't started)
+
+✅ Start with hardcoded values → extract config when needed
+```
+
+### Don't: Optimize for the Wrong Audience
+
+```
+❌ "This architecture will support 10 million users"
+   (Current users: 50. Expected in 1 year: 500)
+
+✅ Design for 10x your current scale, not 1000x.
+   You'll rewrite before you hit 10M anyway.
+```
+
+### Don't: Ignore the "Do Nothing" Option
+
+```
+❌ "We need to migrate from REST to GraphQL"
+   (But REST is working fine and nobody complained)
+
+✅ Ask: "What problem does GraphQL solve that REST doesn't,
+        given our current situation?"
+   Often the answer is: none. Don't fix what isn't broken.
 ```
 
 ---
 
 ## Quick Reference
 
-| Pregunta                         | Acción                                         |
-| -------------------------------- | ---------------------------------------------- |
-| ¿El problema está bien definido? | Si no → preguntar antes de proceder            |
-| ¿Hay alternativas más simples?   | Siempre explorar al menos 2 caminos            |
-| ¿Cuánto cuesta el error?         | Evaluar reversibilidad de la decisión          |
-| ¿Es realmente necesario ahora?   | YAGNI — no construir para el futuro hipotético |
+| Question                                | Action                                              |
+| --------------------------------------- | --------------------------------------------------- |
+| Is the problem well-defined?            | If not → ask clarifying questions before proceeding |
+| Are there simpler alternatives?         | Always explore at least 2 paths                     |
+| What is the cost of being wrong?        | Evaluate reversibility (Type 1 vs Type 2 decision)  |
+| Is this really needed now?              | YAGNI — don't build for a hypothetical future       |
+| Am I solving the symptom or the cause?  | Dig deeper — ask "why" at least 3 times             |
+| How will I know this worked?            | Define success criteria BEFORE implementing         |
+| Is the scope appropriate?               | If scope grew → split into separate tasks           |
+| Am I making assumptions?                | List them explicitly and validate each one           |


### PR DESCRIPTION
## Summary
- Translates all 13 original skills from Spanish to English
- Expands content 2-4x per file with multi-language code examples and bad/good patterns
- Makes shared skills language-agnostic (examples in TypeScript, Python, Java, Go)
- Adds `globs:` field to YAML frontmatter for all skills

## Changes by area

| Area | Files | Before | After |
|------|-------|--------|-------|
| Shared (5) | architecture, code-quality, debug, performance, thinking | 575 lines | 1,400 lines |
| Backend-node (2) | api-design, testing | 323 lines | 761 lines |
| DevOps (2) | cicd, monitoring | 262 lines | 693 lines |
| Frontend (2) | react, nextjs | 248 lines | 807 lines |
| Python (2) | api-design, testing | 299 lines | 846 lines |
| **Total** | **13 files** | **~1,700 lines** | **~4,500 lines** |

## Testing
- All 19 Pester skill tests pass
- CI will run bash E2E tests (no count changes needed — file count unchanged)

Closes #126