### PR TITLE
chore(ci): improve CI coverage and add project configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
+end_of_line = lf
+
+[*.ps1]
+end_of_line = crlf
+
+[*.{yml,yaml}]
+end_of_line = lf
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,4 @@ trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab
+end_of_line = lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         shell: pwsh
         run: |
           $config = New-PesterConfiguration
-          $config.Run.Path = "./tests/functions.Tests.ps1"
+          $config.Run.Path = @("./tests/functions.Tests.ps1", "./tests/skills.Tests.ps1")
           $config.Output.Verbosity = "Detailed"
           $config.TestResult.Enabled = $true
           $config.TestResult.OutputPath = "./testResults.xml"
@@ -51,7 +51,7 @@ jobs:
         run: sudo apt-get install -y shellcheck
 
       - name: Run shellcheck on scripts
-        run: shellcheck --severity=warning -s bash bin/team-ai-kit lib/functions.sh
+        run: shellcheck --severity=warning -s bash bin/team-ai-kit lib/functions.sh tests/e2e-bash.sh tests/functions-bash.sh
 
   bash-e2e:
     name: Bash E2E Tests (Ubuntu)
@@ -70,3 +70,21 @@ jobs:
 
       - name: Run E2E tests
         run: bash tests/e2e-bash.sh
+
+  version-sync:
+    name: Version Sync Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify bash and PS1 versions match
+        run: |
+          bash_version=$(grep -oP "^KIT_VERSION='\\K[^']+" bin/team-ai-kit)
+          ps1_version=$(grep -oP "^\\$KitVersion = '\\K[^']+" bin/team-ai-kit.ps1)
+          echo "Bash version: $bash_version"
+          echo "PS1 version:  $ps1_version"
+          if [ "$bash_version" != "$ps1_version" ]; then
+            echo "::error::Version mismatch! Bash=$bash_version PS1=$ps1_version"
+            exit 1
+          fi
+          echo "✅ Versions match: $bash_version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
         run: |
           bash_version=$(grep -oP "^KIT_VERSION='\\K[^']+" bin/team-ai-kit)
           ps1_version=$(grep -oP "^\\$KitVersion = '\\K[^']+" bin/team-ai-kit.ps1)
