### PR TITLE
fix(cli): use shared team-repo resolution in doctor and fix CRLF in LF files

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -1243,7 +1243,7 @@ cmd_doctor() {
 
     # Team repo
     local config_team
-    config_team=$(get_config_value "teamRepo")
+    config_team=$(_resolve_team_repo "$project_root")
     if [[ -n "$config_team" ]]; then
         ok "Team repo: $config_team"
     else

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -1206,7 +1206,7 @@ function Invoke-DoctorCommand {
         }
 
         # Team repo
-        $effectiveRepo = if ($pc.teamRepo) { $pc.teamRepo } elseif ($config.teamRepo) { $config.teamRepo } else { '' }
+        $effectiveRepo = Resolve-TeamRepo -ProjectRoot $projectRoot
         if ($effectiveRepo) {
             Write-Ok "Team repo: $effectiveRepo"
         }

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1677,8 +1677,8 @@ function Update-InstructionsEngramProtocol {
             if ($endIdx -ge 0) {
                 $endIdx += $endMarker.Length
                 $updated = $existing.Substring(0, $startIdx) + $existing.Substring($endIdx)
-                $updated = $updated -replace '(\r?\n){3,}', "`r`n`r`n"
-                $updated = $updated.TrimEnd() + "`r`n"
+                $updated = $updated -replace '(\r?\n){3,}', "`n`n"
+                $updated = $updated.TrimEnd() + "`n"
                 if ($updated -eq $existing) { return $false }
                 [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.Encoding]::UTF8)
                 return $true


### PR DESCRIPTION
﻿## Summary
- Use shared `_resolve_team_repo`/`Resolve-TeamRepo` in doctor command instead of reading global config only (bash) or inline ternary (PS1)
- Fix PS1 `Update-InstructionsEngramProtocol` to use LF line endings in replacement strings instead of CRLF

## Closes
Closes #166, closes #175
