### PR TITLE
fix(skills): judgment day round 1 — fix 14 issues across skills and packs

### DIFF
--- a/packs/backend-node/rules.md
+++ b/packs/backend-node/rules.md
@@ -1,57 +1,57 @@
 # Pack: Backend Node.js
 
-> Reglas y convenciones para desarrolladores backend del equipo.
+> Rules and conventions for backend developers on the team.
 
 ---
 
 ## Architecture Rules
 
-- Separación en capas: routes → controllers → services → repositories
-- Lógica de negocio solo en services, no en controllers ni routes
-- Repositories abstraen el acceso a base de datos (sin SQL crudo en services)
-- Inyección de dependencias sobre imports directos para facilitar testing
-- Error handling centralizado con middleware de errores
-- No mezclar lógica de autenticación con lógica de negocio
-- Módulos agrupados por dominio (user/, product/, order/)
+- Layer separation: routes → controllers → services → repositories
+- Business logic only in services, not in controllers or routes
+- Repositories abstract database access (no raw SQL in services)
+- Dependency injection over direct imports to facilitate testing
+- Centralized error handling with error middleware
+- Do not mix authentication logic with business logic
+- Modules grouped by domain (user/, product/, order/)
 
 ## Code Quality Rules
 
-### TypeScript Estricto (NO NEGOCIABLE)
+### Strict TypeScript (NON-NEGOTIABLE)
 
-- CERO `any` — siempre tipar explícitamente
-- CERO `unknown` como escape — usar genéricos o discriminated unions
-- Todas las funciones con tipos de retorno explícitos
-- Non-null assertion (`!`) prohibido
+- ZERO `any` — always type explicitly
+- ZERO `unknown` as an escape hatch — use generics or discriminated unions
+- All functions with explicit return types
+- Non-null assertion (`!`) forbidden
 
-### Convenciones
+### Conventions
 
-- Nombres descriptivos: `getUserById()`, no `getUser()`
-- Funciones puras en la capa de dominio — máximo ~30 líneas
-- Validación de inputs con Zod en el borde de entrada (controllers, handlers)
-- Imports ordenados: 1) node:*, 2) externos, 3) internos
+- Descriptive names: `getUserById()`, not `getUser()`
+- Pure functions in the domain layer — ~30 lines max
+- Input validation with Zod at the entry boundary (controllers, handlers)
+- Ordered imports: 1) node:*, 2) external, 3) internal
 
-### Seguridad
+### Security
 
-- Nunca loguear datos sensibles (passwords, tokens, PII)
-- Variables de entorno para configuración, nunca hardcodear credenciales
-- Sanitizar inputs antes de queries/operaciones
+- Never log sensitive data (passwords, tokens, PII)
+- Environment variables for configuration, never hardcode credentials
+- Sanitize inputs before queries/operations
 
 ### Error Handling
 
-- Manejo explícito de errores — nunca swallow silencioso
-- Errores de dominio con clases tipadas (`class NotFoundError extends Error`)
-- Try/catch solo en boundaries (controllers, handlers), no en cada función
+- Explicit error handling — never silently swallow errors
+- Domain errors with typed classes (`class NotFoundError extends Error`)
+- Try/catch only at boundaries (controllers, handlers), not in every function
 
 ## Thinking Rules
 
-- Diseñar la API contract antes de la implementación (API-first)
-- Pensar en idempotencia y casos de error antes del happy path
-- No acoplar el transporte (HTTP) con la lógica de dominio
-- Validar inputs en el borde del sistema, no en el interior
-- Pensar en consistencia de datos ante fallos parciales
+- Design the API contract before implementation (API-first)
+- Think about idempotency and error cases before the happy path
+- Do not couple the transport layer (HTTP) with domain logic
+- Validate inputs at the system boundary, not deep inside
+- Think about data consistency under partial failures
 
-## PROHIBIDO
+## PROHIBITED
 
-- No generar archivos de scripts o tooling que NO se pidió
-- No crear archivos fuera del scope de la tarea
-- No `console.log` en producción — usar logger estructurado
+- Do not generate script or tooling files that were NOT requested
+- Do not create files outside the scope of the task
+- No `console.log` in production — use a structured logger

--- a/packs/devops/rules.md
+++ b/packs/devops/rules.md
@@ -1,33 +1,33 @@
 # Pack: DevOps
 
-> Reglas y convenciones para ingenieros DevOps/SRE del equipo.
+> Rules and conventions for DevOps/SRE engineers on the team.
 
 ---
 
 ## Architecture Rules
 
