### PR TITLE
refactor(lib): extract duplicated engram protocol into shared template

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1614,100 +1614,11 @@ function New-IntelliJMcpConfig {
 function Get-EngramProtocolContent {
     <#
     .SYNOPSIS
-        Returns the Engram Memory Protocol markdown content wrapped in markers.
-        Uses single-quoted here-string to prevent accidental variable expansion.
+        Returns the Engram Memory Protocol markdown content from shared template.
+        Single source of truth: templates/engram-protocol.md
     #>
-    return @'
-
-<!-- team-ai-kit:engram-protocol -->
-## Engram Persistent Memory -- Protocol
-
-You have access to Engram, a persistent memory system that survives across sessions and compactions.
-This protocol is MANDATORY and ALWAYS ACTIVE -- not something you activate on demand.
-
-### PROACTIVE SAVE TRIGGERS (mandatory -- do NOT wait for user to ask)
-
-Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
-- Architecture or design decision made
-- Team convention documented or established
-- Workflow change agreed upon
-- Tool or library choice made with tradeoffs
-- Bug fix completed (include root cause)
-- Feature implemented with non-obvious approach
-- Configuration change or environment setup done
-- Non-obvious discovery about the codebase
-- Gotcha, edge case, or unexpected behavior found
-- Pattern established (naming, structure, convention)
-- User preference or constraint learned
-
-Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
-
-Format for `mem_save`:
-- **title**: Verb + what -- short, searchable (e.g. "Fixed N+1 query in UserList")
-- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
-- **scope**: `project` (default) | `personal`
-- **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
-- **content**:
-  - **What**: One sentence -- what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
-
-Topic update rules:
-- Different topics MUST NOT overwrite each other
-- Same topic evolving -> use same `topic_key` (upsert)
-- Unsure about key -> call `mem_suggest_topic_key` first
-- Know exact ID to fix -> use `mem_update`
-
-### WHEN TO SEARCH MEMORY
-
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "que hicimos", or references to past work:
-1. Call `mem_context` -- checks recent session history (fast, cheap)
-2. If not found, call `mem_search` with relevant keywords
-3. If found, use `mem_get_observation` for full untruncated content
-
-Also search PROACTIVELY when:
-- Starting work on something that might have been done before
-- User mentions a topic you have no context on
-- User's FIRST message references the project, a feature, or a problem -- call `mem_search` with keywords from their message to check for prior work before responding
-
-### SESSION CLOSE PROTOCOL (mandatory)
-
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary` with this structure:
-
-```
-## Goal
-[What we were working on this session]
-
-## Instructions
-[User preferences or constraints discovered -- skip if none]
-
-## Discoveries
-- [Technical findings, gotchas, non-obvious learnings]
-
-## Accomplished
-- [Completed items with key details]
-
-## Next Steps
-- [What remains to be done -- for the next session]
-
-## Relevant Files
-- path/to/file -- [what it does or what changed]
-```
-
-This is NOT optional. If you skip this, the next session starts blind.
-
-### AFTER COMPACTION
-
-If you see a compaction message or "FIRST ACTION REQUIRED":
-1. IMMEDIATELY call `mem_session_summary` with the compacted summary content -- this persists what was done before compaction
-2. Call `mem_context` to recover additional context from previous sessions
-3. Only THEN continue working
-
-Do not skip step 1. Without it, everything done before compaction is lost from memory.
-<!-- /team-ai-kit:engram-protocol -->
-
-'@
+    $kitRoot = Split-Path -Parent $PSScriptRoot
+    Get-Content (Join-Path $kitRoot 'templates' 'engram-protocol.md') -Raw
 }
 
 function Update-InstructionsEngramProtocol {

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1307,99 +1307,11 @@ update_instructions_team_rules() {
 }
 
 get_engram_protocol_content() {
-    # Returns the Engram Memory Protocol markdown content wrapped in markers.
-    # Uses single-quoted heredoc delimiter to prevent variable expansion.
-    cat <<'ENGRAM_PROTOCOL_EOF'
-
-<!-- team-ai-kit:engram-protocol -->
-## Engram Persistent Memory -- Protocol
-
-You have access to Engram, a persistent memory system that survives across sessions and compactions.
-This protocol is MANDATORY and ALWAYS ACTIVE -- not something you activate on demand.
-
-### PROACTIVE SAVE TRIGGERS (mandatory -- do NOT wait for user to ask)
-
-Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
-- Architecture or design decision made
-- Team convention documented or established
-- Workflow change agreed upon
-- Tool or library choice made with tradeoffs
-- Bug fix completed (include root cause)
-- Feature implemented with non-obvious approach
-- Configuration change or environment setup done
-- Non-obvious discovery about the codebase
-- Gotcha, edge case, or unexpected behavior found
-- Pattern established (naming, structure, convention)
-- User preference or constraint learned
-
-Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
-
-Format for `mem_save`:
-- **title**: Verb + what -- short, searchable (e.g. "Fixed N+1 query in UserList")
-- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
-- **scope**: `project` (default) | `personal`
-- **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
-- **content**:
-  - **What**: One sentence -- what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
-
-Topic update rules:
-- Different topics MUST NOT overwrite each other
-- Same topic evolving -> use same `topic_key` (upsert)
-- Unsure about key -> call `mem_suggest_topic_key` first
-- Know exact ID to fix -> use `mem_update`
-
-### WHEN TO SEARCH MEMORY
-
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "que hicimos", or references to past work:
-1. Call `mem_context` -- checks recent session history (fast, cheap)
-2. If not found, call `mem_search` with relevant keywords
-3. If found, use `mem_get_observation` for full untruncated content
-
-Also search PROACTIVELY when:
-- Starting work on something that might have been done before
-- User mentions a topic you have no context on
-- User's FIRST message references the project, a feature, or a problem -- call `mem_search` with keywords from their message to check for prior work before responding
-
-### SESSION CLOSE PROTOCOL (mandatory)
-
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary` with this structure:
-
-```
-## Goal
-[What we were working on this session]
-
-## Instructions
-[User preferences or constraints discovered -- skip if none]
-
-## Discoveries
-- [Technical findings, gotchas, non-obvious learnings]
-
-## Accomplished
-- [Completed items with key details]
-
-## Next Steps
-- [What remains to be done -- for the next session]
-
-## Relevant Files
-- path/to/file -- [what it does or what changed]
-```
-
-This is NOT optional. If you skip this, the next session starts blind.
-
-### AFTER COMPACTION
-
-If you see a compaction message or "FIRST ACTION REQUIRED":
-1. IMMEDIATELY call `mem_session_summary` with the compacted summary content -- this persists what was done before compaction
-2. Call `mem_context` to recover additional context from previous sessions
-3. Only THEN continue working
-
-Do not skip step 1. Without it, everything done before compaction is lost from memory.
-<!-- /team-ai-kit:engram-protocol -->
-
-ENGRAM_PROTOCOL_EOF
+    # Returns the Engram Memory Protocol markdown content from shared template.
+    # Single source of truth: templates/engram-protocol.md
+    local kit_root
+    kit_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    cat "$kit_root/templates/engram-protocol.md"
 }
 
 update_instructions_engram_protocol() {

--- a/templates/engram-protocol.md
+++ b/templates/engram-protocol.md
@@ -1,0 +1,88 @@
+
+<!-- team-ai-kit:engram-protocol -->
+## Engram Persistent Memory -- Protocol
+
+You have access to Engram, a persistent memory system that survives across sessions and compactions.
+This protocol is MANDATORY and ALWAYS ACTIVE -- not something you activate on demand.
+
+### PROACTIVE SAVE TRIGGERS (mandatory -- do NOT wait for user to ask)
+
+Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
+- Architecture or design decision made
+- Team convention documented or established
+- Workflow change agreed upon
+- Tool or library choice made with tradeoffs
+- Bug fix completed (include root cause)
+- Feature implemented with non-obvious approach
+- Configuration change or environment setup done
+- Non-obvious discovery about the codebase
+- Gotcha, edge case, or unexpected behavior found
+- Pattern established (naming, structure, convention)
+- User preference or constraint learned
+
+Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
+
+Format for `mem_save`:
+- **title**: Verb + what -- short, searchable (e.g. "Fixed N+1 query in UserList")
+- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
+- **scope**: `project` (default) | `personal`
+- **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **content**:
+  - **What**: One sentence -- what was done
+  - **Why**: What motivated it (user request, bug, performance, etc.)
+  - **Where**: Files or paths affected
+  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Topic update rules:
+- Different topics MUST NOT overwrite each other
+- Same topic evolving -> use same `topic_key` (upsert)
+- Unsure about key -> call `mem_suggest_topic_key` first
+- Know exact ID to fix -> use `mem_update`
+
+### WHEN TO SEARCH MEMORY
+
+On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "que hicimos", or references to past work:
+1. Call `mem_context` -- checks recent session history (fast, cheap)
+2. If not found, call `mem_search` with relevant keywords
+3. If found, use `mem_get_observation` for full untruncated content
+
+Also search PROACTIVELY when:
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+- User's FIRST message references the project, a feature, or a problem -- call `mem_search` with keywords from their message to check for prior work before responding
+
+### SESSION CLOSE PROTOCOL (mandatory)
+
+Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary` with this structure:
+
+```
+## Goal
+[What we were working on this session]
+
+## Instructions
+[User preferences or constraints discovered -- skip if none]
+
+## Discoveries
+- [Technical findings, gotchas, non-obvious learnings]
+
+## Accomplished
+- [Completed items with key details]
+
+## Next Steps
+- [What remains to be done -- for the next session]
+
+## Relevant Files
+- path/to/file -- [what it does or what changed]
+```
+
+This is NOT optional. If you skip this, the next session starts blind.
+
+### AFTER COMPACTION
+
+If you see a compaction message or "FIRST ACTION REQUIRED":
+1. IMMEDIATELY call `mem_session_summary` with the compacted summary content -- this persists what was done before compaction
+2. Call `mem_context` to recover additional context from previous sessions
+3. Only THEN continue working
+
+Do not skip step 1. Without it, everything done before compaction is lost from memory.
+<!-- /team-ai-kit:engram-protocol -->


### PR DESCRIPTION
﻿## Summary
- Extracts duplicated Engram protocol content (~90 lines) from both `lib/functions.sh` and `lib/functions.ps1` into a single shared template at `templates/engram-protocol.md`
- Both functions now read from the template file at runtime instead of embedding the content inline
- Net reduction: 186 deletions, 97 insertions

## Changes
- **New**: `templates/engram-protocol.md` -- single source of truth for protocol content
- `lib/functions.sh` -- `get_engram_protocol_content()` now reads from template via `cat`
- `lib/functions.ps1` -- `Get-EngramProtocolContent` now reads from template via `Get-Content -Raw`

Closes #148
