### PR TITLE
fix: remove dead Makefile section from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,3 @@ end_of_line = lf
 
 [*.md]
 trim_trailing_whitespace = false
-
-[Makefile]
-indent_style = tab
-end_of_line = lf


### PR DESCRIPTION
﻿## Summary
- Remove dead `[Makefile]` section from `.editorconfig` - the project has no Makefile

## Issue
Closes #176

## Test
No functional changes - config cleanup only.