-- Separar configuración del entorno del código de la aplicación (12-factor)
-- Pipelines CI/CD con etapas claras: lint → test → build → deploy
-- Ambientes reproducibles: dev == staging == prod en comportamiento
-- Secrets nunca en repositorios Git, siempre en vault o env vars del CI
-- Imágenes de contenedor inmutables: no modificar en tiempo de ejecución
-- Health checks y readiness probes obligatorios en servicios
-- Rollback automatizado si los health checks fallan post-deploy
+- Separate environment configuration from application code (12-factor)
+- CI/CD pipelines with clear stages: lint → test → build → deploy
+- Reproducible environments: dev == staging == prod in behavior
+- Secrets never in Git repositories, always in a vault or CI env vars
+- Immutable container images: do not modify at runtime
+- Health checks and readiness probes required for all services
+- Automated rollback if health checks fail post-deploy
 
 ## Code Quality Rules
 
-- Scripts con manejo explícito de errores (set -euo pipefail en bash)
-- Variables nombradas descriptivamente (no $1, $2 sin asignar)
-- Linting de IaC: tflint para Terraform, hadolint para Dockerfiles
-- Dockerfiles con imagen base explícita (con versión, no latest)
-- Pipelines idempotentes: se pueden re-ejecutar sin efectos duplicados
-- Logs estructurados (JSON) para integrarse con sistemas de observabilidad
-- Usar --dry-run / plan antes de apply/destroy en producción
+- Scripts with explicit error handling (set -euo pipefail in bash)
+- Descriptively named variables (no bare $1, $2 without assignment)
+- IaC linting: tflint for Terraform, hadolint for Dockerfiles
+- Dockerfiles with explicit base image (with version, not latest)
+- Idempotent pipelines: can be re-run without duplicate side effects
+- Structured logs (JSON) to integrate with observability systems
+- Use --dry-run / plan before apply/destroy in production
 
 ## Thinking Rules
 
-- Pensar primero en la reversibilidad: todo cambio debe poder deshacerse
-- Automatizar lo que se hace más de dos veces
-- Infraestructura como código: nada configurado manualmente en producción
-- Pensar en el blast radius antes de aplicar cambios
-- Preferir cambios incrementales sobre big-bang deployments
+- Think about reversibility first: every change must be undoable
+- Automate anything done more than twice
+- Infrastructure as code: nothing manually configured in production
+- Think about the blast radius before applying changes
+- Prefer incremental changes over big-bang deployments

--- a/packs/frontend/rules.md
+++ b/packs/frontend/rules.md
@@ -1,72 +1,72 @@
-# Pack: Frontend (React / Next.js)
+# Pack: Frontend (React / Next.js / Angular / Vue)
 
-> Reglas y convenciones para desarrolladores frontend del equipo.
+> Rules and conventions for frontend developers on the team.
 
 ---
 
 ## Architecture Rules
 
-- No cross-feature imports: cada feature es un módulo cerrado
-- Cada feature debe ser completamente independiente
-- Separación estricta entre lógica de servidor y cliente (use client mínimo)
-- Evitar lógica de negocio en componentes UI
-- Componentes presentacionales sin efectos secundarios
-- Custom hooks para encapsular lógica reutilizable
-- Barrel exports (index.ts) por feature para controlar la API pública
-- Colocar estado lo más cerca posible de donde se usa
+- No cross-feature imports: each feature is a closed module
+- Each feature must be completely independent
+- Strict separation between server and client logic (minimal use client)
+- Avoid business logic in UI components
+- Presentational components without side effects
+- Custom hooks to encapsulate reusable logic
+- Barrel exports (index.ts) per feature to control the public API
+- Colocate state as close as possible to where it's used
 
 ## Code Quality Rules
 
-### TypeScript Estricto (NO NEGOCIABLE)
+### Strict TypeScript (NON-NEGOTIABLE)
 
-- CERO `any` — siempre tipar explícitamente
-- CERO `unknown` como escape — usar genéricos o discriminated unions
-- Todas las funciones con tipos de retorno explícitos
-- Interfaces para objetos de datos, `type` para uniones/intersecciones
-- Enums: preferir `as const` objects sobre `enum`
-- Non-null assertion (`!`) prohibido — usar optional chaining o type guards
+- ZERO `any` — always type explicitly
+- ZERO `unknown` as an escape hatch — use generics or discriminated unions
+- All functions with explicit return types
+- Interfaces for data objects, `type` for unions/intersections
+- Enums: prefer `as const` objects over `enum`
+- Non-null assertion (`!`) forbidden — use optional chaining or type guards
 
