### PR TITLE
docs(onboarding): add Windows PowerShell requirement note

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -16,6 +16,8 @@
 
 > Scoop, gentle-ai y engram los instala el setup si faltan.
 
+> **Importante:** En Windows usa siempre **PowerShell** para ejecutar team-ai-kit. Git Bash ejecuta la version bash del script (pensada para macOS/Linux) que requiere `jq` y otras dependencias Unix. Si usas el terminal integrado de tu IDE, asegurate de que el shell seleccionado sea PowerShell y no Git Bash. Ademas, si modificaste el PATH recientemente, reinicia el IDE para que tome los cambios.
+
 ### macOS / Linux
 
 | Herramienta | Instalacion |


### PR DESCRIPTION
﻿## Summary
- Add note in Windows requirements section that team-ai-kit must be run from PowerShell, not Git Bash
- Include tip about restarting IDE after PATH changes

Closes #207

## PR Type
- [x] Documentation only

## Changes

| File | Change |
|------|--------|
| `docs/onboarding.md` | Added PowerShell requirement note + IDE restart tip in Windows section |

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] Docs updated
