### PR TITLE
fix: judgment day round 1 - 7 fixes across PS1, bash, and CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout master
+          git pull --rebase origin master
           git add scoop/team-ai-kit.json
           if git diff --cached --quiet; then
             echo "No scoop manifest changes to commit"

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -271,6 +271,8 @@ cmd_setup() {
         fi
     else
         echo -e "  ${C_DIM}[1/5] Skipping prerequisites (--skip-prerequisites)${C_RESET}"
+        # jq is still required for config/manifest operations even when skipping prerequisites
+        _require_jq || exit 1
     fi
 
     # -- Step 2: IDE Selection -------------------------------------------------
@@ -1334,7 +1336,7 @@ cmd_uninstall() {
     local removed
     removed=$(echo "$result" | jq -r '.removed')
 
-    echo -e "  ${C_GREEN}✔ Uninstalled team-ai-kit from this project ($removed items removed).${C_RESET}"
+    echo -e "  ${C_GREEN}+ Uninstalled team-ai-kit from this project ($removed items removed).${C_RESET}"
     echo ""
     echo -e "  ${C_DIM}Tip: You may also want to remove .engram/ if you no longer need memory sync.${C_RESET}"
     echo ""

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -99,7 +99,8 @@ function Save-TeamAiKitConfig {
         New-Item -ItemType Directory -Path $configDir -Force | Out-Null
     }
     $configPath = Join-Path $configDir 'config.json'
-    $Config | ConvertTo-Json -Depth 5 | Set-Content -Path $configPath -Encoding UTF8
+    $json = $Config | ConvertTo-Json -Depth 5
+    [System.IO.File]::WriteAllText($configPath, $json, [System.Text.UTF8Encoding]::new($false))
     return $configPath
 }
 
@@ -194,7 +195,8 @@ function Save-ProjectConfig {
         [hashtable]$Config
     )
     $configPath = Get-ProjectConfigPath -ProjectRoot $ProjectRoot
-    $Config | ConvertTo-Json -Depth 5 | Set-Content -Path $configPath -Encoding UTF8
+    $json = $Config | ConvertTo-Json -Depth 5
+    [System.IO.File]::WriteAllText($configPath, $json, [System.Text.UTF8Encoding]::new($false))
     return $configPath
 }
 
@@ -272,13 +274,24 @@ function Remove-GitAttributesBlock {
         $cleaned += $line
     }
 
-    $cleaned = @($cleaned | Where-Object { $_.Trim() -ne '' })
+    # Remove consecutive blank lines (collapse to max 1 blank line)
+    $deduped = @()
+    $prevBlank = $false
+    foreach ($line in $cleaned) {
+        $isBlank = ($line.Trim() -eq '')
+        if ($isBlank -and $prevBlank) { continue }
+        $deduped += $line
+        $prevBlank = $isBlank
+    }
+    # Remove leading/trailing blank lines
+    while ($deduped.Count -gt 0 -and $deduped[0].Trim() -eq '') { $deduped = $deduped[1..($deduped.Count - 1)] }
+    while ($deduped.Count -gt 0 -and $deduped[-1].Trim() -eq '') { $deduped = $deduped[0..($deduped.Count - 2)] }
 
-    if ($cleaned.Count -eq 0) {
+    if ($deduped.Count -eq 0) {
         Remove-Item $gaPath -Force
     }
     else {
-        $newContent = ($cleaned -join "`n") + "`n"
+        $newContent = ($deduped -join "`n") + "`n"
         $lfContent = $newContent -replace "`r`n", "`n"
         [System.IO.File]::WriteAllText($gaPath, $lfContent, [System.Text.UTF8Encoding]::new($false))
     }
@@ -1193,14 +1206,8 @@ function Invoke-TeamRepoPull {
     if (-not (Test-TeamRepoCloned -RepoUrl $RepoUrl)) {
         return $false
     }
-    Push-Location $localPath
-    try {
-        $null = & git pull 2>&1
-        return $LASTEXITCODE -eq 0
-    }
-    finally {
-        Pop-Location
-    }
+    $null = & git -C $localPath pull 2>&1
+    return $LASTEXITCODE -eq 0
 }
 
 function Get-TeamRepoSkillPaths {
@@ -1304,7 +1311,8 @@ function Save-SkillManifest {
     if (-not (Test-Path $dir)) {
         New-Item -ItemType Directory -Path $dir -Force | Out-Null
     }
-    $Manifest | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
+    $json = $Manifest | ConvertTo-Json -Depth 5
+    [System.IO.File]::WriteAllText($path, $json, [System.Text.UTF8Encoding]::new($false))
     return $path
 }
 
@@ -1590,7 +1598,7 @@ function Install-ProjectSkills {
         New-Item -ItemType Directory -Path $teamSkillsDir -Force | Out-Null
     }
     $json = $manifest | ConvertTo-Json -Depth 5
-    $json | Set-Content -Path $manifestPath -Encoding UTF8
+    [System.IO.File]::WriteAllText($manifestPath, $json, [System.Text.UTF8Encoding]::new($false))
 
     return $results
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1457,7 +1457,11 @@ initialize_knowledge_repo() {
     done
 
     local created_json
-    created_json=$(printf '%s\n' "${created[@]}" | jq -R . | jq -sc '.')
+    if [[ ${#created[@]} -eq 0 ]]; then
+        created_json='[]'
+    else
+        created_json=$(printf '%s\n' "${created[@]}" | jq -R . | jq -sc '.')
+    fi
     jq -n --argjson created "$created_json" --arg path "$target_dir" \
         '{created: $created, path: $path}'
 }


### PR DESCRIPTION
﻿Closes #201

## PR Type
- [x] Bug fix

## Summary
- Fixes 7 issues found by Judgment Day adversarial review (2 independent blind judges)
- UTF-8 BOM, release push race, empty array guard, blank line stripping, git -C, unicode checkmark, jq guard

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | BOM-less UTF-8 writes (4 locations), Remove-GitAttributesBlock blank line fix, Invoke-TeamRepoPull git -C |
| `lib/functions.sh` | Empty created array guard in initialize_knowledge_repo |
| `bin/team-ai-kit` | Unicode checkmark fix, jq guard for --skip-prerequisites |
| `.github/workflows/release.yml` | git pull --rebase before push |

## Test Plan
- [x] Pester: Set-GitAttributes (3/3), Remove-GitAttributesBlock (4/4), Save-ProjectConfig (2/2), Save-TeamAiKitConfig (3/3) pass
- [x] E2E PS1: 15/15 pass
- [x] No new test failures introduced

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
