### PR TITLE
chore(skills): normalize formatting across all skills and packs

### DIFF
--- a/packs/backend-dotnet/rules.md
+++ b/packs/backend-dotnet/rules.md
@@ -20,7 +20,7 @@
 - Always validate input with FluentValidation or Data Annotations
 - Use middleware for cross-cutting concerns (logging, auth, error handling)
 
-### Testing
+## Testing
 
 - Every service method must have a unit test
 - Use `WebApplicationFactory<Program>` for integration tests
@@ -28,7 +28,7 @@
 - Use FluentAssertions for readable assertions
 - Use Testcontainers for database integration tests when needed
 
-### Naming
+## Naming
 
 - Controllers: `*Controller.cs`
 - Services: `I*Service.cs` (interface) + `*Service.cs`

--- a/packs/backend-dotnet/rules.md
+++ b/packs/backend-dotnet/rules.md
@@ -12,7 +12,7 @@
 - Repositories handle data access via EF Core
 - Use DTOs (record types) for API request/response — never expose entities
 
-## Coding Standards
+## Code Quality Rules
 
 - Use constructor injection via built-in DI (`IServiceCollection`)
 - Prefer async/await for all I/O operations
@@ -20,7 +20,7 @@
 - Always validate input with FluentValidation or Data Annotations
 - Use middleware for cross-cutting concerns (logging, auth, error handling)
 
-## Testing Standards
+### Testing
 
 - Every service method must have a unit test
 - Use `WebApplicationFactory<Program>` for integration tests
@@ -28,10 +28,18 @@
 - Use FluentAssertions for readable assertions
 - Use Testcontainers for database integration tests when needed
 
-## Naming Conventions
+### Naming
 
 - Controllers: `*Controller.cs`
 - Services: `I*Service.cs` (interface) + `*Service.cs`
 - Repositories: `I*Repository.cs` + `*Repository.cs`
 - DTOs: `*Request.cs`, `*Response.cs`
 - Tests: `*Tests.cs` (unit), `*IntegrationTests.cs`
+
+## Thinking Rules
+
+- Design the API contract before implementation (API-first)
+- Think about idempotency and error cases before the happy path
+- Think about the function contract (inputs/outputs) before implementing
+- Validate inputs at the system boundary, not deep inside
+- Consider transaction boundaries and data consistency under partial failures

--- a/packs/backend-java/rules.md
+++ b/packs/backend-java/rules.md
@@ -20,14 +20,14 @@
 - Always validate input with Jakarta Bean Validation (`@Valid`)
 - Use `@ControllerAdvice` for centralized error handling
 
-### Testing
+## Testing
 
 - Every service method must have a unit test
 - Use `@SpringBootTest` only for integration tests — prefer plain JUnit 5 + Mockito for unit tests
 - Use Testcontainers for database integration tests
 - Use AssertJ for fluent, readable assertions
 
-### Naming
+## Naming
 
 - Controllers: `*Controller.java`
 - Services: `*Service.java` (interface) + `*ServiceImpl.java`

--- a/packs/backend-java/rules.md
+++ b/packs/backend-java/rules.md
@@ -12,7 +12,7 @@
 - Repositories handle data access only
 - Use DTOs (record classes) for API request/response — never expose entities
 
-## Coding Standards
+## Code Quality Rules
 
 - Use constructor injection — never field injection with `@Autowired`
 - Prefer `Optional<T>` returns from repositories over null checks
@@ -20,17 +20,25 @@
 - Always validate input with Jakarta Bean Validation (`@Valid`)
 - Use `@ControllerAdvice` for centralized error handling
 
-## Testing Standards
+### Testing
 
 - Every service method must have a unit test
 - Use `@SpringBootTest` only for integration tests — prefer plain JUnit 5 + Mockito for unit tests
 - Use Testcontainers for database integration tests
 - Use AssertJ for fluent, readable assertions
 
-## Naming Conventions
+### Naming
 
 - Controllers: `*Controller.java`
 - Services: `*Service.java` (interface) + `*ServiceImpl.java`
 - Repositories: `*Repository.java`
 - DTOs: `*Request.java`, `*Response.java`
 - Tests: `*Test.java` (unit), `*IT.java` (integration)
+
+## Thinking Rules
+
+- Design the API contract before implementation (API-first)
+- Think about idempotency and error cases before the happy path
+- Think about the function contract (inputs/outputs) before implementing
+- Validate inputs at the system boundary, not deep inside
+- Consider transaction boundaries and data consistency under partial failures

--- a/packs/data/rules.md
+++ b/packs/data/rules.md
@@ -19,14 +19,14 @@
 - Type-hint all function signatures
 - Use `logging` module — never `print()` in production code
 
-### Testing
+## Testing
 
 - Test data transformations with known input/output pairs
 - Validate data schemas with pandera or Great Expectations
 - Assert model metrics stay above defined thresholds (regression tests)
 - Use pytest fixtures for sample DataFrames
 
-### Naming
+## Naming
 
 - Modules: `snake_case.py`
 - Pipelines: `*_pipeline.py`

--- a/packs/data/rules.md
+++ b/packs/data/rules.md
@@ -11,7 +11,7 @@
 - Keep notebooks for exploration only — production code goes in `.py` modules
 - Version datasets and models alongside code
 
-## Coding Standards
+## Code Quality Rules
 
 - Use pandas method chaining for readable transformations
 - Use scikit-learn `Pipeline` + `ColumnTransformer` for reproducible preprocessing
@@ -19,17 +19,25 @@
 - Type-hint all function signatures
 - Use `logging` module — never `print()` in production code
 
-## Testing Standards
+### Testing
 
 - Test data transformations with known input/output pairs
 - Validate data schemas with pandera or Great Expectations
 - Assert model metrics stay above defined thresholds (regression tests)
 - Use pytest fixtures for sample DataFrames
 
-## Naming Conventions
+### Naming
 
 - Modules: `snake_case.py`
 - Pipelines: `*_pipeline.py`
 - Notebooks: `01_exploration.ipynb`, `02_modeling.ipynb` (numbered)
 - Tests: `test_*.py`
 - Models: `model_*.pkl` or `model_*.joblib`
+
+## Thinking Rules
+
+- Prefer the most readable solution over the most clever one
+- Think about data lineage and reproducibility before implementing
+- Think about the function contract (inputs/outputs) before implementing
+- Validate type assumptions at the system boundary, not in every internal function
+- Consider the execution context: batch vs streaming, memory constraints

--- a/packs/mobile/rules.md
+++ b/packs/mobile/rules.md
@@ -11,7 +11,7 @@
 - Keep platform-specific code isolated with `.ios.ts` / `.android.ts` suffixes
 - Use a global state manager (Zustand) for client state and TanStack Query for server state
 
