### PR TITLE
fix(ps1): replace all remaining BOM-ful UTF-8 writes with BOM-less encoding

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -625,7 +625,7 @@ function Invoke-InitCommand {
     }
     else {
         $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent -SkipEngramProtocol:$skipProtocol
-        [System.IO.File]::WriteAllText($instructionsPath, $instructions, [System.Text.Encoding]::UTF8)
+        [System.IO.File]::WriteAllText($instructionsPath, $instructions, [System.Text.UTF8Encoding]::new($false))
         Write-Ok "Created: $relInstructionsPath"
     }
 

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1140,7 +1140,7 @@ function Get-FileContentHash-String {
         Returns a SHA256 hash of a string (used for URL hashing).
     #>
     param([Parameter(Mandatory)][string]$Content)
-    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
+    $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($Content)
     $sha = [System.Security.Cryptography.SHA256]::Create()
     $hashBytes = $sha.ComputeHash($bytes)
     return ($hashBytes | ForEach-Object { $_.ToString('X2') }) -join ''
@@ -1688,7 +1688,7 @@ function Update-InstructionsEngramProtocol {
                 $updated = $updated -replace '(\r?\n){3,}', "`n`n"
                 $updated = $updated.TrimEnd() + "`n"
                 if ($updated -eq $existing) { return $false }
-                [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.Encoding]::UTF8)
+                [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.UTF8Encoding]::new($false))
                 return $true
             }
         }
@@ -1714,7 +1714,7 @@ function Update-InstructionsEngramProtocol {
 
     if ($updated -eq $existing) { return $false }
 
-    [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.Encoding]::UTF8)
+    [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.UTF8Encoding]::new($false))
     return $true
 }
 
@@ -1810,7 +1810,7 @@ function Update-InstructionsTeamRules {
 
     if ($updated -eq $existing) { return $false }
 
-    [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.Encoding]::UTF8)
+    [System.IO.File]::WriteAllText($FilePath, $updated, [System.Text.UTF8Encoding]::new($false))
     return $true
 }
 


### PR DESCRIPTION
﻿Closes #203

## PR Type
- [x] Bug fix

## Summary
- Replace 4 remaining BOM-ful `[System.Text.Encoding]::UTF8` with BOM-less `[System.Text.UTF8Encoding]::new($false)`
- Found by Judgment Day Round 2 (both judges flagged independently)

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | 3 WriteAllText calls: Update-InstructionsEngramProtocol (2), Update-InstructionsTeamRules (1) |
| `bin/team-ai-kit.ps1` | 1 WriteAllText call: New-CopilotInstructions write |

## Test Plan
- [x] No `[System.Text.Encoding]::UTF8` remaining in any PS1 file

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
