### PR TITLE
fix(config): align .editorconfig ps1 eol to LF matching .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 end_of_line = lf
 
 [*.ps1]
-end_of_line = crlf
+end_of_line = lf
 
 [*.{yml,yaml}]
 end_of_line = lf


### PR DESCRIPTION
﻿## Summary
- Aligns `.editorconfig` ps1 line ending from CRLF to LF, matching `.gitattributes`
- Prevents phantom diffs when editors save ps1 files with CRLF that git normalizes back to LF

## Changes
- `.editorconfig:14` — `end_of_line = crlf` changed to `end_of_line = lf`

Closes #147
