### PR TITLE
fix(cli): add git prerequisite check and fix CONTRIBUTING.md branch reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This project follows a straightforward
 
 1. Fork the repo
 2. Clone your fork
-3. Create a feature branch from `main`
+3. Create a feature branch from `master`
 
 ```bash
 git clone https://github.com/<your-user>/team-ai-kit

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -146,6 +146,13 @@ cmd_setup() {
         fi
         ok "jq available"
 
+        if ! command -v git &>/dev/null; then
+            err "git is required but not found"
+            step "Install: brew install git (macOS) or apt install git (Debian/Ubuntu)"
+            exit 1
+        fi
+        ok "git available"
+
         if ! test_curl_installed; then
             err "curl is required but not found"
             exit 1
@@ -1151,6 +1158,10 @@ cmd_doctor() {
     # jq (required)
     if test_jq_installed; then ok "jq: installed"
     else err "jq: NOT found (required)"; all_good=false; fi
+
+    # git (required)
+    if command -v git &>/dev/null; then ok "git: $(git --version | head -1)"
+    else err "git: NOT found (required)"; all_good=false; fi
 
     # Homebrew (optional)
     if test_brew_installed; then ok "Homebrew: installed"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -165,6 +165,16 @@ function Invoke-SetupCommand {
 
         Set-TlsProtocol
 
+        # -- git (required) --
+        if (Get-Command git -ErrorAction SilentlyContinue) {
+            Write-Ok 'git available'
+        }
+        else {
+            Write-Err 'git is required but not found'
+            Write-Step 'Install: https://git-scm.com/downloads or winget install Git.Git'
+            return
+        }
+
         # -- gentle-ai --
         if (Test-GentleAiInstalled) {
             if ($Update -and (Test-ScoopInstalled)) {
@@ -1116,6 +1126,14 @@ function Invoke-DoctorCommand {
     else {
         Write-Ok "team-ai-kit: v$KitVersion"
     }
+
+    # git (required)
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $gitVer = (& git --version) -replace 'git version ', ''
+        Write-Ok "git: v$gitVer"
+    }
+    else { Write-Err 'git: NOT found (required)'; $allGood = $false }
 
     # Scoop (optional)
     if (Test-ScoopInstalled) { Write-Ok 'Scoop: installed' }


### PR DESCRIPTION
﻿## Summary
- Add git prerequisite check to setup and doctor commands in both bash and PS1 (#164)
- Fix CONTRIBUTING.md to reference `master` instead of `main` (#165)

## Changes
- `bin/team-ai-kit`: git check in setup prerequisites + doctor health check
- `bin/team-ai-kit.ps1`: git check in setup prerequisites + doctor health check with version display
- `CONTRIBUTING.md`: branch reference corrected to `master`

## Testing
- 204 passed, 19 failed (pre-existing), 1 skipped - same baseline
