### PR TITLE
feat(init): always inject engram protocol in project instructions for all IDEs

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -617,7 +617,10 @@ function Invoke-InitCommand {
         }
     }
 
-    $skipProtocol = Test-GentleAiSupportsIde -Ide $effectiveIde
+    # Always inject engram protocol into project instructions for all IDEs.
+    # Even when gentle-ai handles it globally, having it at project level
+    # reinforces the behavior (especially for models that don't follow global instructions reliably).
+    $skipProtocol = $false
     $relInstructionsPath = $instructionsPath.Replace($projectRoot, '').TrimStart('\', '/')
 
     if ($DryRun) {
@@ -992,7 +995,8 @@ function Invoke-UpdateCommand {
                 Write-Dry "Would update engram protocol in: $relPath"
             }
             else {
-                $skipProtocol = Test-GentleAiSupportsIde -Ide $config.ide
+                # Always inject engram protocol -- reinforces behavior at project level
+                $skipProtocol = $false
                 $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath -SkipEngramProtocol:$skipProtocol
                 if ($protocolChanged) {
                     if ($skipProtocol) {


### PR DESCRIPTION
﻿## Summary
- Always inject Engram Memory Protocol into project-level instructions for ALL IDEs
- Previously skipped for VS Code/Cursor/OpenCode (assumed gentle-ai handled it globally)
- Models like Copilot don't reliably follow global instructions, so project-level reinforcement is needed

Closes #215

## PR Type
- [x] New feature

## Changes

| File | Change |
|------|--------|
| `bin/team-ai-kit.ps1` | Init and update commands now set `skipProtocol = false` instead of checking `Test-GentleAiSupportsIde` |

## Test Plan
- [x] Existing function-level tests for SkipEngramProtocol still pass (flag still works in the function)
- [x] Init now generates copilot-instructions.md WITH engram protocol for VS Code
- [x] Update command also injects protocol on refresh

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
