### PR TITLE
fix(cli): normalize SHA256 hash to uppercase and fix sync indentation

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -770,7 +770,7 @@ function Invoke-SyncCommand {
     # Check project config for project name
     $projectName = ''
     if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
-    $projectName = ConvertTo-SafeProjectName (Split-Path $projectRoot -Leaf)
+        $projectName = ConvertTo-SafeProjectName (Split-Path $projectRoot -Leaf)
     }
 
     Write-Host '  Syncing engram memories...' -ForegroundColor White

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1120,7 +1120,7 @@ function Get-FileContentHash-String {
     $bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
     $sha = [System.Security.Cryptography.SHA256]::Create()
     $hashBytes = $sha.ComputeHash($bytes)
-    return ($hashBytes | ForEach-Object { $_.ToString('x2') }) -join ''
+    return ($hashBytes | ForEach-Object { $_.ToString('X2') }) -join ''
 }
 
 function Test-TeamRepoCloned {


### PR DESCRIPTION
## Summary
- **CRITICAL**: Normalize `Get-FileContentHash-String` to output uppercase hex (`'X2'`) matching bash `_sha256`, preventing different team-repo clone paths across platforms
- Fix missing indentation in `Invoke-SyncCommand` if block

## Changes
- `lib/functions.ps1:1123` — `'x2'` changed to `'X2'`
- `bin/team-ai-kit.ps1:773` — added proper indentation

Closes #152, closes #157
