### PR TITLE
refactor(cli): extract shared team-repo resolution into reusable functions

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -518,14 +518,7 @@ cmd_init() {
 
     # Resolve team repo URL: CLI param > project config > global config
     local effective_team_repo=""
-    if [[ -n "$OPT_TEAM_REPO" ]]; then
-        effective_team_repo="$OPT_TEAM_REPO"
-    elif test_project_initialized "$project_root"; then
-        effective_team_repo=$(get_project_config_value "$project_root" "teamRepo" 2>/dev/null) || true
-    fi
-    if [[ -z "$effective_team_repo" ]]; then
-        effective_team_repo=$(get_config_value "teamRepo" 2>/dev/null) || true
-    fi
+    effective_team_repo=$(_resolve_team_repo "$project_root" "$OPT_TEAM_REPO")
 
     # Clone/pull team repo if configured
     local team_rules_content=""
@@ -809,11 +802,8 @@ cmd_update() {
     project_root=$(pwd)
     if test_project_initialized "$project_root"; then
         has_project_config="true"
-        effective_team_repo=$(get_project_config_value "$project_root" "teamRepo" 2>/dev/null) || true
     fi
-    if [[ -z "$effective_team_repo" ]]; then
-        effective_team_repo=$(get_config_value "teamRepo" 2>/dev/null) || true
-    fi
+    effective_team_repo=$(_resolve_team_repo "$project_root")
 
     # Step 1: Pull team repo if configured
     local has_team_repo="false"
@@ -1006,14 +996,10 @@ cmd_status() {
     fi
 
     # Resolve per-project > global team repo
-    local effective_team_repo="$config_team"
     local project_root
     project_root=$(pwd)
-    if test_project_initialized "$project_root"; then
-        local pt
-        pt=$(get_project_config_value "$project_root" "teamRepo" 2>/dev/null) || true
-        if [[ -n "$pt" ]]; then effective_team_repo="$pt"; fi
-    fi
+    local effective_team_repo=""
+    effective_team_repo=$(_resolve_team_repo "$project_root")
 
     echo -e "  ${C_WHITE}Configuration:${C_RESET}"
     echo "    IDE:         $config_ide"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -567,10 +567,7 @@ function Invoke-InitCommand {
     }
 
     # Resolve team repo URL: CLI param > project config > global config
-    $effectiveTeamRepo = if ($TeamRepo) { $TeamRepo }
-        elseif ($existingConfig -and $existingConfig.teamRepo) { $existingConfig.teamRepo }
-        elseif ($globalConfig.teamRepo) { $globalConfig.teamRepo }
-        else { '' }
+    $effectiveTeamRepo = Resolve-TeamRepo -ProjectRoot $projectRoot -CliParam $TeamRepo
 
     # Clone/pull team repo if configured
     $teamRulesContent = ''
@@ -824,9 +821,7 @@ function Invoke-UpdateCommand {
     if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
         $projectConfig = Get-ProjectConfig -ProjectRoot $projectRoot
     }
-    $effectiveTeamRepo = if ($projectConfig -and $projectConfig.teamRepo) { $projectConfig.teamRepo }
-        elseif ($config.teamRepo) { $config.teamRepo }
-        else { '' }
+    $effectiveTeamRepo = Resolve-TeamRepo -ProjectRoot $projectRoot
 
     Write-Host "  Updating for: IDE=$($config.ide), Role=$($config.role)" -ForegroundColor White
     Write-Host ''
@@ -1028,11 +1023,7 @@ function Invoke-StatusCommand {
     Write-Host "    Provider:    $($config.provider)"
     # Team repo status -- resolve per-project > global
     $projectRoot = (Get-Location).Path
-    $effectiveTeamRepo = $config.teamRepo
-    if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
-        $pc = Get-ProjectConfig -ProjectRoot $projectRoot
-        if ($pc.teamRepo) { $effectiveTeamRepo = $pc.teamRepo }
-    }
+    $effectiveTeamRepo = Resolve-TeamRepo -ProjectRoot $projectRoot
 
     Write-Host "    Team Repo:   $(if ($effectiveTeamRepo) { $effectiveTeamRepo } else { '(none)' })"
     Write-Host "    Installed:   $($config.installedAt)"

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -156,6 +156,30 @@ function Get-ProjectConfig {
     return $config
 }
 
+function Resolve-TeamRepo {
+    <#
+    .SYNOPSIS
+        Resolves the effective team repo URL using priority: CLI param > project config > global config.
+    .OUTPUTS
+        The resolved URL string (empty string if none configured).
+    #>
+    param(
+        [string]$ProjectRoot = '',
+        [string]$CliParam = ''
+    )
+    if ($CliParam) { return $CliParam }
+
+    if ($ProjectRoot -and (Test-ProjectInitialized -ProjectRoot $ProjectRoot)) {
+        $pc = Get-ProjectConfig -ProjectRoot $ProjectRoot
+        if ($pc -and $pc.teamRepo) { return $pc.teamRepo }
+    }
+
+    $globalConfig = Get-Config
+    if ($globalConfig.teamRepo) { return $globalConfig.teamRepo }
+
+    return ''
+}
+
 function Save-ProjectConfig {
     <#
     .SYNOPSIS

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -31,6 +31,25 @@ _sanitize_project_name() {
     echo "$1" | tr -cd 'a-zA-Z0-9._-'
 }
 
+_resolve_team_repo() {
+    # Resolves the effective team repo URL using priority: CLI param > project config > global config.
+    # Usage: _resolve_team_repo "$project_root" "$cli_param"
+    # Echoes the resolved URL (empty string if none configured).
+    local project_root="$1"
+    local cli_param="${2:-}"
+    local result=""
+
+    if [[ -n "$cli_param" ]]; then
+        result="$cli_param"
+    elif [[ -n "$project_root" ]] && test_project_initialized "$project_root" 2>/dev/null; then
+        result=$(get_project_config_value "$project_root" "teamRepo" 2>/dev/null) || true
+    fi
+    if [[ -z "$result" ]]; then
+        result=$(get_config_value "teamRepo" 2>/dev/null) || true
+    fi
+    echo "$result"
+}
+
 _array_contains() {
     local needle="$1"; shift
     local item


### PR DESCRIPTION
﻿## Summary
- Extract duplicated team-repo resolution logic (CLI > project config > global config) into shared functions
- Bash: `_resolve_team_repo()` in `lib/functions.sh`
- PS1: `Resolve-TeamRepo` in `lib/functions.ps1`
- Replace 3 inline resolution patterns in each script (init, update, status) with shared function calls

Closes #137

## PR Type
- [x] Code refactoring

## Changes

| File | Change |
|------|--------|
| `lib/functions.sh` | New `_resolve_team_repo()` function |
| `lib/functions.ps1` | New `Resolve-TeamRepo` function |
| `bin/team-ai-kit` | Replaced 3 inline team-repo resolution blocks with `_resolve_team_repo` calls |
| `bin/team-ai-kit.ps1` | Replaced 3 inline team-repo resolution blocks with `Resolve-TeamRepo` calls |

## Test Plan
- [x] Judgment Day passed (Round 1, both judges clean)
- [x] Priority order verified: init (CLI>project>global), update (project>global), status (project>global)
- [x] Bash/PS1 parity verified

## Contributor Checklist
- [x] Linked approved issue (#137)
- [x] Added type label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
