### PR TITLE
fix(init): preserve existing copilot-instructions content on init

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -625,6 +625,17 @@ function Invoke-InitCommand {
     }
     else {
         $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent -SkipEngramProtocol:$skipProtocol
+
+        # Preserve existing instructions content: append below team-ai-kit section
+        if (Test-Path $instructionsPath) {
+            $existing = [System.IO.File]::ReadAllText($instructionsPath, [System.Text.UTF8Encoding]::new($false))
+            # Only preserve if it's NOT a previous team-ai-kit generated file
+            if ($existing -and $existing -notmatch '# Team AI Kit -- Copilot Instructions') {
+                Write-Step "Existing $relInstructionsPath found -- preserving content below team-ai-kit section"
+                $instructions += "`n---`n`n## Project Instructions (pre-existing)`n`n$existing"
+            }
+        }
+
         [System.IO.File]::WriteAllText($instructionsPath, $instructions, [System.Text.UTF8Encoding]::new($false))
         Write-Ok "Created: $relInstructionsPath"
     }


### PR DESCRIPTION
﻿## Summary
- Preserve existing copilot-instructions.md content when running `team-ai-kit init`
- Team-ai-kit content goes on top, existing project instructions appended below with a separator
- If the file is already a team-ai-kit generated file, it gets replaced normally (re-init)

Closes #213

## PR Type
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `bin/team-ai-kit.ps1` | Init reads existing instructions, checks if it's user content (not team-ai-kit), and appends below |

## Test Plan
- [x] New project (no existing file): creates normally
- [x] Existing user instructions: preserved below team-ai-kit section
- [x] Re-init (existing team-ai-kit file): replaced cleanly, no duplication

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