-### Convenciones
+### Conventions
 
-- Nombres descriptivos obligatorios: `getUserById()`, no `getUser()`
-- Funciones pequeñas y puras — máximo ~30 líneas
-- Imports ordenados: 1) externos, 2) internos absolutos (@/), 3) relativos
-- Un export por archivo cuando es componente/hook principal
+- Descriptive names required: `getUserById()`, not `getUser()`
+- Small, pure functions — ~30 lines max
+- Ordered imports: 1) external, 2) internal absolute (@/), 3) relative
+- One export per file when it's the main component/hook
 
 ### React / UI
 
-- Props tipadas con interfaces dedicadas
-- Keys únicas y estables en listas (nunca índice del array)
-- useMemo/useCallback solo con evidencia de problema real
-- Componentes: solo UI y binding. Lógica en hooks o services
-- Event handlers tipados
+- Props typed with dedicated interfaces
+- Unique and stable keys in lists (never array index)
+- useMemo/useCallback only with evidence of a real problem
+- Components: UI and binding only. Logic in hooks or services
+- Typed event handlers
 
-### Validación
+### Validation
 
-- Zod para validación de forms y datos de API
-- Schemas co-localizados con la feature que los usa
+- Zod for form and API data validation
+- Schemas co-located with the feature that uses them
 
 ## Next.js Rules
 
-- Preferir Server Components por defecto
-- Minimizar `use client`: solo cuando se necesita estado o eventos
-- Usar Server Actions para mutaciones
-- Evitar fetch en cliente si puede hacerse en servidor
-- loading.tsx y error.tsx para UX por segmento
-- cache() para deduplicar fetches en el mismo request
+- Prefer Server Components by default
+- Minimize `use client`: only when state or events are needed
+- Use Server Actions for mutations
+- Avoid client-side fetch if it can be done on the server
+- loading.tsx and error.tsx for per-segment UX
+- cache() to deduplicate fetches within the same request
 
 ## Thinking Rules
 
-- Cuestionar el problema antes de proponer solución
-- Evitar soluciones complejas si existe una simple
-- Priorizar velocidad de validación sobre perfección
-- No abstraer sin al menos 2 casos reales
-- UX primero, implementación técnica después
-- Preferir composición sobre herencia
+- Question the problem before proposing a solution
+- Avoid complex solutions if a simple one exists
+- Prioritize validation speed over perfection
+- Don't abstract without at least 2 real use cases
+- UX first, technical implementation second
+- Prefer composition over inheritance
 
-## PROHIBIDO
+## PROHIBITED
 
-- No generar archivos de scripts o tooling que NO se pidió
-- No crear archivos fuera del scope de la tarea
-- No `console.log` en producción
-- No hardcodear strings mágicos
+- Do not generate script or tooling files that were NOT requested
+- Do not create files outside the scope of the task
+- No `console.log` in production
+- Do not hardcode magic strings

--- a/packs/python/rules.md
+++ b/packs/python/rules.md
@@ -1,32 +1,32 @@
 # Pack: Python
 
-> Reglas y convenciones para desarrolladores Python del equipo.
+> Rules and conventions for Python developers on the team.
 
 ---
 
 ## Architecture Rules
 
-- Organización por dominio: cada módulo es un paquete con `__init__.py` explícito
-- Separación de responsabilidades: routers/views → services → repositories
-- Dependency injection via constructores o FastAPI Depends()
-- Configuración centralizada con pydantic-settings o python-decouple
-- Evitar imports circulares: diseñar la jerarquía de dependencias desde el inicio
-- Type hints obligatorios en funciones públicas
+- Domain-based organization: each module is a package with an explicit `__init__.py`
+- Separation of responsibilities: routers/views → services → repositories
+- Dependency injection via constructors or FastAPI Depends()
+- Centralized configuration with pydantic-settings or python-decouple
+- Avoid circular imports: design the dependency hierarchy from the start
+- Type hints required on public functions
 
 ## Code Quality Rules
 
