### PR TITLE
fix(security): validate repo URLs and harden hook injection surface

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -366,7 +366,7 @@ function Install-GitHooks {
     }
 
     $marker = '# [team-ai-kit] engram sync hook'
-    $projectFlag = if ($ProjectName) { "--project `"$ProjectName`"" } else { '--all' }
+    $projectFlag = if ($ProjectName) { "--project '$ProjectName'" } else { '--all' }
 
     # -- pre-commit hook -------------------------------------------------------
     $preCommitPath = Join-Path $gitHooksDir 'pre-commit'
@@ -1143,6 +1143,17 @@ function Test-TeamRepoCloned {
     return Test-Path (Join-Path $localPath '.git')
 }
 
+function Test-RepoUrl {
+    <#
+    .SYNOPSIS
+        Validates that a repo URL uses an allowed protocol (https, http, git@ SSH).
+    .OUTPUTS
+        $true if valid, $false otherwise.
+    #>
+    param([Parameter(Mandatory)][string]$Url)
+    return ($Url -match '^https?://' -or $Url -match '^git@')
+}
+
 function Invoke-TeamRepoClone {
     <#
     .SYNOPSIS
@@ -1154,6 +1165,10 @@ function Invoke-TeamRepoClone {
         [Parameter(Mandatory)]
         [string]$RepoUrl
     )
+    if (-not (Test-RepoUrl -Url $RepoUrl)) {
+        Write-Error "Invalid repo URL - only https://, http://, or git@ URLs are allowed."
+        return $false
+    }
     $localPath = Get-TeamRepoLocalPath -RepoUrl $RepoUrl
     if (Test-TeamRepoCloned -RepoUrl $RepoUrl) {
         return Invoke-TeamRepoPull -RepoUrl $RepoUrl
@@ -1162,7 +1177,7 @@ function Invoke-TeamRepoClone {
     if (-not (Test-Path $parentDir)) {
         New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
     }
-    $null = & git clone $RepoUrl $localPath 2>&1
+    $null = & git clone -- $RepoUrl $localPath 2>&1
     return $LASTEXITCODE -eq 0
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -357,7 +357,7 @@ install_git_hooks() {
 
     local project_flag
     if [[ -n "$project_name" ]]; then
-        project_flag="--project \"$project_name\""
+        project_flag="--project '${project_name}'"
     else
         project_flag="--all"
     fi
@@ -868,8 +868,22 @@ test_team_repo_cloned() {
     [[ -d "$local_path/.git" ]]
 }
 
+_validate_repo_url() {
+    # Validates that a repo URL uses an allowed protocol (https, http, git@ SSH).
+    # Rejects anything else to prevent git flag injection or path traversal.
+    local url="$1"
+    if [[ "$url" =~ ^https?:// ]] || [[ "$url" =~ ^git@ ]]; then
+        return 0
+    fi
+    return 1
+}
+
 invoke_team_repo_clone() {
     local repo_url="$1"
+    if ! _validate_repo_url "$repo_url"; then
+        echo "Error: invalid repo URL — only https://, http://, or git@ URLs are allowed." >&2
+        return 1
+    fi
     local local_path
     local_path=$(get_team_repo_local_path "$repo_url")
     if test_team_repo_cloned "$repo_url"; then
@@ -879,11 +893,15 @@ invoke_team_repo_clone() {
     local parent_dir
     parent_dir=$(dirname "$local_path")
     [[ -d "$parent_dir" ]] || mkdir -p "$parent_dir"
-    git clone "$repo_url" "$local_path" &>/dev/null
+    git clone -- "$repo_url" "$local_path" &>/dev/null
 }
 
 invoke_team_repo_pull() {
     local repo_url="${1:-}"
+    if [[ -n "$repo_url" ]] && ! _validate_repo_url "$repo_url"; then
+        echo "Error: invalid repo URL — only https://, http://, or git@ URLs are allowed." >&2
+        return 1
+    fi
     local local_path
     local_path=$(get_team_repo_local_path "$repo_url")
     test_team_repo_cloned "$repo_url" || return 1


### PR DESCRIPTION
﻿## Summary
- Add URL validation to `git clone`/`git pull` — only https://, http://, and git@ URLs accepted (#162)
- Harden git hook injection surface by using single quotes for project_flag embedding (#163)
- Add `--` separator before URL args in git clone to prevent flag injection

## Changes
- `lib/functions.sh`: new `_validate_repo_url()` + applied to clone/pull + single-quoted hook template
- `lib/functions.ps1`: new `Test-RepoUrl` + applied to clone + single-quoted hook template

## Testing
- 204 passed, 19 failed (pre-existing Join-Path PS 5.1 bug), 1 skipped — same as master baseline
