### PR TITLE
fix(cli): resolve 4 audit bugs — uninstall, sanitization, jq validation, dead code

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -387,15 +387,6 @@ cmd_setup() {
     total_updated=$(echo "$merge_json" | jq -r '.updated')
     total_skipped=$(echo "$merge_json" | jq -r '.skipped')
     ok "$total_installed installed, $total_updated updated, $total_skipped unchanged"
-
-    # 5c. Generate project-level instructions
-    local pack_rules_content=""
-    local pack_rules_path=""
-    pack_rules_path=$(get_pack_rules_path "$KIT_ROOT" "$OPT_ROLE" 2>/dev/null) || true
-    if [[ -n "$pack_rules_path" ]]; then
-        pack_rules_content=$(cat "$pack_rules_path")
-    fi
-    ok "Project instructions generated for role: $OPT_ROLE"
     step "Run 'team-ai-kit init' in each project to apply instructions"
 
     # -- Save config -----------------------------------------------------------
@@ -451,6 +442,7 @@ cmd_setup() {
 # -- Init (project-level) -----------------------------------------------------
 cmd_init() {
     show_banner
+    _require_jq || exit 1
     local project_root
     project_root=$(pwd)
 
@@ -636,7 +628,7 @@ cmd_init() {
         fi
         if echo "$hooks_json" | jq -e '.skipped | index("not-a-git-repo")' >/dev/null 2>&1; then
             warn "Not a git repo -- hooks skipped"
-        elif [[ -n "$hooks_skipped_list" && "$hooks_skipped_list" != "" ]]; then
+        elif [[ -n "$hooks_skipped_list" ]]; then
             step "Git hooks already present: $hooks_skipped_list"
         fi
 
@@ -750,10 +742,8 @@ cmd_init_knowledge() {
 # -- Sync (manual engram sync) -------------------------------------------------
 cmd_sync() {
     show_banner
-    local project_root
-    project_root=$(pwd)
-
-    # Check project config for project name
+    _require_jq || exit 1
+    local project_root    # Check project config for project name
     local project_name=""
     if test_project_initialized "$project_root"; then
         project_name=$(_sanitize_project_name "$(basename "$project_root")")
@@ -798,6 +788,7 @@ cmd_sync() {
 # -- Update --------------------------------------------------------------------
 cmd_update() {
     show_banner
+    _require_jq || exit 1
     local config_ide config_role
     config_ide=$(get_config_value "ide")
     config_role=$(get_config_value "role")
@@ -995,6 +986,7 @@ cmd_update() {
 # -- Status --------------------------------------------------------------------
 cmd_status() {
     show_banner
+    _require_jq || exit 1
     local config_ide config_role config_provider config_team config_installed config_update config_version
     config_ide=$(get_config_value "ide")
     config_role=$(get_config_value "role")
@@ -1102,6 +1094,7 @@ cmd_status() {
 # -- Doctor --------------------------------------------------------------------
 cmd_doctor() {
     show_banner
+    _require_jq || exit 1
     echo -e "  ${C_WHITE}Checking installation health...${C_RESET}"
     echo ""
 

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -1192,7 +1192,8 @@ cmd_uninstall() {
     show_banner
     _require_jq || exit 1
     local project_root
-    project_root=$(pwd)    if ! test_project_initialized "$project_root"; then
+    project_root=$(pwd)
+    if ! test_project_initialized "$project_root"; then
         err "No team-ai-kit project found in this directory."
         echo "  Run this command from a project that was initialized with 'team-ai-kit init'."
         exit 1

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -697,6 +697,7 @@ cmd_init() {
 # -- Init Knowledge (scaffold team knowledge repo) ----------------------------
 cmd_init_knowledge() {
     show_banner
+    _require_jq || exit 1
     local target_dir
     target_dir=$(pwd)
 
@@ -743,7 +744,9 @@ cmd_init_knowledge() {
 cmd_sync() {
     show_banner
     _require_jq || exit 1
-    local project_root    # Check project config for project name
+    local project_root
+    project_root=$(pwd)
+    # Check project config for project name
     local project_name=""
     if test_project_initialized "$project_root"; then
         project_name=$(_sanitize_project_name "$(basename "$project_root")")
@@ -1187,10 +1190,9 @@ cmd_doctor() {
 # -- Uninstall -----------------------------------------------------------------
 cmd_uninstall() {
     show_banner
+    _require_jq || exit 1
     local project_root
-    project_root=$(pwd)
-
-    if ! test_project_initialized "$project_root"; then
+    project_root=$(pwd)    if ! test_project_initialized "$project_root"; then
         err "No team-ai-kit project found in this directory."
         echo "  Run this command from a project that was initialized with 'team-ai-kit init'."
         exit 1

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -631,7 +631,7 @@ function Invoke-InitCommand {
     Write-Host '  [4/4] Setting up engram sync and git hooks...' -ForegroundColor White
 
     # Derive project name from directory
-    $projectName = Split-Path $projectRoot -Leaf
+    $projectName = ConvertTo-SafeProjectName (Split-Path $projectRoot -Leaf)
 
     if ($DryRun) {
         Write-Dry "Would run engram sync for project: $projectName"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -11,11 +11,19 @@ set -euo pipefail
 VALID_IDES=("vscode" "intellij" "opencode" "cursor")
 VALID_ROLES=("frontend" "backend-node" "backend-java" "backend-dotnet" "devops" "python" "mobile" "data")
 VALID_PROVIDERS=("openai" "azure-openai" "anthropic" "github-copilot")
-VALID_COMMANDS=("setup" "init" "init-knowledge" "sync" "update" "status" "doctor" "help")
+VALID_COMMANDS=("setup" "init" "init-knowledge" "sync" "update" "uninstall" "status" "doctor" "help")
 
 # -- Helpers -------------------------------------------------------------------
 
 _lowercase() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+_require_jq() {
+    # Validates that jq is installed before commands that depend on it.
+    if ! command -v jq &>/dev/null; then
+        echo "Error: 'jq' is required but not installed. Run 'team-ai-kit setup' or install jq manually." >&2
+        return 1
+    fi
+}
 
 _sanitize_project_name() {
     # Strips unsafe characters from project name to prevent shell injection in git hooks.

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -20,7 +20,7 @@ _lowercase() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
 _require_jq() {
     # Validates that jq is installed before commands that depend on it.
     if ! command -v jq &>/dev/null; then
-        echo "Error: 'jq' is required but not installed. Run 'team-ai-kit setup' or install jq manually." >&2
+        echo "Error: 'jq' is required but not installed. Install it: brew install jq (macOS) or apt install jq (Linux)." >&2
         return 1
     fi
 }


### PR DESCRIPTION
﻿## Summary
- Add missing `uninstall` to VALID_COMMANDS in bash (Fixes #132)
- Sanitize project name in PS1 `Invoke-InitCommand` via `ConvertTo-SafeProjectName` (Fixes #131)
- Add `_require_jq` guard to all jq-dependent commands: init, sync, update, status, doctor, init-knowledge, uninstall (Fixes #136)
- Remove dead `pack_rules_content` code from `cmd_setup` and simplify redundant condition (Fixes #133)

Closes #131
Closes #132
Closes #133
Closes #136

## PR Type
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/functions.sh` | Added `uninstall` to VALID_COMMANDS, added `_require_jq()` helper |
| `bin/team-ai-kit` | Added `_require_jq` guard to 7 commands, removed dead code, fixed redundant condition |
| `bin/team-ai-kit.ps1` | Wrapped project name with `ConvertTo-SafeProjectName` in `Invoke-InitCommand` |

## Test Plan
- [x] Judgment Day passed (3 rounds, both judges clean)
- [x] All fixes verified by adversarial review

## Contributor Checklist
- [x] Linked approved issues (#131, #132, #133, #136)
- [x] Added type label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