-- Type hints obligatorios en todas las funciones públicas
-- Docstrings en funciones/clases de dominio (una línea basta para funciones simples)
-- Nombres en snake_case, clases en PascalCase
-- Funciones cortas y con responsabilidad única
-- Evitar mutación de parámetros de entrada
-- Nunca ignorar excepciones en silencio (bare `except: pass` prohibido)
-- f-strings para formateo de strings, nunca concatenación con +
+- Type hints required on all public functions
+- Docstrings on domain functions/classes (one line is enough for simple functions)
+- Names in snake_case, classes in PascalCase
+- Short functions with a single responsibility
+- Avoid mutating input parameters
+- Never silently ignore exceptions (bare `except: pass` forbidden)
+- f-strings for string formatting, never concatenation with +
 
 ## Thinking Rules
 
-- Preferir la solución más legible sobre la más "pythónica" si hay trade-off de claridad
-- Evitar abstracciones prematuras: primero funciona, luego abstrae
-- Pensar en el contrato de la función (inputs/outputs) antes de implementar
-- Considerar el contexto de ejecución: sync vs async, CPU-bound vs I/O-bound
-- Validar supuestos de tipos en el borde del sistema, no en cada función interna
+- Prefer the most readable solution over the most "Pythonic" one if there's a clarity trade-off
+- Avoid premature abstractions: make it work first, then abstract
+- Think about the function contract (inputs/outputs) before implementing
+- Consider the execution context: sync vs async, CPU-bound vs I/O-bound
+- Validate type assumptions at the system boundary, not in every internal function

--- a/skills/roles/backend-dotnet/api-design/SKILL.md
+++ b/skills/roles/backend-dotnet/api-design/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 - Registering services, repositories, or validators in the DI container (`IServiceCollection`).
 - Building or extending the middleware pipeline (`Program.cs` / `Startup.cs`).
 - Implementing input validation with FluentValidation (`AbstractValidator<T>`).
-- Designing error handling that returns RFC 7807 ProblemDetails responses.
+- Designing error handling that returns RFC 9457 ProblemDetails responses.
 - Setting up the repository pattern over Entity Framework Core (`DbContext`, `DbSet<T>`).
 
 ---
