### PR TITLE
fix(doctor): resolve unknown version on corporate PCs + add corporate onboarding docs

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -311,6 +311,67 @@ Invoke-Pester tests/skills.Tests.ps1 -Output Detailed
 
 ---
 
+## Instalacion en PC corporativa (sin Scoop)
+
+Si tu PC corporativa no permite instalar Scoop o modificar variables de entorno via script, segui estos pasos:
+
+### 1. Clonar el repositorio
+
+Clona team-ai-kit en la carpeta que prefieras:
+
+```powershell
+git clone https://github.com/lazarogadiel93/team-ai-kit <RUTA_DONDE_QUIERAS>
+# Ejemplo: git clone https://github.com/lazarogadiel93/team-ai-kit C:\tools\team-ai-kit
+```
+
+### 2. Ejecutar el setup
+
+```powershell
+cd <RUTA_DONDE_QUIERAS>
+.\setup.ps1
+```
+
+El setup descarga gentle-ai y engram automaticamente. Es posible que veas warnings como:
+
+```
+WARNING: could not add ... to PATH: exit status 1
+```
+
+Esto es normal en PCs corporativas. Los binarios se instalaron correctamente, solo que no se pudo agregar la ruta al PATH automaticamente.
+
+### 3. Agregar team-ai-kit al PATH manualmente
+
+Para poder ejecutar `team-ai-kit.ps1` desde cualquier carpeta:
+
+1. **Win + R** → escribir `sysdm.cpl` → Enter
+2. Pestaña **Advanced** → boton **Environment Variables**
+3. En **User variables** (las de arriba), seleccionar **Path** → **Edit**
+4. Click en **New** → pegar: `<RUTA_DONDE_QUIERAS>\bin`
+5. Aceptar todo y **reiniciar la terminal**
+
+> Nota: las variables de usuario no requieren permisos de administrador. Si el boton Edit esta deshabilitado, consulta con tu equipo de IT.
+
+### 4. Verificar
+
+Abri una terminal nueva y correr:
+
+```powershell
+team-ai-kit.ps1 doctor
+```
+
+Deberia mostrar gentle-ai y engram como disponibles.
+
+### 5. Inicializar en tu proyecto
+
+```powershell
+cd mi-proyecto
+team-ai-kit.ps1 init
+```
+
+Listo. Abri VS Code y empeza a trabajar.
+
+---
+
 ## Troubleshooting
 
 ### Primero: correr doctor
@@ -324,9 +385,15 @@ Si algo falla, te dice exactamente que.
 ### gentle-ai no se encuentra
 
 ```powershell
-# Windows
+# Windows (Scoop)
 scoop bucket add team-ai-kit https://github.com/lazarogadiel93/scoop-bucket
 scoop install gentle-ai
+```
+
+```powershell
+# Windows (PC corporativa -- sin Scoop)
+# El setup ya lo descarga automaticamente.
+# Si no funciona el comando, es un problema de PATH. Ver seccion "Instalacion en PC corporativa".
 ```
 
 ```bash

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -868,10 +868,18 @@ function Get-InstalledVersion {
     <#
     .SYNOPSIS
         Returns the installed version of a tool (gentle-ai or engram).
+        Uses full binary path to work even when PATH is not configured
+        (e.g. corporate environments that block PATH modifications).
     #>
     param([Parameter(Mandatory)][string]$Tool)
+    $binPath = switch ($Tool) {
+        'gentle-ai' { Get-GentleAiBinaryPath }
+        'engram'    { Get-EngramBinaryPath }
+        default     { $Tool }
+    }
+    if (-not $binPath) { return $null }
     try {
-        $output = & $Tool version 2>$null
+        $output = & $binPath version 2>$null
         if ($output -match '(\d+\.\d+\.\d+)') { return $Matches[1] }
     }
     catch {}


### PR DESCRIPTION
﻿## Summary
- Fix `Get-InstalledVersion` to use full binary path resolution instead of PATH-dependent name lookup
- Add corporate PC onboarding section to `docs/onboarding.md` with manual PATH setup instructions

Closes #205

## PR Type
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | `Get-InstalledVersion` now uses `Get-GentleAiBinaryPath`/`Get-EngramBinaryPath` to find binaries |
| `docs/onboarding.md` | New section for corporate PC setup without Scoop |

## Test Plan
- [x] Manually tested `team-ai-kit doctor` on corporate PC
- [x] Non-corporate installs unaffected (same code path when PATH works)

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] Docs updated
