### PR TITLE
fix(lib): preserve global manifest on per-project uninstall

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -2102,12 +2102,8 @@ function Invoke-Uninstall {
         }
     }
 
-    # Remove global manifest
-    $manifestPath = Get-SkillManifestPath
-    if (Test-Path $manifestPath) {
-        Remove-Item $manifestPath -Force
-        $removed++
-    }
+    # Note: global manifest (~/.team-ai-kit/manifest.json) is intentionally
+    # preserved to avoid breaking skill tracking for other projects.
 
     return @{ removed = $removed }
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1624,13 +1624,8 @@ uninstall_project() {
         fi
     done <<< "$targets"
 
-    # Remove from global manifest
-    local manifest_path
-    manifest_path=$(get_skill_manifest_path)
-    if [[ -f "$manifest_path" ]]; then
-        rm -f "$manifest_path"
-        removed=$((removed + 1))
-    fi
+    # Note: global manifest (~/.team-ai-kit/manifest.json) is intentionally
+    # preserved to avoid breaking skill tracking for other projects.
 
     echo "{\"removed\":$removed}"
 }


### PR DESCRIPTION
## Summary
- Stop deleting the global manifest (`~/.team-ai-kit/manifest.json`) during per-project uninstall
- Previously, uninstalling from one project would nuke skill tracking for ALL other projects on the machine

## Changes
- `lib/functions.sh` — removed `rm -f "$manifest_path"` block, added comment explaining preservation
- `lib/functions.ps1` — removed `Remove-Item $manifestPath` block, added same comment

Closes #154