-## Coding Standards
+## Code Quality Rules
 
 - Use `FlashList` over `FlatList` for large lists
 - Always handle loading, error, and empty states in every screen
@@ -19,16 +19,24 @@
 - Handle keyboard avoidance, safe areas, and gesture conflicts
 - Test on both iOS and Android before merging
 
-## Testing Standards
+### Testing
 
 - Use React Native Testing Library (RNTL) for component tests
 - Mock native modules with `jest.mock()` in setup files
 - Avoid snapshot tests — prefer behavioral assertions
 - Use Detox or Maestro for E2E testing
 
-## Naming Conventions
+### Naming
 
 - Screens: `*Screen.tsx` in `app/` or `screens/`
 - Components: PascalCase in `components/`
 - Hooks: `use*.ts` in `hooks/`
 - Navigation: defined in `app/` (Expo Router) or `navigation/`
+
+## Thinking Rules
+
+- Think about the user experience on both platforms before implementing
+- Consider offline-first patterns and optimistic updates for mobile UX
+- Think about the function contract (inputs/outputs) before implementing
+- Validate inputs at the system boundary, not deep inside
+- Avoid premature abstractions: make it work first, then abstract

--- a/packs/mobile/rules.md
+++ b/packs/mobile/rules.md
@@ -19,14 +19,14 @@
 - Handle keyboard avoidance, safe areas, and gesture conflicts
 - Test on both iOS and Android before merging
 
-### Testing
+## Testing
 
 - Use React Native Testing Library (RNTL) for component tests
 - Mock native modules with `jest.mock()` in setup files
 - Avoid snapshot tests — prefer behavioral assertions
 - Use Detox or Maestro for E2E testing
 
-### Naming
+## Naming
 
 - Screens: `*Screen.tsx` in `app/` or `screens/`
 - Components: PascalCase in `components/`

--- a/skills/roles/backend-dotnet/testing/SKILL.md
+++ b/skills/roles/backend-dotnet/testing/SKILL.md
@@ -12,8 +12,6 @@ metadata:
   version: "1.0"
 ---
 
-# Backend .NET — Testing
-
 ## When to Use
 
 Load this skill when:

