### PR TITLE
fix(cli): call Get-TeamAiKitConfig instead of non-existent Get-Config

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -174,7 +174,7 @@ function Resolve-TeamRepo {
         if ($pc -and $pc.teamRepo) { return $pc.teamRepo }
     }
 
-    $globalConfig = Get-Config
+    $globalConfig = Get-TeamAiKitConfig
     if ($globalConfig.teamRepo) { return $globalConfig.teamRepo }
 
     return ''


### PR DESCRIPTION
﻿## Summary
- Fixes `Resolve-TeamRepo` in `lib/functions.ps1` calling non-existent `Get-Config` (should be `Get-TeamAiKitConfig`)
- Runtime crash when resolving team repo from global config without `--team-repo` flag

## Changes
- `lib/functions.ps1:177` — `Get-Config` changed to `Get-TeamAiKitConfig`

Closes #146
