### PR TITLE
refactor: rename Ensure-GitAttributes to Set-GitAttributes

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -692,7 +692,7 @@ function Invoke-InitCommand {
         }
 
         # 4c. Setup .gitattributes for clean PR diffs
-        $gaResult = Ensure-GitAttributes -ProjectRoot $projectRoot
+        $gaResult = Set-GitAttributes -ProjectRoot $projectRoot
 
         if ($gaResult.created) {
             Write-Ok '.gitattributes created -- .engram/ diffs collapsed in PRs'
@@ -1003,7 +1003,7 @@ function Invoke-UpdateCommand {
         Write-Dry 'Would ensure .gitattributes has engram diff rules'
     }
     else {
-        $gaResult = Ensure-GitAttributes -ProjectRoot $projectRoot
+        $gaResult = Set-GitAttributes -ProjectRoot $projectRoot
 
         if ($gaResult.created) {
             Write-Ok '.gitattributes created -- .engram/ diffs collapsed in PRs'

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -198,7 +198,7 @@ function Save-ProjectConfig {
     return $configPath
 }
 
-function Ensure-GitAttributes {
+function Set-GitAttributes {
     <#
     .SYNOPSIS
         Creates or updates .gitattributes with rules to collapse .engram/ diffs in PRs.

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -2119,7 +2119,7 @@ Describe 'Test-ValidCommand includes uninstall' {
 
 # -- GitAttributes (.engram/ diff rules) ----------------------------------------
 
-Describe 'Ensure-GitAttributes' {
+Describe 'Set-GitAttributes' {
     BeforeEach {
         $script:gaTestDir = Join-Path $TestDrive "ga-test-$(Get-Random)"
         New-Item -ItemType Directory -Path $script:gaTestDir -Force | Out-Null
@@ -2129,7 +2129,7 @@ Describe 'Ensure-GitAttributes' {
     }
 
     It 'creates .gitattributes when file does not exist' {
-        $result = Ensure-GitAttributes -ProjectRoot $script:gaTestDir
+        $result = Set-GitAttributes -ProjectRoot $script:gaTestDir
         $result.created | Should -BeTrue
         $result.updated | Should -BeFalse
         $gaPath = Join-Path $script:gaTestDir '.gitattributes'
@@ -2143,7 +2143,7 @@ Describe 'Ensure-GitAttributes' {
     It 'appends rules to existing .gitattributes without our marker' {
         $gaPath = Join-Path $script:gaTestDir '.gitattributes'
         "*.pdf binary`n" | Set-Content $gaPath -NoNewline
-        $result = Ensure-GitAttributes -ProjectRoot $script:gaTestDir
+        $result = Set-GitAttributes -ProjectRoot $script:gaTestDir
         $result.created | Should -BeFalse
         $result.updated | Should -BeTrue
         $content = Get-Content $gaPath -Raw
@@ -2155,7 +2155,7 @@ Describe 'Ensure-GitAttributes' {
         $gaPath = Join-Path $script:gaTestDir '.gitattributes'
         $existing = "# [team-ai-kit] engram diff rules`n.engram/** linguist-generated=true`n.engram/** -diff`n"
         Set-Content $gaPath -Value $existing -NoNewline
-        $result = Ensure-GitAttributes -ProjectRoot $script:gaTestDir
+        $result = Set-GitAttributes -ProjectRoot $script:gaTestDir
         $result.created | Should -BeFalse
         $result.updated | Should -BeFalse
     }


### PR DESCRIPTION
﻿## Summary
- Rename `Ensure-GitAttributes` to `Set-GitAttributes` across PS1 codebase
- `Ensure` is not an approved PowerShell verb; `Set` is the standard equivalent
- Updated in `lib/functions.ps1`, `bin/team-ai-kit.ps1`, and `tests/functions.Tests.ps1`
- All 3 Pester tests pass

## Issue
Closes #173
