### PR TITLE
fix(setup): normalize temp path to resolve 8.3 short names on corporate PCs

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -680,8 +680,11 @@ function Install-GithubReleaseBinary {
         New-Item -ItemType Directory -Path $binDir -Force | Out-Null
     }
 
-    $tempZip = Join-Path $env:TEMP "$Repo-download-$(Get-Random).zip"
-    $tempExtract = Join-Path $env:TEMP "$Repo-extract-$(Get-Random)"
+    # Normalize $env:TEMP to long path -- corporate PCs may have 8.3 short paths
+    # (e.g. C:\Users\C630D~1.LAB\...) that fail when creating files/directories.
+    $tempDir = if (Test-Path $env:TEMP) { (Get-Item $env:TEMP).FullName } else { $env:TEMP }
+    $tempZip = Join-Path $tempDir "$Repo-download-$(Get-Random).zip"
+    $tempExtract = Join-Path $tempDir "$Repo-extract-$(Get-Random)"
 
     try {
         Invoke-WebRequest -Uri $release.url -OutFile $tempZip -UseBasicParsing


### PR DESCRIPTION
﻿## Summary
- Normalize `C:\Users\Win11\AppData\Local\Temp` to long path in `Install-GithubReleaseBinary` to fix 8.3 short name resolution failures on corporate PCs

Closes #211

## PR Type
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | `Install-GithubReleaseBinary` resolves `C:\Users\Win11\AppData\Local\Temp` via `Get-Item` before creating temp files |

## Test Plan
- [x] Normal PCs: `Get-Item` on a long path returns the same path — no behavior change
- [x] Corporate PCs: 8.3 short path gets resolved to full username path

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
