### PR TITLE
feat: add Testing and Naming sections to Python and DevOps packs

### DIFF
--- a/packs/devops/rules.md
+++ b/packs/devops/rules.md
@@ -24,6 +24,24 @@
 - Structured logs (JSON) to integrate with observability systems
 - Use --dry-run / plan before apply/destroy in production
 
+## Testing
+
+- Every pipeline must be tested in a non-production environment first
+- Use linting as the first validation gate: shellcheck, hadolint, tflint
+- Terraform: `terraform validate` + `terraform plan` in CI before apply
+- Docker: build and scan images in CI (trivy, grype, or similar)
+- Smoke tests post-deploy to verify critical endpoints/services
+- Infrastructure integration tests with Terratest or similar when complexity warrants it
+
+## Naming
+
+- Scripts: `kebab-case` (e.g. `deploy-staging.sh`)
+- Environment variables: `UPPER_SNAKE_CASE` (e.g. `DATABASE_URL`)
+- Terraform resources: `snake_case` (e.g. `aws_instance.web_server`)
+- Docker images: `lowercase-with-dashes` (e.g. `my-app-api`)
+- CI/CD jobs: `kebab-case` (e.g. `build-and-push`, `deploy-staging`)
+- Secrets: `UPPER_SNAKE_CASE` with prefix (e.g. `SECRET_DB_PASSWORD`)
+
 ## Thinking Rules
 
 - Think about reversibility first: every change must be undoable

--- a/packs/python/rules.md
+++ b/packs/python/rules.md
@@ -23,6 +23,24 @@
 - Never silently ignore exceptions (bare `except: pass` forbidden)
 - f-strings for string formatting, never concatenation with +
 
+## Testing
+
+- Every service/use-case function must have a unit test
+- Use pytest as the test runner (never unittest directly)
+- Use pytest fixtures for setup/teardown and dependency injection
+- Use unittest.mock or pytest-mock for mocking dependencies
+- Use Testcontainers for database integration tests when needed
+- Async tests with pytest-asyncio and explicit `@pytest.mark.asyncio`
+
+## Naming
+
+- Modules/packages: `snake_case` (e.g. `user_service.py`)
+- Classes: `PascalCase` (e.g. `UserService`)
+- Functions/variables: `snake_case` (e.g. `get_user_by_id`)
+- Constants: `UPPER_SNAKE_CASE` (e.g. `MAX_RETRIES`)
+- Tests: `test_*.py` files, `test_*` functions (e.g. `test_create_user_returns_201`)
+- Private: prefix with `_` (e.g. `_validate_input`)
+
 ## Thinking Rules
 
 - Prefer the most readable solution over the most "Pythonic" one if there's a clarity trade-off


### PR DESCRIPTION
﻿## Summary
- Add Testing and Naming sections to Python pack
- Add Testing and Naming sections to DevOps pack
- Aligns with existing convention in backend-dotnet, backend-java, data, and mobile packs

## Issues
Closes #179
Closes #180
