### PR TITLE
feat: add scoop manifest version to CI version-sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,18 +77,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify bash and PS1 versions match
+      - name: Verify bash, PS1, and scoop manifest versions match
         run: |
           bash_version=$(sed -n "s/^KIT_VERSION='\(.*\)'/\1/p" bin/team-ai-kit)
           ps1_version=$(sed -n "s/^\$KitVersion = '\(.*\)'/\1/p" bin/team-ai-kit.ps1)
-          if [ -z "$bash_version" ] || [ -z "$ps1_version" ]; then
-            echo "::error::Could not extract version from one or both scripts (bash='$bash_version' ps1='$ps1_version')"
+          scoop_version=$(jq -r '.version' scoop/team-ai-kit.json)
+          if [ -z "$bash_version" ] || [ -z "$ps1_version" ] || [ -z "$scoop_version" ]; then
+            echo "::error::Could not extract version (bash='$bash_version' ps1='$ps1_version' scoop='$scoop_version')"
             exit 1
           fi
-          echo "Bash version: $bash_version"
-          echo "PS1 version:  $ps1_version"
+          echo "Bash version:  $bash_version"
+          echo "PS1 version:   $ps1_version"
+          echo "Scoop version: $scoop_version"
+          failed=0
           if [ "$bash_version" != "$ps1_version" ]; then
             echo "::error::Version mismatch! Bash=$bash_version PS1=$ps1_version"
+            failed=1
+          fi
+          if [ "$bash_version" != "$scoop_version" ]; then
+            echo "::error::Version mismatch! Bash=$bash_version Scoop=$scoop_version"
+            failed=1
+          fi
+          if [ "$failed" -eq 1 ]; then
             exit 1
           fi
-          echo "Versions match: $bash_version"
+          echo "All versions match: $bash_version"


### PR DESCRIPTION
﻿## Summary
- Extend version-sync CI job to also check `scoop/team-ai-kit.json` version
- Prevents scoop manifest version from drifting out of sync with bash/PS1 versions
- Reports all mismatches before failing (not just the first one)

## Issue
Closes #170