--- a/skills/roles/backend-java/api-design/SKILL.md
+++ b/skills/roles/backend-java/api-design/SKILL.md
@@ -325,7 +325,7 @@ public class UserService {
 
 ## Anti-Patterns
 
-### Don't: Use Field Injection with @Autowired
+### Anti-Pattern 1: Use Field Injection with @Autowired
 
 Field injection hides dependencies, breaks testability, and makes it impossible to create
 immutable objects. Constructor injection is the Spring team's recommended approach.
@@ -368,7 +368,7 @@ Why constructor injection wins:
 - **Testable** — pass mocks directly in unit tests, no reflection or Spring context needed
 - Catches missing beans at **startup**, not at runtime
 
-### Don't: Put Business Logic in Controllers
+### Anti-Pattern 2: Put Business Logic in Controllers
 
 Controllers that contain business rules become untestable, unreusable, and violate SRP.
 If you need a `@Transactional` annotation on a controller method, something is wrong.

--- a/skills/roles/backend-java/testing/SKILL.md
+++ b/skills/roles/backend-java/testing/SKILL.md
@@ -12,8 +12,6 @@ metadata:
   version: "1.0"
 ---
 
-# Backend Java — Testing
-
 ## When to Use
 
 - Writing unit tests for services or domain logic with JUnit 5 + Mockito

--- a/skills/roles/backend-node/api-design/SKILL.md
+++ b/skills/roles/backend-node/api-design/SKILL.md
@@ -376,7 +376,7 @@ app.use(cors({
 
 ## Anti-Patterns
 
-### Don't: Raw SQL in Services
+### Anti-Pattern 1: Raw SQL in Services
 
 ```typescript
 // ❌ BAD — service coupled to raw SQL
@@ -390,7 +390,7 @@ async function getUser(id: string) {
 }
 ```
 
-### Don't: Leaking Internal State in Responses
+### Anti-Pattern 2: Leaking Internal State in Responses
 
 ```typescript
 // ❌ BAD — exposes password hash and internal fields
@@ -407,7 +407,7 @@ function toUserResponse(user: User): UserResponse {
 res.json({ data: toUserResponse(user) })
 ```
 
-### Don't: God Router Files
+### Anti-Pattern 3: God Router Files
 
 ```typescript
 // ❌ BAD — one file with 50+ routes

--- a/skills/roles/backend-node/testing/SKILL.md
+++ b/skills/roles/backend-node/testing/SKILL.md
@@ -415,7 +415,7 @@ describe('User API Contract', () => {
 
 ## Anti-Patterns
 
-### Don't: Test Everything Through the HTTP Layer
+### Anti-Pattern 1: Test Everything Through the HTTP Layer
 
 ```typescript
 // ❌ BAD — testing business logic via HTTP (slow, brittle)
@@ -431,7 +431,7 @@ it('should reject password shorter than 8 chars', () => {
 })
 ```
 
-### Don't: Share Mutable State Across Tests
+### Anti-Pattern 2: Share Mutable State Across Tests
 
 ```typescript
 // ❌ BAD — shared mutable state causes flaky tests
@@ -461,7 +461,7 @@ it('test 2', async () => {
 })
 ```
 
-### Don't: Skip Error Path Tests
+### Anti-Pattern 3: Skip Error Path Tests
 
 ```typescript
 // ❌ BAD — only testing the happy path

--- a/skills/roles/data/pipelines/SKILL.md
+++ b/skills/roles/data/pipelines/SKILL.md
@@ -31,7 +31,7 @@ transformation pipelines. Each step returns a **new** DataFrame, making the flow
 and debuggable.
 
 ```python
-# ❌ BAD: imperative mutations scattered across lines
+# ❌ BAD — imperative mutations scattered across lines
 df["revenue_usd"] = df["revenue"] * df["exchange_rate"]
 df = df[df["revenue_usd"] > 0]
 df["log_revenue"] = np.log1p(df["revenue_usd"])
@@ -40,7 +40,7 @@ df = df.sort_values("log_revenue", ascending=False)
 ```
 
 ```python
-# ✅ GOOD: method chaining: each step is a pure transformation
+# ✅ GOOD — method chaining: each step is a pure transformation
 def compute_log_revenue(df: pd.DataFrame) -> pd.DataFrame:
     """Custom transform compatible with .pipe()."""
     return df.assign(log_revenue=lambda d: np.log1p(d["revenue_usd"]))
@@ -58,7 +58,7 @@ clean_df = (
 
 **Key rules:**
 - Wrap the entire chain in parentheses for multi-line readability.
-- Use `assign` for new/derived columns: it returns a new DataFrame.
+- Use `assign` for new/derived columns — it returns a new DataFrame.
 - Use `pipe` to inject custom functions into the chain without breaking the flow.
 - Use `query` instead of boolean indexing (`df[df["col"] > 0]`) inside chains.
 - Every function passed to `pipe` MUST accept a DataFrame and return a DataFrame.
@@ -72,7 +72,7 @@ Separate numeric and categorical preprocessing into sub-pipelines, combine them 
 guarantees identical transformations at train and inference time.
 
 ```python
-# ❌ BAD: manual, fragile, order-dependent preprocessing
+# ❌ BAD — manual, fragile, order-dependent preprocessing
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
 
@@ -87,11 +87,11 @@ X_test[num_cols] = scaler.transform(X_test[num_cols])
 encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
 X_train_cat = encoder.fit_transform(X_train[cat_cols])
 X_test_cat = encoder.transform(X_test[cat_cols])
-# Easy to forget a step or apply fit_transform on test data: data leakage
+# Easy to forget a step or apply fit_transform on test data — data leakage
 ```
 
 ```python
-# ✅ GOOD: declarative Pipeline + ColumnTransformer
+# ✅ GOOD — declarative Pipeline + ColumnTransformer
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
 from sklearn.impute import SimpleImputer
@@ -121,17 +121,17 @@ model = Pipeline([
     ("classifier", RandomForestClassifier(n_estimators=200, random_state=42)),
 ])
 
-# Single call: no leakage possible
+# Single call — no leakage possible
 model.fit(X_train, y_train)
 predictions = model.predict(X_test)
 ```
 
 **Key rules:**
 - Define feature lists (`NUM_FEATURES`, `CAT_FEATURES`) as module-level constants.
-- Never call `fit_transform` on test/validation data: the Pipeline handles this.
+- Never call `fit_transform` on test/validation data — the Pipeline handles this.
 - Use `handle_unknown="ignore"` in `OneHotEncoder` to survive unseen categories at inference.
 - Use `Pipeline` (not `make_pipeline`) when you need named steps for grid search: `"classifier__n_estimators"`.
-- The entire pipeline is serializable with `joblib`: ship it as one artifact.
+- The entire pipeline is serializable with `joblib` — ship it as one artifact.
 
 ---
 
@@ -142,7 +142,7 @@ Define explicit contracts for your data at pipeline boundaries. Use `DataFrameMo
 automatic runtime validation on function inputs and outputs.
 
 ```python
-# ❌ BAD: ad-hoc assertions that miss edge cases and are hard to maintain
+# ❌ BAD — ad-hoc assertions that miss edge cases and are hard to maintain
 assert df["age"].dtype == int
 assert df["age"].min() >= 0
 assert df["email"].str.contains("@").all()
@@ -151,7 +151,7 @@ assert set(df.columns) == {"age", "email", "score"}
 ```
 
 ```python
-# ✅ GOOD: pandera DataFrameModel with typed fields and reusable checks
+# ✅ GOOD — pandera DataFrameModel with typed fields and reusable checks
 import pandera.pandas as pa
 from pandera.typing import Series, DataFrame
 
@@ -169,7 +169,7 @@ class ScoredUserSchema(UserSchema):
 
 @pa.check_types
 def enrich_users(df: DataFrame[UserSchema]) -> DataFrame[ScoredUserSchema]:
-    """Validated input AND output: contract enforced at runtime."""
+    """Validated input AND output — contract enforced at runtime."""
     return df.assign(
         risk_label=lambda d: pd.cut(
             d["score"], bins=[0, 0.33, 0.66, 1.0], labels=["low", "medium", "high"]
@@ -183,7 +183,7 @@ result = enrich_users(raw_df)
 **Key rules:**
 - Prefer `DataFrameModel` (class-based) over `DataFrameSchema` (dict-based) for type safety.
 - Use `coerce=True` to auto-cast columns before checking (e.g., `"123"` to `123`).
-- Use `strict=True` to reject unexpected columns: catches schema drift early.
+- Use `strict=True` to reject unexpected columns — catches schema drift early.
 - Use `@pa.check_types` on every function at a pipeline boundary (ingestion, transformation, export).
 - Inherit schemas (`ScoredUserSchema(UserSchema)`) to extend contracts without duplication.
 
@@ -195,7 +195,7 @@ Wrap every training run in `mlflow.start_run()`, log parameters, metrics (with s
 and the final model. This makes every experiment reproducible and comparable.
 
 ```python
-# ❌ BAD: results printed to console, lost after the session
+# ❌ BAD — results printed to console, lost after the session
 model = RandomForestClassifier(n_estimators=200, max_depth=10)
 model.fit(X_train, y_train)
 print(f"Accuracy: {model.score(X_test, y_test)}")
@@ -203,7 +203,7 @@ print(f"Accuracy: {model.score(X_test, y_test)}")
 ```
 
 ```python
-# ✅ GOOD: structured experiment tracking with MLflow
+# ✅ GOOD — structured experiment tracking with MLflow
 import mlflow
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 
@@ -236,7 +236,7 @@ with mlflow.start_run(run_name="rf-baseline") as run:
     }
     mlflow.log_metrics(metrics)
 
-    # Log the model artifact: includes conda env and signature
+    # Log the model artifact — includes conda env and signature
     mlflow.sklearn.log_model(
         sk_model=model,
         artifact_path="model",
@@ -248,11 +248,11 @@ with mlflow.start_run(run_name="rf-baseline") as run:
 ```
 
 **Key rules:**
-- Always use `mlflow.start_run()` as a context manager: guarantees the run is closed.
+- Always use `mlflow.start_run()` as a context manager — guarantees the run is closed.
 - Use `log_params` (plural) to log a dict of hyperparameters in one call.
 - Use `log_metrics` (plural) to log all evaluation metrics together.
 - Use `set_tag` for metadata not related to model performance (dataset version, author, etc.).
-- Pass `input_example` to `log_model`: enables signature inference and serving validation.
+- Pass `input_example` to `log_model` — enables signature inference and serving validation.
 - For iterative training (deep learning), use `log_metric("loss", value, step=epoch)`.
 - For scikit-learn specifically, consider `mlflow.sklearn.autolog()` as a complementary tool.
 
@@ -266,7 +266,7 @@ In-place mutation makes pipelines fragile, non-deterministic, and impossible to 
 A function that modifies its input silently corrupts upstream references.
 
 ```python
-# ❌ DANGEROUS: in-place mutation
+# ❌ DANGEROUS — in-place mutation
 def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
     df["age_bucket"] = pd.cut(df["age"], bins=[0, 18, 35, 65, 120])
     df.drop(columns=["raw_timestamp"], inplace=True)
@@ -275,11 +275,11 @@ def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
 
 # Caller's original DataFrame is now silently modified
 clean = prepare_features(raw_df)
-# raw_df has ALSO been mutated: "raw_timestamp" is gone
+# raw_df has ALSO been mutated — "raw_timestamp" is gone
 ```
 
 ```python
-# ✅ SAFE: method chaining returns new DataFrames
+# ✅ SAFE — method chaining returns new DataFrames
 def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
     return (
         df
@@ -304,7 +304,7 @@ Scattering magic numbers across training scripts makes experiments unreproducibl
 comparison impossible.
 
 ```python
-# ❌ FRAGILE: hyperparameters buried in code
+# ❌ FRAGILE — hyperparameters buried in code
 model = GradientBoostingClassifier(
     n_estimators=150,
     learning_rate=0.05,
@@ -316,7 +316,7 @@ model.fit(X_train, y_train)
 ```
 
 ```python
-# ✅ TRACEABLE: config dict + MLflow tracking
+# ✅ TRACEABLE — config dict + MLflow tracking
 from dataclasses import dataclass, asdict
 
 @dataclass(frozen=True)

--- a/skills/roles/data/pipelines/SKILL.md
+++ b/skills/roles/data/pipelines/SKILL.md
@@ -24,14 +24,14 @@ Load this skill when:
 
 ## Critical Patterns
 
-### Pattern 1 — Pandas Method Chaining for Readable Transformations
+### Pattern 1: Pandas Method Chaining for Readable Transformations
 
 Use `assign`, `pipe`, `query`, and other chainable methods to build linear, readable
 transformation pipelines. Each step returns a **new** DataFrame, making the flow explicit
 and debuggable.
 
 ```python
-# ❌ BAD — imperative mutations scattered across lines
+# ❌ BAD: imperative mutations scattered across lines
 df["revenue_usd"] = df["revenue"] * df["exchange_rate"]
 df = df[df["revenue_usd"] > 0]
 df["log_revenue"] = np.log1p(df["revenue_usd"])
@@ -40,7 +40,7 @@ df = df.sort_values("log_revenue", ascending=False)
 ```
 
 ```python
-# ✅ GOOD — method chaining: each step is a pure transformation
+# ✅ GOOD: method chaining: each step is a pure transformation
 def compute_log_revenue(df: pd.DataFrame) -> pd.DataFrame:
     """Custom transform compatible with .pipe()."""
     return df.assign(log_revenue=lambda d: np.log1p(d["revenue_usd"]))
@@ -58,21 +58,21 @@ clean_df = (
 
 **Key rules:**
 - Wrap the entire chain in parentheses for multi-line readability.
-- Use `assign` for new/derived columns — it returns a new DataFrame.
+- Use `assign` for new/derived columns: it returns a new DataFrame.
 - Use `pipe` to inject custom functions into the chain without breaking the flow.
 - Use `query` instead of boolean indexing (`df[df["col"] > 0]`) inside chains.
 - Every function passed to `pipe` MUST accept a DataFrame and return a DataFrame.
 
 ---
 
-### Pattern 2 — scikit-learn Pipeline + ColumnTransformer for Reproducible Preprocessing
+### Pattern 2: scikit-learn Pipeline + ColumnTransformer for Reproducible Preprocessing
 
 Separate numeric and categorical preprocessing into sub-pipelines, combine them with
 `ColumnTransformer`, then chain the result with an estimator via `Pipeline`. This
 guarantees identical transformations at train and inference time.
 
 ```python
-# ❌ BAD — manual, fragile, order-dependent preprocessing
+# ❌ BAD: manual, fragile, order-dependent preprocessing
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
 
@@ -87,11 +87,11 @@ X_test[num_cols] = scaler.transform(X_test[num_cols])
 encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
 X_train_cat = encoder.fit_transform(X_train[cat_cols])
 X_test_cat = encoder.transform(X_test[cat_cols])
-# Easy to forget a step or apply fit_transform on test data — data leakage
+# Easy to forget a step or apply fit_transform on test data: data leakage
 ```
 
 ```python
-# ✅ GOOD — declarative Pipeline + ColumnTransformer
+# ✅ GOOD: declarative Pipeline + ColumnTransformer
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
 from sklearn.impute import SimpleImputer
@@ -121,28 +121,28 @@ model = Pipeline([
     ("classifier", RandomForestClassifier(n_estimators=200, random_state=42)),
 ])
 
-# Single call — no leakage possible
+# Single call: no leakage possible
 model.fit(X_train, y_train)
 predictions = model.predict(X_test)
 ```
 
 **Key rules:**
 - Define feature lists (`NUM_FEATURES`, `CAT_FEATURES`) as module-level constants.
-- Never call `fit_transform` on test/validation data — the Pipeline handles this.
+- Never call `fit_transform` on test/validation data: the Pipeline handles this.
 - Use `handle_unknown="ignore"` in `OneHotEncoder` to survive unseen categories at inference.
 - Use `Pipeline` (not `make_pipeline`) when you need named steps for grid search: `"classifier__n_estimators"`.
-- The entire pipeline is serializable with `joblib` — ship it as one artifact.
+- The entire pipeline is serializable with `joblib`: ship it as one artifact.
 
 ---
 
-### Pattern 3 — Data Validation with Pandera Schemas
+### Pattern 3: Data Validation with Pandera Schemas
 
 Define explicit contracts for your data at pipeline boundaries. Use `DataFrameModel`
 (class-based API) for type-annotated schemas and the `@check_types` decorator for
 automatic runtime validation on function inputs and outputs.
 
 ```python
-# ❌ BAD — ad-hoc assertions that miss edge cases and are hard to maintain
+# ❌ BAD: ad-hoc assertions that miss edge cases and are hard to maintain
 assert df["age"].dtype == int
 assert df["age"].min() >= 0
 assert df["email"].str.contains("@").all()
@@ -151,7 +151,7 @@ assert set(df.columns) == {"age", "email", "score"}
 ```
 
 ```python
-# ✅ GOOD — pandera DataFrameModel with typed fields and reusable checks
+# ✅ GOOD: pandera DataFrameModel with typed fields and reusable checks
 import pandera.pandas as pa
 from pandera.typing import Series, DataFrame
 
@@ -169,7 +169,7 @@ class ScoredUserSchema(UserSchema):
 
 @pa.check_types
 def enrich_users(df: DataFrame[UserSchema]) -> DataFrame[ScoredUserSchema]:
-    """Validated input AND output — contract enforced at runtime."""
+    """Validated input AND output: contract enforced at runtime."""
     return df.assign(
         risk_label=lambda d: pd.cut(
             d["score"], bins=[0, 0.33, 0.66, 1.0], labels=["low", "medium", "high"]
@@ -183,19 +183,19 @@ result = enrich_users(raw_df)
 **Key rules:**
 - Prefer `DataFrameModel` (class-based) over `DataFrameSchema` (dict-based) for type safety.
 - Use `coerce=True` to auto-cast columns before checking (e.g., `"123"` to `123`).
-- Use `strict=True` to reject unexpected columns — catches schema drift early.
+- Use `strict=True` to reject unexpected columns: catches schema drift early.
 - Use `@pa.check_types` on every function at a pipeline boundary (ingestion, transformation, export).
 - Inherit schemas (`ScoredUserSchema(UserSchema)`) to extend contracts without duplication.
 
 ---
 
-### Pattern 4 — Experiment Tracking with MLflow
+### Pattern 4: Experiment Tracking with MLflow
 
 Wrap every training run in `mlflow.start_run()`, log parameters, metrics (with step),
 and the final model. This makes every experiment reproducible and comparable.
 
 ```python
-# ❌ BAD — results printed to console, lost after the session
+# ❌ BAD: results printed to console, lost after the session
 model = RandomForestClassifier(n_estimators=200, max_depth=10)
 model.fit(X_train, y_train)
 print(f"Accuracy: {model.score(X_test, y_test)}")
@@ -203,7 +203,7 @@ print(f"Accuracy: {model.score(X_test, y_test)}")
 ```
 
 ```python
-# ✅ GOOD — structured experiment tracking with MLflow
+# ✅ GOOD: structured experiment tracking with MLflow
 import mlflow
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 
@@ -236,7 +236,7 @@ with mlflow.start_run(run_name="rf-baseline") as run:
     }
     mlflow.log_metrics(metrics)
 
-    # Log the model artifact — includes conda env and signature
+    # Log the model artifact: includes conda env and signature
     mlflow.sklearn.log_model(
         sk_model=model,
         artifact_path="model",
@@ -248,11 +248,11 @@ with mlflow.start_run(run_name="rf-baseline") as run:
 ```
 
 **Key rules:**
-- Always use `mlflow.start_run()` as a context manager — guarantees the run is closed.
+- Always use `mlflow.start_run()` as a context manager: guarantees the run is closed.
 - Use `log_params` (plural) to log a dict of hyperparameters in one call.
 - Use `log_metrics` (plural) to log all evaluation metrics together.
 - Use `set_tag` for metadata not related to model performance (dataset version, author, etc.).
-- Pass `input_example` to `log_model` — enables signature inference and serving validation.
+- Pass `input_example` to `log_model`: enables signature inference and serving validation.
 - For iterative training (deep learning), use `log_metric("loss", value, step=epoch)`.
 - For scikit-learn specifically, consider `mlflow.sklearn.autolog()` as a complementary tool.
 
@@ -266,7 +266,7 @@ In-place mutation makes pipelines fragile, non-deterministic, and impossible to 
 A function that modifies its input silently corrupts upstream references.
 
 ```python
-# ❌ DANGEROUS — in-place mutation
+# ❌ DANGEROUS: in-place mutation
 def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
     df["age_bucket"] = pd.cut(df["age"], bins=[0, 18, 35, 65, 120])
     df.drop(columns=["raw_timestamp"], inplace=True)
@@ -275,11 +275,11 @@ def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
 
 # Caller's original DataFrame is now silently modified
 clean = prepare_features(raw_df)
-# raw_df has ALSO been mutated — "raw_timestamp" is gone
+# raw_df has ALSO been mutated: "raw_timestamp" is gone
 ```
 
 ```python
-# ✅ SAFE — method chaining returns new DataFrames
+# ✅ SAFE: method chaining returns new DataFrames
 def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
     return (
         df
@@ -304,7 +304,7 @@ Scattering magic numbers across training scripts makes experiments unreproducibl
 comparison impossible.
 
 ```python
-# ❌ FRAGILE — hyperparameters buried in code
+# ❌ FRAGILE: hyperparameters buried in code
 model = GradientBoostingClassifier(
     n_estimators=150,
     learning_rate=0.05,
@@ -316,7 +316,7 @@ model.fit(X_train, y_train)
 ```
 
 ```python
-# ✅ TRACEABLE — config dict + MLflow tracking
+# ✅ TRACEABLE: config dict + MLflow tracking
 from dataclasses import dataclass, asdict
 
 @dataclass(frozen=True)

--- a/skills/roles/data/pipelines/SKILL.md
+++ b/skills/roles/data/pipelines/SKILL.md
@@ -260,7 +260,7 @@ with mlflow.start_run(run_name="rf-baseline") as run:
 
 ## Anti-Patterns
 
-### Anti-Pattern 1 — Mutating DataFrames In-Place
+### Anti-Pattern 1: Mutating DataFrames In-Place
 
 In-place mutation makes pipelines fragile, non-deterministic, and impossible to debug.
 A function that modifies its input silently corrupts upstream references.
@@ -298,7 +298,7 @@ in the other. Method chaining with immutable returns makes data flow explicit an
 
 ---
 
-### Anti-Pattern 2 — Hardcoding Hyperparameters
+### Anti-Pattern 2: Hardcoding Hyperparameters
 
 Scattering magic numbers across training scripts makes experiments unreproducible and
 comparison impossible.

--- a/skills/roles/devops/cicd/SKILL.md
+++ b/skills/roles/devops/cicd/SKILL.md
@@ -319,7 +319,7 @@ jobs:
 
 ## Anti-Patterns
 
-### Don't: Use `latest` as Image Tag
+### Anti-Pattern 1: Use `latest` as Image Tag
 
 ```dockerfile
 # ❌ BAD — not reproducible, breaks caching
@@ -329,7 +329,7 @@ FROM node:latest
 FROM node:20.11-alpine
 ```
 
-### Don't: Pipeline Without Fail-Fast
+### Anti-Pattern 2: Pipeline Without Fail-Fast
 
 ```yaml
 # ❌ BAD — deploys even if tests fail
@@ -344,7 +344,7 @@ stages:
     condition: succeeded()
 ```
 
-### Don't: Install Dev Dependencies in Production Image
+### Anti-Pattern 3: Install Dev Dependencies in Production Image
 
 ```dockerfile
 # ❌ BAD — image includes test/build tools
@@ -354,7 +354,7 @@ RUN npm install
 RUN npm ci --only=production
 ```
 
-### Don't: Run Containers as Root
+### Anti-Pattern 4: Run Containers as Root
 
 ```dockerfile
 # ❌ BAD — runs as root (security risk)
@@ -366,7 +366,7 @@ USER appuser
 CMD ["node", "dist/index.js"]
 ```
 
-### Don't: Skip .dockerignore
+### Anti-Pattern 5: Skip .dockerignore
 
 ```
 # .dockerignore — always include one
@@ -379,7 +379,7 @@ coverage
 .github
 ```
 
-### Don't: Hardcode Environment-Specific Values
+### Anti-Pattern 6: Hardcode Environment-Specific Values
 
 ```yaml
 # ❌ BAD — environment baked into pipeline

--- a/skills/roles/devops/monitoring/SKILL.md
+++ b/skills/roles/devops/monitoring/SKILL.md
@@ -359,7 +359,7 @@ async function callDownstream(url: string) {
 
 ## Anti-Patterns
 
-### Don't: Log Sensitive Data
+### Anti-Pattern 1: Log Sensitive Data
 
 ```typescript
 // ❌ BAD — leaks credentials into log aggregator
@@ -369,7 +369,7 @@ logger.info({ password: user.password, token }, 'Auth attempt')
 logger.info({ userId: user.id, hasToken: !!token }, 'Auth attempt')
 ```
 
-### Don't: Use String Interpolation in Log Messages
+### Anti-Pattern 2: Use String Interpolation in Log Messages
 
 ```typescript
 // ❌ BAD — prevents log aggregation (every message is unique)
@@ -379,7 +379,7 @@ logger.info(`User ${userId} placed order ${orderId}`)
 logger.info({ userId, orderId }, 'Order placed')
 ```
 
-### Don't: High-Cardinality Labels
+### Anti-Pattern 3: High-Cardinality Labels
 
 ```typescript
 // ❌ BAD — userId as label creates millions of time series, kills Prometheus
@@ -395,7 +395,7 @@ const counter = new Counter({
 })
 ```
 
-### Don't: Alert on Symptoms Without Context
+### Anti-Pattern 4: Alert on Symptoms Without Context
 
 ```
 ❌ BAD: Alert on "disk usage > 80%" with no follow-up
@@ -403,7 +403,7 @@ const counter = new Counter({
          with a runbook link explaining how to expand or clean up
 ```
 
-### Don't: Ignore Log Correlation
+### Anti-Pattern 5: Ignore Log Correlation
 
 ```typescript
 // ❌ BAD — logs from different services can't be correlated

--- a/skills/roles/frontend/nextjs/SKILL.md
+++ b/skills/roles/frontend/nextjs/SKILL.md
@@ -373,7 +373,7 @@ export default function DashboardError({
 
 ## Anti-Patterns
 
-### Don't: Client-side fetch when Server Components can do it
+### Anti-Pattern 1: Client-side fetch when Server Components can do it
 
 ```typescript
 // ❌ BAD — useEffect fetch in a Client Component
@@ -393,7 +393,7 @@ export default async function ProductList() {
 }
 ```
 
-### Don't: `'use client'` at the page level
+### Anti-Pattern 2: `'use client'` at the page level
 
 ```typescript
 // ❌ BAD — entire page is a Client Component
@@ -412,7 +412,7 @@ export default async function SettingsPage() {
 }
 ```
 
-### Don't: Await sequential fetches without streaming
+### Anti-Pattern 3: Await sequential fetches without streaming
 
 ```typescript
 // ❌ BAD — waterfall: total time = sum of all fetches

--- a/skills/roles/frontend/react/SKILL.md
+++ b/skills/roles/frontend/react/SKILL.md
@@ -434,7 +434,7 @@ export function Select<T>({ items, value, onChange, getLabel, getKey }: SelectPr
 
 ## Anti-Patterns
 
-### Don't: Side effects during render
+### Anti-Pattern 1: Side effects during render
 
 ```typescript
 // ❌ BAD — runs on every render, blocks paint
@@ -452,7 +452,7 @@ export function List({ items }: ListProps) {
 }
 ```
 
-### Don't: Components with too many responsibilities
+### Anti-Pattern 2: Components with too many responsibilities
 
 ```typescript
 // ❌ BAD — fetches, parses, validates, and renders all in one (200+ lines)
@@ -465,7 +465,7 @@ export function UserDashboard() {
 }
 ```
 
-### Don't: Array index as key for dynamic lists
+### Anti-Pattern 3: Array index as key for dynamic lists
 
 ```typescript
 // ❌ BAD — index keys break state when items reorder or delete
@@ -475,7 +475,7 @@ export function UserDashboard() {
 {items.map(item => <TodoItem key={item.id} item={item} />)}
 ```
 
-### Don't: Derive state that can be computed
+### Anti-Pattern 4: Derive state that can be computed
 
 ```typescript
 // ❌ BAD — syncing derived state with useEffect

--- a/skills/roles/frontend/react/SKILL.md
+++ b/skills/roles/frontend/react/SKILL.md
@@ -509,7 +509,7 @@ const filteredItems = items.filter(i => i.active)
 | Error Boundary             | Catch render errors — wrap per independent section    |
 | React.lazy                 | Code split heavy/conditional components               |
 | key prop reset             | Force remount when identity changes (e.g. chat ID)    |
-| forwardRef                 | Reusable primitives that expose DOM ref               |
+| forwardRef                 | Reusable primitives that expose DOM ref (pre-React 19; React 19+ uses ref as prop directly) |
 | useMemo                    | Expensive computations — profile first                |
 | useCallback                | Stable ref for memoized children — profile first      |
 | Generic components         | Reusable UI that works with multiple data types       |

--- a/skills/roles/mobile/architecture/SKILL.md
+++ b/skills/roles/mobile/architecture/SKILL.md
@@ -24,7 +24,7 @@ metadata:
 
 ## Critical Patterns
 
-### 1. File-Based Routing with Expo Router
+### Pattern 1: File-Based Routing with Expo Router
 
 Expo Router maps the `app/` directory to navigation routes. Layout files (`_layout.tsx`) define
 navigators. Route groups `(groupName)` organize routes without affecting the URL. Use typed
@@ -120,7 +120,7 @@ export default function TabLayout() {
 
 ---
 
-### 2. FlashList Over FlatList for Large Lists
+### Pattern 2: FlashList Over FlatList for Large Lists
 
 FlashList from `@shopify/flash-list` is a drop-in replacement for FlatList with recycling-based
 rendering. It is dramatically faster for lists with 100+ items.
@@ -172,7 +172,7 @@ export function Feed({ items }: { items: FeedItem[] }) {
 
 ---
 
-### 3. State Management: Zustand (Client) + TanStack Query (Server)
+### Pattern 3: State Management: Zustand (Client) + TanStack Query (Server)
 
 Separate **client UI state** (modals, filters, theme) from **server/async state** (API data,
 pagination, cache). Zustand owns client state. TanStack Query owns server state.
@@ -255,7 +255,7 @@ export function UserListScreen() {
 
 ---
 
-### 4. Platform-Specific Code Isolation
+### Pattern 4: Platform-Specific Code Isolation
 
 React Native resolves `.ios.tsx` and `.android.tsx` extensions automatically. Use this for
 components with fundamentally different native behavior. For minor tweaks, use `Platform.select`.
@@ -344,7 +344,7 @@ import { DatePicker } from "@/components/date-picker/date-picker";
 
 ## Anti-Patterns
 
-### 1. Using FlatList for Large Lists
+### Anti-Pattern 1: Using FlatList for Large Lists
 
 FlatList creates and destroys views on scroll — no recycling. For lists beyond ~100 items, this
 causes frame drops and high memory usage. FlashList's recycling architecture maintains 60fps
@@ -358,7 +358,7 @@ add `estimatedItemSize` (v1), and verify in release mode. See Pattern 2 above.
 
 ---
 
-### 2. Inline Styles Instead of StyleSheet.create or NativeWind
+### Anti-Pattern 2: Inline Styles Instead of StyleSheet.create or NativeWind
 
 Inline style objects are re-created on every render, triggering unnecessary bridge
 serialization and layout recalculations. This adds up in lists and animated views.

--- a/skills/roles/mobile/testing/SKILL.md
+++ b/skills/roles/mobile/testing/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 
 ## Critical Patterns
 
-### 1. Component Testing with RNTL (render, screen, userEvent)
+### Pattern 1: Component Testing with RNTL (render, screen, userEvent)
 
 Use `@testing-library/react-native` with **userEvent** for realistic interactions.
 Query by **role first**, then label, then text. Avoid testID when an accessible query exists.
@@ -81,7 +81,7 @@ test('submits login form with valid credentials', async () => {
 
 ---
 
-### 2. Mocking Native Modules in jest.setup.ts
+### Pattern 2: Mocking Native Modules in jest.setup.ts
 
 Native modules crash under Jest because there is no bridge. Mock them in a central
 setup file referenced by `setupFiles` in your Jest config.
@@ -156,7 +156,7 @@ jest.mock('expo-location', () => ({
 
 ---
 
-### 3. Testing Navigation (mocking useNavigation / useRouter)
+### Pattern 3: Testing Navigation (mocking useNavigation / useRouter)
 
 Navigation tests should verify that the correct **route** is called, not that the
 navigator renders. Mock the hook, not the entire library.
@@ -238,7 +238,7 @@ test('pushes to profile screen', async () => {
 
 ---
 
-### 4. E2E Testing with Detox (device, element, expect)
+### Pattern 4: E2E Testing with Detox (device, element, expect)
 
 Detox tests run on a real simulator/emulator. They use `element()`, `by.*` matchers,
 actions (`.tap()`, `.typeText()`), and `expect()` assertions.
@@ -299,7 +299,7 @@ describe('Login flow', () => {
 
 ## Anti-Patterns
 
-### 1. Snapshot Tests for Behavior Verification
+### Anti-Pattern 1: Snapshot Tests for Behavior Verification
 
 Snapshot tests capture rendered output as a string. They are useful for detecting
 **unintentional UI changes** but tell you nothing about **behavior**.
@@ -331,7 +331,7 @@ of service screen) against accidental changes. Never as the only test for a comp
 
 ---
 
-### 2. Testing Implementation Details (testID Over Accessible Queries)
+### Anti-Pattern 2: Testing Implementation Details (testID Over Accessible Queries)
 
 Querying by `testID` when an accessible role or label exists couples tests to
 implementation rather than user-visible behavior.

--- a/skills/roles/python/api-design/SKILL.md
+++ b/skills/roles/python/api-design/SKILL.md
@@ -466,7 +466,7 @@ app = FastAPI(
 
 ## Anti-Patterns
 
-### Don't: Bare except
+### Anti-Pattern 1: Bare except
 
 ```python
 # ❌ BAD — swallows all errors silently
@@ -483,7 +483,7 @@ except SpecificError as e:
     raise
 ```
 
-### Don't: Use sync DB calls in async endpoints
+### Anti-Pattern 2: Use sync DB calls in async endpoints
 
 ```python
 # ❌ BAD — blocks the event loop
@@ -498,7 +498,7 @@ async def get_user(user_id: str, db: AsyncSession = Depends(get_db)):
     return result.scalar_one_or_none()
 ```
 
-### Don't: Return ORM models directly
+### Anti-Pattern 3: Return ORM models directly
 
 ```python
 # ❌ BAD — leaks internal fields and breaks if ORM changes

--- a/skills/roles/python/testing/SKILL.md
+++ b/skills/roles/python/testing/SKILL.md
@@ -439,7 +439,7 @@ async def test_welcome_email_sent_after_registration(client, sample_user):
 
 ## Anti-Patterns
 
-### Don't: Tests that depend on execution order
+### Anti-Pattern 1: Tests that depend on execution order
 
 ```python
 # ❌ BAD — test_b depends on test_a having run first
@@ -460,7 +460,7 @@ async def test_get_user(client, sample_user):
     assert response.status_code == 200
 ```
 
-### Don't: Test implementation details
+### Anti-Pattern 2: Test implementation details
 
 ```python
 # ❌ BAD — asserting on internal method calls
@@ -475,7 +475,7 @@ async def test_register_creates_user(client, sample_user):
     assert response.json()["email"] == sample_user["email"]
 ```
 
-### Don't: Ignore test isolation
+### Anti-Pattern 3: Ignore test isolation
 
 ```python
 # ❌ BAD — shared mutable state between tests

--- a/skills/shared/architecture/SKILL.md
+++ b/skills/shared/architecture/SKILL.md
@@ -247,7 +247,7 @@ func (r *RedisStorage) Set(key string, value string) error {
 
 ## Anti-Patterns
 
-### Don't: Business Logic in UI/Handler Layer
+### Anti-Pattern 1: Business Logic in UI/Handler Layer
 
 ```typescript
 // ❌ BAD — discount calculation in a UI component
@@ -279,7 +279,7 @@ def create_order():
     return jsonify(order.to_dict())
 ```
 
-### Don't: Framework Lock-in in Domain
+### Anti-Pattern 2: Framework Lock-in in Domain
 
 ```java
 // ❌ BAD — domain entity tied to JPA
@@ -298,7 +298,7 @@ public class User {
 // JPA mapping lives in the data layer, not in domain
 ```
 
-### Don't: God Modules
+### Anti-Pattern 3: God Modules
 
 ```
 # ❌ BAD — one file/module does everything

--- a/skills/shared/code-quality/SKILL.md
+++ b/skills/shared/code-quality/SKILL.md
@@ -337,7 +337,7 @@ class UserRepository:
 
 ## Anti-Patterns
 
-### Don't: Non-null Assertions Without Context
+### Anti-Pattern 1: Non-null Assertions Without Context
 
 ```typescript
 // ❌ BAD
@@ -348,7 +348,7 @@ const value = map.get(key);
 if (!value) throw new Error(`Key not found: ${key}`);
 ```
 
-### Don't: Swallow Errors Silently
+### Anti-Pattern 2: Swallow Errors Silently
 
 ```python
 # ❌ BAD
@@ -365,7 +365,7 @@ except PaymentError as e:
     raise
 ```
 
-### Don't: Boolean Parameters That Change Behavior
+### Anti-Pattern 3: Boolean Parameters That Change Behavior
 
 ```java
 // ❌ BAD — what does `true` mean here?
@@ -379,7 +379,7 @@ generateReport(data, new ReportOptions(
 ));
 ```
 
-### Don't: Magic Numbers and Strings
+### Anti-Pattern 4: Magic Numbers and Strings
 
 ```go
 // ❌ BAD

--- a/skills/shared/debug/SKILL.md
+++ b/skills/shared/debug/SKILL.md
@@ -245,7 +245,7 @@ public class OrderService {
 
 ## Anti-Patterns
 
-### Don't: Swallow Errors Silently
+### Anti-Pattern 1: Swallow Errors Silently
 
 ```typescript
 // ❌ BAD
@@ -279,7 +279,7 @@ except SpecificError as e:
     return fallback_value
 ```
 
-### Don't: Log and Throw (Double Handling)
+### Anti-Pattern 2: Log and Throw (Double Handling)
 
 ```java
 // ❌ BAD — logs the error AND throws it → duplicate log entries
@@ -299,7 +299,7 @@ try {
 }
 ```
 
-### Don't: Catch Generic Exceptions
+### Anti-Pattern 3: Catch Generic Exceptions
 
 ```python
 # ❌ BAD — catches everything including KeyboardInterrupt
@@ -316,7 +316,7 @@ except (ConnectionError, TimeoutError) as e:
     return None
 ```
 
-### Don't: Use Print Debugging in Production Code
+### Anti-Pattern 4: Use Print Debugging in Production Code
 
 ```go
 // ❌ BAD — fmt.Println left in production code

--- a/skills/shared/performance/SKILL.md
+++ b/skills/shared/performance/SKILL.md
@@ -292,14 +292,14 @@ const [user, orders, profile] = await Promise.all([
 
 ## Anti-Patterns
 
-### Don't: Premature Optimization
+### Anti-Pattern 1: Premature Optimization
 
 ```
 ❌ BAD: "Let me add Redis caching to every endpoint just in case"
 ✅ GOOD: Profile → find the actual bottleneck → cache only what's slow
 ```
 
-### Don't: Load Entire Datasets Into Memory
+### Anti-Pattern 2: Load Entire Datasets Into Memory
 
 ```java
 // ❌ BAD — loads everything
@@ -312,7 +312,7 @@ try (Stream<Transaction> stream = transactionRepo.streamAll()) {
 }
 ```
 
-### Don't: Ignore Resource Cleanup
+### Anti-Pattern 3: Ignore Resource Cleanup
 
 ```go
 // ❌ BAD — response body never closed → connection leak
@@ -335,7 +335,7 @@ with open("large.csv") as f:
     data = f.read()
 ```
 
-### Don't: Cache Without Invalidation Strategy
+### Anti-Pattern 4: Cache Without Invalidation Strategy
 
 ```
 ❌ BAD: cache.set("user:123", user_data)  // no TTL, no invalidation → stale forever

--- a/skills/shared/thinking/SKILL.md
+++ b/skills/shared/thinking/SKILL.md
@@ -229,7 +229,7 @@ Start by reviewing those changes.
 
 ## Anti-Patterns
 
-### Don't: Jump Straight to Code
+### Anti-Pattern 1: Jump Straight to Code
 
 ```
 ❌ User: "I need authentication"
@@ -241,7 +241,7 @@ Start by reviewing those changes.
            Do you need role-based access?"
 ```
 
-### Don't: Abstract Prematurely
+### Anti-Pattern 2: Abstract Prematurely
 
 ```
 ❌ Create BaseRepository<T> when you only have one use case
@@ -249,7 +249,7 @@ Start by reviewing those changes.
 ✅ Implement directly. Extract an abstraction at the second real case.
 ```
 
-### Don't: Confuse Effort with Progress
+### Anti-Pattern 3: Confuse Effort with Progress
 
 ```
 ❌ "I spent 3 days building a perfect config system"
@@ -258,7 +258,7 @@ Start by reviewing those changes.
 ✅ Start with hardcoded values → extract config when needed
 ```
 
-### Don't: Optimize for the Wrong Audience
+### Anti-Pattern 4: Optimize for the Wrong Audience
 
 ```
 ❌ "This architecture will support 10 million users"
@@ -268,7 +268,7 @@ Start by reviewing those changes.
    You'll rewrite before you hit 10M anyway.
 ```
 
-### Don't: Ignore the "Do Nothing" Option
+### Anti-Pattern 5: Ignore the "Do Nothing" Option
 
 ```
 ❌ "We need to migrate from REST to GraphQL"


### PR DESCRIPTION
﻿Closes #138

## PR Type
- [x] Maintenance/tooling

## Summary
- Normalized all anti-pattern headings from `### Don't:` to `### Anti-Pattern N:` across 16 skill files
- Standardized pattern numbering (`### 1.` → `### Pattern 1:`) and em-dash headings to colons
- Normalized 4 pack section names to `Code Quality Rules` + `Thinking Rules`, kept Testing/Naming at H2
- Removed redundant H1 headers and updated React forwardRef for React 19

## Changes

| File | Change |
|------|--------|
| 16 `skills/roles/*/SKILL.md` + `skills/shared/*/SKILL.md` | `Don't:` → `Anti-Pattern N:`, pattern numbering |
| `skills/roles/data/pipelines/SKILL.md` | Em-dash headings → colons (headings only) |
| 4 `packs/*/rules.md` | Section rename + Thinking Rules added |
| `skills/roles/frontend/react/SKILL.md` | forwardRef React 19 note |
| `skills/roles/backend-java/testing/SKILL.md` | Removed extra H1 |
| `skills/roles/backend-dotnet/testing/SKILL.md` | Removed extra H1 |

## Test Plan
- [x] All changes are markdown-only — no scripts modified
- [x] Skills load correctly (content preserved, only headings changed)
- [x] Judgment Day: 3 rounds, both judges CLEAN on Round 3

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
