### PR TITLE
feat(cli): add version check to bash doctor command for parity with PS1

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -1089,6 +1089,16 @@ cmd_doctor() {
 
     local all_good=true
 
+    # team-ai-kit version check
+    step "Checking for updates..."
+    local kit_latest=""
+    kit_latest=$(_get_latest_github_version "lazarogadiel93" "team-ai-kit")
+    if [[ -n "$kit_latest" ]] && _version_lt "$KIT_VERSION" "$kit_latest"; then
+        warn "team-ai-kit: v$KIT_VERSION (update available: v$kit_latest)"
+    else
+        ok "team-ai-kit: v$KIT_VERSION"
+    fi
+
     # jq (required)
     if test_jq_installed; then ok "jq: installed"
     else err "jq: NOT found (required)"; all_good=false; fi
@@ -1099,16 +1109,32 @@ cmd_doctor() {
 
     # gentle-ai
     if test_gentle_ai_installed; then
-        local gentle_path=""
+        local gentle_path="" gentle_installed="" gentle_latest=""
         gentle_path=$(get_gentle_ai_binary_path 2>/dev/null) || gentle_path="(in PATH)"
-        ok "gentle-ai: installed ($gentle_path)"
+        gentle_installed=$(_get_installed_version "gentle-ai")
+        gentle_latest=$(_get_latest_github_version "Gentleman-Programming" "gentle-ai")
+        if [[ -n "$gentle_installed" && -n "$gentle_latest" ]] && _version_lt "$gentle_installed" "$gentle_latest"; then
+            warn "gentle-ai: v$gentle_installed (update available: v$gentle_latest)"
+        elif [[ -n "$gentle_installed" ]]; then
+            ok "gentle-ai: v$gentle_installed ($gentle_path)"
+        else
+            ok "gentle-ai: installed ($gentle_path)"
+        fi
     else err "gentle-ai: NOT found"; all_good=false; fi
 
     # engram
     if test_engram_installed; then
-        local engram_path=""
+        local engram_path="" engram_installed="" engram_latest=""
         engram_path=$(get_engram_binary_path 2>/dev/null) || engram_path="(in PATH)"
-        ok "engram: installed ($engram_path)"
+        engram_installed=$(_get_installed_version "engram")
+        engram_latest=$(_get_latest_github_version "Gentleman-Programming" "engram")
+        if [[ -n "$engram_installed" && -n "$engram_latest" ]] && _version_lt "$engram_installed" "$engram_latest"; then
+            warn "engram: v$engram_installed (update available: v$engram_latest)"
+        elif [[ -n "$engram_installed" ]]; then
+            ok "engram: v$engram_installed ($engram_path)"
+        else
+            ok "engram: installed ($engram_path)"
+        fi
     else err "engram: NOT found"; all_good=false; fi
 
     # Config

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -1094,7 +1094,7 @@ cmd_doctor() {
     local kit_latest=""
     kit_latest=$(_get_latest_github_version "lazarogadiel93" "team-ai-kit")
     if [[ -n "$kit_latest" ]] && _version_lt "$KIT_VERSION" "$kit_latest"; then
-        warn "team-ai-kit: v$KIT_VERSION (update available: v$kit_latest)"
+        warn "team-ai-kit: v$KIT_VERSION (update available: v$kit_latest) -- run: brew upgrade team-ai-kit"
     else
         ok "team-ai-kit: v$KIT_VERSION"
     fi
@@ -1114,7 +1114,7 @@ cmd_doctor() {
         gentle_installed=$(_get_installed_version "gentle-ai")
         gentle_latest=$(_get_latest_github_version "Gentleman-Programming" "gentle-ai")
         if [[ -n "$gentle_installed" && -n "$gentle_latest" ]] && _version_lt "$gentle_installed" "$gentle_latest"; then
-            warn "gentle-ai: v$gentle_installed (update available: v$gentle_latest)"
+            warn "gentle-ai: v$gentle_installed (update available: v$gentle_latest) -- run: brew upgrade gentle-ai"
         elif [[ -n "$gentle_installed" ]]; then
             ok "gentle-ai: v$gentle_installed ($gentle_path)"
         else
@@ -1129,7 +1129,7 @@ cmd_doctor() {
         engram_installed=$(_get_installed_version "engram")
         engram_latest=$(_get_latest_github_version "Gentleman-Programming" "engram")
         if [[ -n "$engram_installed" && -n "$engram_latest" ]] && _version_lt "$engram_installed" "$engram_latest"; then
-            warn "engram: v$engram_installed (update available: v$engram_latest)"
+            warn "engram: v$engram_installed (update available: v$engram_latest) -- run: brew upgrade engram"
         elif [[ -n "$engram_installed" ]]; then
             ok "engram: v$engram_installed ($engram_path)"
         else

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -1093,7 +1093,7 @@ cmd_doctor() {
     step "Checking for updates..."
     local kit_latest=""
     kit_latest=$(_get_latest_github_version "lazarogadiel93" "team-ai-kit")
-    if [[ -n "$kit_latest" ]] && _version_lt "$KIT_VERSION" "$kit_latest"; then
+    if [[ -n "$kit_latest" && -n "$KIT_VERSION" ]] && _version_lt "$KIT_VERSION" "$kit_latest"; then
         warn "team-ai-kit: v$KIT_VERSION (update available: v$kit_latest) -- run: brew upgrade team-ai-kit"
     else
         ok "team-ai-kit: v$KIT_VERSION"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -76,9 +76,9 @@ _get_latest_github_version() {
 
     # Fallback: curl GitHub API (uses GITHUB_TOKEN if available for rate limit)
     if [[ -z "$tag" ]] && command -v curl &>/dev/null; then
-        local auth_header=""
-        [[ -n "${GITHUB_TOKEN:-}" ]] && auth_header="-H Authorization: token $GITHUB_TOKEN"
-        tag=$(curl -fsSL $auth_header "https://api.github.com/repos/$owner/$repo/releases/latest" 2>/dev/null \
+        local auth_args=()
+        [[ -n "${GITHUB_TOKEN:-}" ]] && auth_args=(-H "Authorization: token $GITHUB_TOKEN")
+        tag=$(curl -fsSL --max-time 5 "${auth_args[@]}" "https://api.github.com/repos/$owner/$repo/releases/latest" 2>/dev/null \
             | jq -r '.tag_name // empty' 2>/dev/null) || true
     fi
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -93,7 +93,9 @@ _version_lt() {
     local v1="$1" v2="$2"
     if [[ "$v1" == "$v2" ]]; then return 1; fi
     local IFS='.'
-    local -a a=($v1) b=($v2)
+    local -a a b
+    read -ra a <<< "$v1"
+    read -ra b <<< "$v2"
     local i
     for i in 0 1 2; do
         if (( ${a[i]:-0} < ${b[i]:-0} )); then return 0; fi

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -50,6 +50,50 @@ _resolve_team_repo() {
     echo "$result"
 }
 
+_get_installed_version() {
+    # Returns the installed semver of a tool (gentle-ai or engram) by running `<tool> version`.
+    # Echoes the version string (e.g. "1.2.3") or empty string if not found.
+    local tool="$1"
+    local output=""
+    output=$("$tool" version 2>/dev/null) || true
+    if [[ "$output" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    fi
+}
+
+_get_latest_github_version() {
+    # Returns the latest release version from a GitHub repo.
+    # Usage: _get_latest_github_version "owner" "repo"
+    # Echoes the version string (e.g. "1.2.3") or empty string if unavailable.
+    local owner="$1" repo="$2"
+    local tag=""
+
+    # Try gh CLI first (most reliable)
+    if command -v gh &>/dev/null; then
+        tag=$(gh release view --repo "$owner/$repo" --json tagName -q '.tagName' 2>/dev/null) || true
+    fi
+
+    # Fallback: curl GitHub API
+    if [[ -z "$tag" ]] && command -v curl &>/dev/null; then
+        tag=$(curl -fsSL "https://api.github.com/repos/$owner/$repo/releases/latest" 2>/dev/null \
+            | jq -r '.tag_name // empty' 2>/dev/null) || true
+    fi
+
+    if [[ "$tag" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    fi
+}
+
+_version_lt() {
+    # Returns 0 (true) if version $1 < $2, 1 (false) otherwise.
+    # Simple semver comparison using sort -V.
+    local v1="$1" v2="$2"
+    if [[ "$v1" == "$v2" ]]; then return 1; fi
+    local lowest
+    lowest=$(printf '%s\n%s' "$v1" "$v2" | sort -V | head -n1)
+    [[ "$lowest" == "$v1" ]]
+}
+
 _array_contains() {
     local needle="$1"; shift
     local item

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -52,6 +52,7 @@ _resolve_team_repo() {
 
 _get_installed_version() {
     # Returns the installed semver of a tool (gentle-ai or engram) by running `<tool> version`.
+    # SAFETY: only call with hardcoded tool names — executes "$tool" directly.
     # Echoes the version string (e.g. "1.2.3") or empty string if not found.
     local tool="$1"
     local output=""
@@ -73,9 +74,11 @@ _get_latest_github_version() {
         tag=$(gh release view --repo "$owner/$repo" --json tagName -q '.tagName' 2>/dev/null) || true
     fi
 
-    # Fallback: curl GitHub API
+    # Fallback: curl GitHub API (uses GITHUB_TOKEN if available for rate limit)
     if [[ -z "$tag" ]] && command -v curl &>/dev/null; then
-        tag=$(curl -fsSL "https://api.github.com/repos/$owner/$repo/releases/latest" 2>/dev/null \
+        local auth_header=""
+        [[ -n "${GITHUB_TOKEN:-}" ]] && auth_header="-H Authorization: token $GITHUB_TOKEN"
+        tag=$(curl -fsSL $auth_header "https://api.github.com/repos/$owner/$repo/releases/latest" 2>/dev/null \
             | jq -r '.tag_name // empty' 2>/dev/null) || true
     fi
 
@@ -86,12 +89,17 @@ _get_latest_github_version() {
 
 _version_lt() {
     # Returns 0 (true) if version $1 < $2, 1 (false) otherwise.
-    # Simple semver comparison using sort -V.
+    # Pure-bash semver comparison (no sort -V dependency for macOS compatibility).
     local v1="$1" v2="$2"
     if [[ "$v1" == "$v2" ]]; then return 1; fi
-    local lowest
-    lowest=$(printf '%s\n%s' "$v1" "$v2" | sort -V | head -n1)
-    [[ "$lowest" == "$v1" ]]
+    local IFS='.'
+    local -a a=($v1) b=($v2)
+    local i
+    for i in 0 1 2; do
+        if (( ${a[i]:-0} < ${b[i]:-0} )); then return 0; fi
+        if (( ${a[i]:-0} > ${b[i]:-0} )); then return 1; fi
+    done
+    return 1
 }
 
 _array_contains() {


### PR DESCRIPTION
﻿## Summary
- Add version checking to bash `doctor` command matching PS1 `Invoke-DoctorCommand` behavior
- New helpers in `lib/functions.sh`: `_get_installed_version`, `_get_latest_github_version`, `_version_lt`
- Doctor now checks for updates of team-ai-kit, gentle-ai, and engram with update hints

Closes #134

## PR Type
- [x] New feature

## Changes

| File | Change |
|------|--------|
| `lib/functions.sh` | Added `_get_installed_version`, `_get_latest_github_version` (gh + curl fallback with GITHUB_TOKEN), `_version_lt` (pure-bash, macOS-compatible) |
| `bin/team-ai-kit` | Updated `cmd_doctor` to check versions and show update availability with upgrade hints |

## Test Plan
- [x] Judgment Day passed (3 rounds, both judges clean)
- [x] Pure-bash semver comparison — no `sort -V` dependency (macOS compatible)
- [x] Curl auth uses array approach — no word-splitting issues
- [x] Graceful degradation when gh/curl/network unavailable

## Contributor Checklist
- [x] Linked approved issue (#134)
- [x] Added type label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
