### PR TITLE
docs(onboarding): add update instructions for corporate PCs

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -372,6 +372,14 @@ team-ai-kit.ps1 init
 
 Listo. Abri VS Code y empeza a trabajar.
 
+### 6. Actualizar
+
+| Que actualizar | Comando |
+|----------------|---------|
+| **team-ai-kit** (scripts, skills, docs) | `cd <RUTA_DONDE_QUIERAS>` → `git pull` |
+| **gentle-ai + engram** (binarios) | `team-ai-kit.ps1 setup -Update` |
+| **Skills + reglas en un proyecto** | `cd mi-proyecto` → `team-ai-kit.ps1 update` |
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
﻿## Summary
- Add update instructions table to corporate PC section in onboarding docs
- Covers: team-ai-kit (git pull), gentle-ai/engram (setup -Update), project skills (update)

Closes #209

## PR Type
- [x] Documentation only

## Changes

| File | Change |
|------|--------|
| `docs/onboarding.md` | Added step 6 with update commands table in corporate section |

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] Docs updated
