### PR TITLE
feat(cli): add --update flag to bash setup for parity with PS1

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -113,6 +113,7 @@ show_help() {
     echo "    --role <role>              Override global role for this project"
     echo "    --force                    Re-initialize without asking"
     echo "    --dry-run                  Preview changes without writing to disk"
+    echo "    --update                   Update already-installed tools during setup"
     echo ""
     echo -e "  ${C_YELLOW}Examples:${C_RESET}"
     echo "    team-ai-kit setup"
@@ -152,7 +153,27 @@ cmd_setup() {
 
         # -- gentle-ai --
         if test_gentle_ai_installed; then
-            ok "gentle-ai available"
+            if [[ "$OPT_UPDATE" == "true" ]]; then
+                if test_brew_installed; then
+                    step "Updating gentle-ai via Homebrew..."
+                    if brew upgrade gentle-ai 2>/dev/null; then
+                        ok "gentle-ai updated"
+                    else
+                        warn "Failed to update gentle-ai -- continuing with current version"
+                    fi
+                else
+                    step "Updating gentle-ai via direct download..."
+                    if dl_result=$(install_github_release_binary "Gentleman-Programming" "gentle-ai" "gentle-ai"); then
+                        local dl_version
+                        dl_version=$(echo "$dl_result" | jq -r '.version')
+                        ok "gentle-ai updated to $dl_version"
+                    else
+                        warn "Failed to update gentle-ai -- continuing with current version"
+                    fi
+                fi
+            else
+                ok "gentle-ai available"
+            fi
         elif test_brew_installed; then
             step "Installing gentle-ai via Homebrew..."
             if brew tap Gentleman-Programming/tap 2>/dev/null && brew install gentle-ai 2>/dev/null; then
@@ -186,7 +207,27 @@ cmd_setup() {
 
         # -- engram --
         if test_engram_installed; then
-            ok "engram available"
+            if [[ "$OPT_UPDATE" == "true" ]]; then
+                if test_brew_installed; then
+                    step "Updating engram via Homebrew..."
+                    if brew upgrade engram 2>/dev/null; then
+                        ok "engram updated"
+                    else
+                        warn "Failed to update engram -- continuing with current version"
+                    fi
+                else
+                    step "Updating engram via direct download..."
+                    if dl_result=$(install_github_release_binary "Gentleman-Programming" "engram" "engram"); then
+                        local dl_version
+                        dl_version=$(echo "$dl_result" | jq -r '.version')
+                        ok "engram updated to $dl_version"
+                    else
+                        warn "Failed to update engram -- continuing with current version"
+                    fi
+                fi
+            else
+                ok "engram available"
+            fi
         else
             step "Installing engram..."
             if test_brew_installed; then
@@ -1293,6 +1334,7 @@ SKIP_PREREQUISITES="false"
 SKIP_GENTLE_AI="false"
 OPT_FORCE="false"
 OPT_DRY_RUN="false"
+OPT_UPDATE="false"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -1315,6 +1357,7 @@ while [[ $# -gt 0 ]]; do
         --skip-gentle-ai)    SKIP_GENTLE_AI="true"; shift ;;
         --force)             OPT_FORCE="true"; shift ;;
         --dry-run)           OPT_DRY_RUN="true"; shift ;;
+        --update)            OPT_UPDATE="true"; shift ;;
         *)
             err "Unknown option: $1"
             echo '  Run "team-ai-kit help" for usage.'

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -156,21 +156,22 @@ cmd_setup() {
             if [[ "$OPT_UPDATE" == "true" ]]; then
                 if test_brew_installed; then
                     step "Updating gentle-ai via Homebrew..."
-                    local brew_output=""
-                    brew_output=$(brew upgrade gentle-ai 2>&1) || true
+                    local brew_output="" brew_exit=0
+                    brew_output=$(brew upgrade gentle-ai 2>&1) || brew_exit=$?
                     if echo "$brew_output" | grep -qi "already up-to-date\|already installed"; then
                         ok "gentle-ai already at latest version"
-                    elif [[ -n "$brew_output" ]]; then
+                    elif [[ $brew_exit -eq 0 ]]; then
                         ok "gentle-ai updated"
                     else
-                        warn "Failed to update gentle-ai -- continuing with current version"
+                        warn "Failed to update gentle-ai via Homebrew -- continuing with current version"
                     fi
                 else
                     step "Updating gentle-ai via direct download..."
+                    local dl_result=""
                     if dl_result=$(install_github_release_binary "Gentleman-Programming" "gentle-ai" "gentle-ai"); then
-                        local dl_version
-                        dl_version=$(echo "$dl_result" | jq -r '.version')
-                        ok "gentle-ai updated to $dl_version"
+                        local dl_version=""
+                        dl_version=$(echo "$dl_result" | jq -r '.version' 2>/dev/null)
+                        ok "gentle-ai updated${dl_version:+ to $dl_version}"
                     else
                         warn "Failed to update gentle-ai -- continuing with current version"
                     fi
@@ -213,21 +214,22 @@ cmd_setup() {
             if [[ "$OPT_UPDATE" == "true" ]]; then
                 if test_brew_installed; then
                     step "Updating engram via Homebrew..."
-                    local brew_output=""
-                    brew_output=$(brew upgrade engram 2>&1) || true
+                    local brew_output="" brew_exit=0
+                    brew_output=$(brew upgrade engram 2>&1) || brew_exit=$?
                     if echo "$brew_output" | grep -qi "already up-to-date\|already installed"; then
                         ok "engram already at latest version"
-                    elif [[ -n "$brew_output" ]]; then
+                    elif [[ $brew_exit -eq 0 ]]; then
                         ok "engram updated"
                     else
-                        warn "Failed to update engram -- continuing with current version"
+                        warn "Failed to update engram via Homebrew -- continuing with current version"
                     fi
                 else
                     step "Updating engram via direct download..."
+                    local dl_result=""
                     if dl_result=$(install_github_release_binary "Gentleman-Programming" "engram" "engram"); then
-                        local dl_version
-                        dl_version=$(echo "$dl_result" | jq -r '.version')
-                        ok "engram updated to $dl_version"
+                        local dl_version=""
+                        dl_version=$(echo "$dl_result" | jq -r '.version' 2>/dev/null)
+                        ok "engram updated${dl_version:+ to $dl_version}"
                     else
                         warn "Failed to update engram -- continuing with current version"
                     fi

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -156,7 +156,11 @@ cmd_setup() {
             if [[ "$OPT_UPDATE" == "true" ]]; then
                 if test_brew_installed; then
                     step "Updating gentle-ai via Homebrew..."
-                    if brew upgrade gentle-ai 2>/dev/null; then
+                    local brew_output=""
+                    brew_output=$(brew upgrade gentle-ai 2>&1) || true
+                    if echo "$brew_output" | grep -qi "already up-to-date\|already installed"; then
+                        ok "gentle-ai already at latest version"
+                    elif [[ -n "$brew_output" ]]; then
                         ok "gentle-ai updated"
                     else
                         warn "Failed to update gentle-ai -- continuing with current version"
@@ -171,9 +175,8 @@ cmd_setup() {
                         warn "Failed to update gentle-ai -- continuing with current version"
                     fi
                 fi
-            else
-                ok "gentle-ai available"
             fi
+            ok "gentle-ai available"
         elif test_brew_installed; then
             step "Installing gentle-ai via Homebrew..."
             if brew tap Gentleman-Programming/tap 2>/dev/null && brew install gentle-ai 2>/dev/null; then
@@ -210,7 +213,11 @@ cmd_setup() {
             if [[ "$OPT_UPDATE" == "true" ]]; then
                 if test_brew_installed; then
                     step "Updating engram via Homebrew..."
-                    if brew upgrade engram 2>/dev/null; then
+                    local brew_output=""
+                    brew_output=$(brew upgrade engram 2>&1) || true
+                    if echo "$brew_output" | grep -qi "already up-to-date\|already installed"; then
+                        ok "engram already at latest version"
+                    elif [[ -n "$brew_output" ]]; then
                         ok "engram updated"
                     else
                         warn "Failed to update engram -- continuing with current version"
@@ -225,9 +232,8 @@ cmd_setup() {
                         warn "Failed to update engram -- continuing with current version"
                     fi
                 fi
-            else
-                ok "engram available"
             fi
+            ok "engram available"
         else
             step "Installing engram..."
             if test_brew_installed; then


### PR DESCRIPTION
﻿## Summary
- Add `--update` flag to bash `setup` command matching PS1 `-Update` switch
- When passed, already-installed tools (gentle-ai, engram) are upgraded via `brew upgrade` or re-downloaded
- Properly handles `brew upgrade` exit codes (already-latest vs actual failure)
- Always shows availability confirmation after update attempt (PS1 parity)

Closes #135

## PR Type
- [x] New feature

## Changes

| File | Change |
|------|--------|
| `bin/team-ai-kit` | Added `--update` flag, `OPT_UPDATE` variable, update logic for gentle-ai and engram in `cmd_setup`, help text |

## Test Plan
- [x] Judgment Day passed (2 rounds)
- [x] brew upgrade exit code properly checked (no false positives)
- [x] Direct download fallback with jq guard
- [x] PS1 parity verified (unconditional "available" message)

## Contributor Checklist
- [x] Linked approved issue (#135)
- [x] Added type label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
