### PR TITLE
fix: skill content cleanup across shared and role skills

### DIFF
--- a/skills/roles/backend-java/testing/SKILL.md
+++ b/skills/roles/backend-java/testing/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 ## When to Use
 
+Load this skill when:
+
 - Writing unit tests for services or domain logic with JUnit 5 + Mockito
 - Testing Spring MVC controllers with `@WebMvcTest` and `MockMvc`
 - Writing integration tests that boot the full Spring context with `@SpringBootTest`

--- a/skills/roles/data/pipelines/SKILL.md
+++ b/skills/roles/data/pipelines/SKILL.md
@@ -16,6 +16,7 @@ metadata:
 ## When to Use
 
 Load this skill when:
+
 - Transforming or cleaning data with pandas (ETL pipelines, feature engineering)
 - Building reproducible ML preprocessing with scikit-learn Pipeline and ColumnTransformer
 - Adding runtime data validation with pandera schemas

--- a/skills/roles/data/testing/SKILL.md
+++ b/skills/roles/data/testing/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 ## When to Use
 
+Load this skill when:
+
 - Writing tests for pandas/polars DataFrame transformations
 - Validating data schemas at pipeline boundaries (ingestion, transform, export)
 - Testing ML model performance against baseline thresholds

--- a/skills/roles/frontend/react/SKILL.md
+++ b/skills/roles/frontend/react/SKILL.md
@@ -493,6 +493,15 @@ const filteredItems = items.filter(i => i.active)
 
 ---
 
+## React 18+ Compatibility Notes
+
+- **`createRoot` API**: Use `createRoot(container).render(<App />)` instead of the legacy `ReactDOM.render(<App />, container)`. The legacy API is deprecated and will be removed in a future version.
+- **Strict Mode double rendering**: In development, `<React.StrictMode>` intentionally double-invokes render, effects setup, and effects cleanup to surface impure components. Do not write code that relies on effects running exactly once.
+- **Automatic batching**: React 18 batches all state updates (including inside promises, timeouts, and event handlers) by default. If you need to force a synchronous re-render, use `flushSync()`.
+- **`useId`**: Use `useId()` for generating stable unique IDs that work with SSR hydration. Do not use `Math.random()` or incrementing counters for IDs.
+
+---
+
 ## Quick Reference
 
 | Pattern                    | When to apply                                         |

--- a/skills/roles/mobile/architecture/SKILL.md
+++ b/skills/roles/mobile/architecture/SKILL.md
@@ -15,6 +15,8 @@ metadata:
 
 ## When to Use
 
+Load this skill when:
+
 - Setting up or modifying Expo Router file-based navigation (layouts, groups, typed routes)
 - Building list-heavy screens that need scroll performance optimization
 - Choosing between client state (Zustand) and server state (TanStack Query)

--- a/skills/roles/mobile/testing/SKILL.md
+++ b/skills/roles/mobile/testing/SKILL.md
@@ -15,6 +15,8 @@ metadata:
 
 ## When to Use
 
+Load this skill when:
+
 - Writing unit or integration tests for React Native / Expo components
 - Testing screen-level behavior (forms, lists, navigation transitions)
 - Mocking native modules that crash in the Jest JSDOM environment
@@ -37,13 +39,13 @@ import { render, fireEvent } from '@testing-library/react-native';
 
 test('submits form', () => {
   const onSubmit = jest.fn();
-  render(<LoginForm onSubmit={onSubmit} />);
+  const { getByTestId } = render(<LoginForm onSubmit={onSubmit} />);
 
   fireEvent.changeText(
-    render.getByTestId('email-input'),
+    getByTestId('email-input'),
     'user@example.com',
   );
-  fireEvent.press(render.getByTestId('submit-btn'));
+  fireEvent.press(getByTestId('submit-btn'));
 
   expect(onSubmit).toHaveBeenCalled();
 });

--- a/skills/roles/python/testing/SKILL.md
+++ b/skills/roles/python/testing/SKILL.md
@@ -285,6 +285,9 @@ markers = [
 
 ```python
 # With anyio (recommended — works with both asyncio and trio)
+# Use anyio when: your code or dependencies may need to run on different async
+# backends (asyncio or trio), or when you want a single test suite that is
+# backend-agnostic. Install: pip install anyio pytest
 import pytest
 
 @pytest.mark.anyio
@@ -292,7 +295,10 @@ async def test_async_operation():
     result = await some_async_function()
     assert result is not None
 
-# With pytest-asyncio
+# With pytest-asyncio (simpler — asyncio only)
+# Use pytest-asyncio when: your project exclusively uses asyncio (e.g., FastAPI,
+# aiohttp) and you have no need for trio compatibility.
+# Install: pip install pytest-asyncio
 import pytest
 
 @pytest.mark.asyncio

--- a/skills/shared/debug/SKILL.md
+++ b/skills/shared/debug/SKILL.md
@@ -9,6 +9,14 @@ globs:
   - "**/*Test.*"
   - "**/*.spec.*"
   - "**/*.log"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.java"
+  - "**/*.cs"
+  - "**/*.go"
 metadata:
   author: team-ai-kit
   version: "1.0"
@@ -245,41 +253,7 @@ public class OrderService {
 
 ## Anti-Patterns
 
-### Anti-Pattern 1: Swallow Errors Silently
-
-```typescript
-// ❌ BAD
-try {
-  await riskyOperation();
-} catch {
-  /* total silence */
-}
-
-// ✅ GOOD
-try {
-  await riskyOperation();
-} catch (error) {
-  logger.error("riskyOperation failed", { error });
-  // decide: re-throw, fallback, or notify
-}
-```
-
-```python
-# ❌ BAD
-try:
-    process()
-except Exception:
-    pass
-
-# ✅ GOOD
-try:
-    process()
-except SpecificError as e:
-    logger.warning("Process failed, using fallback", exc_info=e)
-    return fallback_value
-```
-
-### Anti-Pattern 2: Log and Throw (Double Handling)
+### Anti-Pattern 1: Shotgun Debugging (Random Changes)
 
 ```java
 // ❌ BAD — logs the error AND throws it → duplicate log entries
@@ -299,7 +273,7 @@ try {
 }
 ```
 
-### Anti-Pattern 3: Catch Generic Exceptions
+### Anti-Pattern 2: Catch Generic Exceptions
 
 ```python
 # ❌ BAD — catches everything including KeyboardInterrupt
@@ -316,7 +290,7 @@ except (ConnectionError, TimeoutError) as e:
     return None
 ```
 
-### Anti-Pattern 4: Use Print Debugging in Production Code
+### Anti-Pattern 3: Use Print Debugging in Production Code
 
 ```go
 // ❌ BAD — fmt.Println left in production code


### PR DESCRIPTION
﻿## Summary
- Remove duplicate Swallow Errors anti-pattern from debug skill (already in code-quality) - #181
- Expand debug skill globs to match source files (.ts, .py, .java, etc.), not just test files - #182
- Normalize 'When to Use' section format with 'Load this skill when:' intro across 5 role skills - #183
- Fix mobile testing BAD example: `render.getByTestId()` is invalid API, replaced with destructured `getByTestId` - #184
- Add React 18+ compatibility notes (createRoot, StrictMode double render, automatic batching, useId) - #185
- Clarify when to use anyio vs pytest-asyncio in Python testing skill - #186

## Issues
Closes #181, #182, #183, #184, #185, #186