+          if [ -z "$bash_version" ] || [ -z "$ps1_version" ]; then
+            echo "::error::Could not extract version from one or both scripts (bash='$bash_version' ps1='$ps1_version')"
+            exit 1
+          fi
           echo "Bash version: $bash_version"
           echo "PS1 version:  $ps1_version"
           if [ "$bash_version" != "$ps1_version" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
 
       - name: Verify bash and PS1 versions match
         run: |
-          bash_version=$(grep -oP "^KIT_VERSION='\\K[^']+" bin/team-ai-kit)
-          ps1_version=$(grep -oP "^\\$KitVersion = '\\K[^']+" bin/team-ai-kit.ps1)
+          bash_version=$(sed -n "s/^KIT_VERSION='\(.*\)'/\1/p" bin/team-ai-kit)
+          ps1_version=$(sed -n "s/^\$KitVersion = '\(.*\)'/\1/p" bin/team-ai-kit.ps1)
           if [ -z "$bash_version" ] || [ -z "$ps1_version" ]; then
             echo "::error::Could not extract version from one or both scripts (bash='$bash_version' ps1='$ps1_version')"
             exit 1
@@ -91,4 +91,4 @@ jobs:
             echo "::error::Version mismatch! Bash=$bash_version PS1=$ps1_version"
             exit 1
           fi
-          echo "✅ Versions match: $bash_version"
+          echo "Versions match: $bash_version"

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ team-ai-kit/
 ├── tests/
 │   ├── functions.Tests.ps1        Unit tests (Pester)
 │   ├── skills.Tests.ps1           Skill validation tests (Pester)
-│   ├── functions-bash.sh           Unit tests (bash)
+│   ├── functions-bash.sh          Unit tests (bash)
 │   └── e2e-bash.sh                E2E tests (bash)
 ├── docs/
 │   ├── examples-by-role.md        Detailed examples per role

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ team-ai-kit/
 ├── tests/
 │   ├── functions.Tests.ps1        Unit tests (Pester)
 │   ├── skills.Tests.ps1           Skill validation tests (Pester)
+│   ├── functions-bash.sh           Unit tests (bash)
 │   └── e2e-bash.sh                E2E tests (bash)
 ├── docs/
 │   ├── examples-by-role.md        Detailed examples per role

--- a/tests/e2e-bash.sh
+++ b/tests/e2e-bash.sh
@@ -95,7 +95,7 @@ echo "--- Test 6: user modification preserved ---"
 arch_skill="$TEST_DIR/team-skills/shared/architecture/SKILL.md"
 if [ -f "$arch_skill" ]; then
     echo '# MY CUSTOM ARCHITECTURE RULES' > "$arch_skill"
-    bash "$KIT_ROOT/bin/team-ai-kit" update --target-dir "$TEST_DIR" 2>&1 >/dev/null || true
+    bash "$KIT_ROOT/bin/team-ai-kit" update --target-dir "$TEST_DIR" >/dev/null 2>&1 || true
     content=$(cat "$arch_skill")
     if echo "$content" | grep -q "MY CUSTOM"; then
         pass "user modification preserved"
@@ -157,7 +157,7 @@ IJ_TEST_DIR="/tmp/team-ai-kit-e2e-ij-$$"
 IJ_HOME="/tmp/team-ai-kit-e2e-ij-home-$$"
 mkdir -p "$IJ_HOME" "$IJ_TEST_DIR/.git"
 # Setup with intellij first
-HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide intellij --role backend-node --target-dir "$IJ_TEST_DIR" --skip-prerequisites --skip-gentle-ai 2>&1 >/dev/null || true
+HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide intellij --role backend-node --target-dir "$IJ_TEST_DIR" --skip-prerequisites --skip-gentle-ai >/dev/null 2>&1 || true
 # Now init
 (cd "$IJ_TEST_DIR" && HOME="$IJ_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init 2>&1) >/dev/null || true
 ij_instructions="$IJ_TEST_DIR/.github/copilot-instructions.md"
@@ -225,7 +225,7 @@ DRYRUN_DIR="/tmp/team-ai-kit-dryrun-$$"
 DRYRUN_HOME="/tmp/team-ai-kit-dryrun-home-$$"
 mkdir -p "$DRYRUN_HOME" "$DRYRUN_DIR/.git"
 # Setup first
-HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide vscode --role frontend --target-dir "$DRYRUN_DIR" --skip-prerequisites --skip-gentle-ai 2>&1 >/dev/null || true
+HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" setup --ide vscode --role frontend --target-dir "$DRYRUN_DIR" --skip-prerequisites --skip-gentle-ai >/dev/null 2>&1 || true
 # Init with --dry-run
 output=$(cd "$DRYRUN_DIR" && HOME="$DRYRUN_HOME" bash "$KIT_ROOT/bin/team-ai-kit" init --dry-run 2>&1) || true
 if echo "$output" | grep -q "\[DRY-RUN\]"; then


### PR DESCRIPTION
﻿Closes #139

## PR Type
- [x] Maintenance/tooling

## Summary
- Added `skills.Tests.ps1` to Pester CI job and expanded shellcheck to cover all 4 bash files
- Added version-sync CI job that fails if bash and PS1 versions diverge (with empty extraction guard)
- Added `.editorconfig` for consistent formatting across contributors
- Updated README project structure to include `tests/functions-bash.sh`

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added skills.Tests.ps1 to Pester path, expanded shellcheck targets, new version-sync job |
| `.editorconfig` | New file: indent, line endings, trailing whitespace rules |
| `README.md` | Added functions-bash.sh to project structure tree |

## Test Plan
- [x] CI YAML syntax validated
- [x] Version sync grep patterns verified against actual file content
- [x] Judgment Day: Round 1 clean (minor fixes applied inline)

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