@@ -186,7 +186,7 @@ app.MapPost("/api/orders", async (
 
 ### Pattern 3: Centralized Error Handling with Exception Middleware + ProblemDetails
 
-Never let raw exceptions leak to the client. Use `AddProblemDetails()` and `UseExceptionHandler` to produce RFC 7807 responses for every unhandled exception.
+Never let raw exceptions leak to the client. Use `AddProblemDetails()` and `UseExceptionHandler` to produce RFC 9457 responses for every unhandled exception.
 
 ✅ **Program.cs setup:**
 
@@ -245,7 +245,7 @@ app.MapControllers();
 app.Run();
 ```
 
-✅ **Client receives consistent RFC 7807 JSON:**
+✅ **Client receives consistent RFC 9457 JSON:**
 
 ```json
 {
@@ -398,7 +398,7 @@ public async Task<IActionResult> GetById(int id)
 public async Task<IActionResult> GetById(int id)
 {
     // No try/catch needed — the exception middleware
-    // converts unhandled exceptions to ProblemDetails (RFC 7807)
+    // converts unhandled exceptions to ProblemDetails (RFC 9457)
     var order = await _orders.GetByIdAsync(id);
     return Ok(order);
 }
@@ -415,7 +415,7 @@ The centralized exception handler (Pattern 3) maps exceptions to appropriate sta
 | **Controller role**    | HTTP adapter only — parse request, delegate, map response             |
 | **Business logic**     | Lives in service classes registered as `Scoped` in DI                 |
 | **Validation**         | FluentValidation `AbstractValidator<T>`, explicit call, not auto-pipe |
-| **Error responses**    | `AddProblemDetails()` + `UseExceptionHandler` — RFC 7807              |
+| **Error responses**    | `AddProblemDetails()` + `UseExceptionHandler` — RFC 9457              |
 | **Data access**        | `IRepository<T>` over EF Core `DbContext`                             |
 | **DTOs**               | C# `record` types — immutable, value equality, concise                |
 | **DI lifetimes**       | `Scoped` for services/repos, `Transient` for validators              |

--- a/skills/roles/backend-node/api-design/SKILL.md
+++ b/skills/roles/backend-node/api-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backend-node-api
 description: >
-  Node.js REST API design patterns: routes, controllers, middleware, validation, error handling with Express and Fastify.
+  Node.js REST API design patterns: routes, controllers, middleware, validation, error handling with Express.
   Trigger: When creating endpoints, defining routes, implementing middleware, or handling HTTP errors.
 globs:
   - "**/*.controller.ts"

--- a/skills/roles/frontend/nextjs/SKILL.md
+++ b/skills/roles/frontend/nextjs/SKILL.md
@@ -88,8 +88,8 @@ export default async function ProductsPage() {
   return (
     <div>
       <h1>Products</h1>
-      <SearchBar onSearch={handleSearch} />  {/* Client Component */}
-      <ProductGrid products={products} />     {/* Server Component */}
+      <SearchBar />                            {/* Client Component handles its own state */}
+      <ProductGrid products={products} />      {/* Server Component */}
     </div>
   )
 }
@@ -251,10 +251,11 @@ export const metadata: Metadata = {
   openGraph: { title: 'About Us', description: 'Learn about our company' },
 }
 
-// Dynamic metadata
+// Dynamic metadata (Next.js 15: params is a Promise)
 // app/posts/[slug]/page.tsx
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const post = await getPost(params.slug)
+  const { slug } = await params
+  const post = await getPost(slug)
   return {
     title: post.title,
     description: post.excerpt,

--- a/skills/roles/frontend/react/SKILL.md
+++ b/skills/roles/frontend/react/SKILL.md
@@ -173,8 +173,11 @@ function UserProfile({ userPromise }: { userPromise: Promise<User> }) {
   return <h1>{user.name}</h1>
 }
 
+// Create the promise OUTSIDE the component (e.g., in a route loader or parent)
+// to avoid re-creating it on every render
+const userPromise = fetchUser()
+
 export function UserPage() {
-  const userPromise = fetchUser() // starts fetching immediately
   return (
     <Suspense fallback={<Skeleton />}>
       <UserProfile userPromise={userPromise} />
@@ -330,27 +333,31 @@ function LoginForm() {
 }
 ```
 
-### Pattern 12: forwardRef for reusable primitives
+### Pattern 12: ref as prop (React 19 — no forwardRef needed)
 
 ```typescript
-// ✅ GOOD — exposes ref for parent to control focus, scroll, etc.
-import { forwardRef, type ComponentPropsWithoutRef } from 'react'
-
-interface InputProps extends ComponentPropsWithoutRef<'input'> {
+// ✅ GOOD — React 19: ref is a regular prop, no forwardRef wrapper needed
+interface InputProps extends React.ComponentPropsWithoutRef<'input'> {
   label: string
   error?: string
+  ref?: React.Ref<HTMLInputElement>
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, ...rest }, ref) => (
+export function Input({ label, error, ref, ...rest }: InputProps) {
+  return (
     <div>
       <label>{label}</label>
       <input ref={ref} {...rest} />
       {error && <span className="error">{error}</span>}
     </div>
   )
-)
-Input.displayName = 'Input'
+}
+
+// Parent uses it naturally:
+function LoginForm() {
+  const emailRef = useRef<HTMLInputElement>(null)
+  return <Input ref={emailRef} label="Email" />
+}
 ```
 
 ### Pattern 13: useCallback and useMemo — when to use and when NOT to

--- a/skills/roles/frontend/vue/SKILL.md
+++ b/skills/roles/frontend/vue/SKILL.md
@@ -87,10 +87,10 @@ const props = withDefaults(
   },
 )
 
-// --- Typed emits ---
+// --- Typed emits (Vue 3.3+ named tuple syntax) ---
 const emit = defineEmits<{
-  (e: 'update', value: number): void
-  (e: 'close'): void
+  update: [value: number]
+  close: []
 }>()
 
 function handleClick() {

--- a/skills/roles/mobile/architecture/SKILL.md
+++ b/skills/roles/mobile/architecture/SKILL.md
@@ -65,10 +65,10 @@ function goToProfile() {
 
 ```tsx
 // ✅ Typed routes — compiler catches invalid paths, full autocomplete
-import { router, type Href } from "expo-router";
+import { router } from "expo-router";
 
 function goToProfile() {
-  router.push("/profile" as Href); // type-checked route
+  router.push("/profile"); // type-checked route (enable typed routes in app.json)
 }
 
 function goToSettings(id: string) {

--- a/skills/roles/mobile/testing/SKILL.md
+++ b/skills/roles/mobile/testing/SKILL.md
@@ -84,7 +84,7 @@ test('submits login form with valid credentials', async () => {
 ### 2. Mocking Native Modules in jest.setup.ts
 
 Native modules crash under Jest because there is no bridge. Mock them in a central
-setup file referenced by `setupFilesAfterFramework` in your Jest config.
+setup file referenced by `setupFiles` in your Jest config.
 
 ```ts
 // ❌ BAD — mocking inline in every test file; incomplete mocks cause leaks
@@ -140,7 +140,7 @@ jest.mock('expo-location', () => ({
 // jest.config.ts (or package.json "jest" key)
 {
   "preset": "jest-expo", // or "react-native"
-  "setupFilesAfterSetup": ["./jest.setup.ts"],
+  "setupFiles": ["./jest.setup.ts"],
   "transformIgnorePatterns": [
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*)/)"
   ]

--- a/skills/shared/architecture/SKILL.md
+++ b/skills/shared/architecture/SKILL.md
@@ -58,7 +58,7 @@ Features must NEVER import directly from other features.
 import { DashboardLayout } from "../dashboard/components/DashboardLayout";
 
 // ✅ GOOD — use shared module or communicate via contracts
-import { DashboardLayout } from "@/shared/layouts/DashboardLayout";
+import { DashboardLayout } from "../../shared/layouts/DashboardLayout";
 ```
 
 ```python

--- a/skills/shared/performance/SKILL.md
+++ b/skills/shared/performance/SKILL.md
@@ -105,7 +105,7 @@ Level 4: Database query cache (usually last resort)
 ```
 
 ```python
-# ✅ GOOD — cache expensive computation with TTL
+# ✅ GOOD — cache expensive computation (note: lru_cache has no TTL — use cachetools.TTLCache if expiry is needed)
 from functools import lru_cache
 import time
 
@@ -176,8 +176,8 @@ def get_user(user_id: str):
         pool.putconn(conn)
 ```
 
-```java
-// ✅ GOOD — HikariCP connection pool (Spring Boot default)
+```yaml
+# ✅ GOOD — HikariCP connection pool (Spring Boot application.yml)
 spring:
   datasource:
     hikari:

--- a/skills/shared/thinking/SKILL.md
+++ b/skills/shared/thinking/SKILL.md
@@ -63,9 +63,8 @@ Example: Choosing a message queue
 | Ops complexity     | Medium | Medium   | High    | Low     |
 | Team familiarity   | High   | Low      | Medium  | High    |
 | Cost at our scale  | Medium | Self-host| Self-host| Pay/use|
-| ---------------------------------------- | ------- |
-| Winner for THIS context:                 | SQS     |
 
+Winner for THIS context: SQS
 WHY: Our throughput is moderate, team knows AWS well,
 and we don't want to operate infrastructure.
 Kafka would be overengineering at our current scale.
@@ -80,9 +79,9 @@ Example: Monolith vs Microservices
 | Deployment speed   | Medium | Fast ✅      | Complex ❌    |
 | Independent scaling| Low    | No ❌        | Yes ✅        |
 | Debugging ease     | High   | Easy ✅      | Distributed ❌|
-| ----------------------------------------- | ------------- |
-| Winner: Monolith — team is too small for microservices.
-| Revisit when team reaches 15+ developers.
+
+Winner: Monolith — team is too small for microservices.
+Revisit when team reaches 15+ developers.
 ```
 
 ### Pattern 3: Prioritize Simplicity


### PR DESCRIPTION
## Summary
Adversarial review (Judgment Day) of all Sprint 3 output. Two independent judges reviewed every file in parallel, fixes applied, re-judged — both judges pass clean.

## Fixes (14 files)

### Confirmed issues (both judges agreed)
- **thinking**: fix malformed decision matrix table rows
- **architecture**: replace `@/shared` with relative import (language-agnostic)
- **react**: replace deprecated `forwardRef` with React 19 ref-as-prop pattern
- **react**: fix `fetchUser()` creating promise on every render
- **nextjs**: `await params` in `generateMetadata` (Next.js 15 breaking change)
- **nextjs**: remove undefined `handleSearch` from Server Component
- **vue**: update `defineEmits` to Vue 3.3+ named tuple syntax
- **mobile/testing**: fix invalid Jest config key `setupFilesAfterSetup` → `setupFiles`
- **4 old packs** translated from Spanish to English

### Additional fixes
- **performance**: fix `lru_cache` TTL claim + YAML in java fence
- **mobile/architecture**: remove `as Href` cast defeating type safety
- **backend-node/api-design**: remove Fastify from description (no examples)
- **backend-dotnet/api-design**: update RFC 7807 → RFC 9457