### PR TITLE
fix(init): resolve Join-Path PS 5.1 incompatibility in engram protocol loading

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -626,7 +626,7 @@ function Invoke-InitCommand {
         Write-Dry "Would create: $relInstructionsPath"
     }
     else {
-        $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent
+        $instructions = New-CopilotInstructions -Role $effectiveRole -PackRulesContent $packRulesContent -TeamRulesContent $teamRulesContent -KitRoot $kitRoot
 
         # Preserve existing instructions content: append below team-ai-kit section
         if (Test-Path $instructionsPath) {
@@ -995,7 +995,7 @@ function Invoke-UpdateCommand {
             }
             else {
                 # Always inject engram protocol -- reinforces behavior at project level
-                $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath
+                $protocolChanged = Update-InstructionsEngramProtocol -FilePath $instructionsPath -KitRoot $kitRoot
                 if ($protocolChanged) {
                     Write-Ok 'Engram Memory Protocol updated in project instructions'
                 }

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1661,8 +1661,18 @@ function Get-EngramProtocolContent {
         Returns the Engram Memory Protocol markdown content from shared template.
         Single source of truth: templates/engram-protocol.md
     #>
-    $kitRoot = Split-Path -Parent $PSScriptRoot
-    Get-Content (Join-Path $kitRoot 'templates' 'engram-protocol.md') -Raw
+    param(
+        [string]$KitRoot
+    )
+    if (-not $KitRoot) {
+        $KitRoot = Split-Path -Parent $PSScriptRoot
+    }
+    $templatePath = Join-Path (Join-Path $KitRoot 'templates') 'engram-protocol.md'
+    if (-not (Test-Path $templatePath)) {
+        Write-Warning "Engram protocol template not found: $templatePath"
+        return ''
+    }
+    return [string](Get-Content $templatePath -Raw)
 }
 
 function Update-InstructionsEngramProtocol {
@@ -1678,6 +1688,7 @@ function Update-InstructionsEngramProtocol {
     param(
         [Parameter(Mandatory)]
         [string]$FilePath,
+        [string]$KitRoot = '',
         [switch]$SkipEngramProtocol
     )
 
@@ -1706,7 +1717,7 @@ function Update-InstructionsEngramProtocol {
         return $false
     }
 
-    $protocolContent = Get-EngramProtocolContent
+    $protocolContent = Get-EngramProtocolContent -KitRoot $KitRoot
     $newSection = $protocolContent.Trim()
     if ($startIdx -ge 0) {
         $endIdx = $existing.IndexOf($endMarker, $startIdx)
@@ -1733,15 +1744,14 @@ function New-CopilotInstructions {
     <#
     .SYNOPSIS
         Generates the copilot-instructions.md content with team rules injected.
-        Engram protocol is only included for IDEs where gentle-ai does NOT handle it
-        (e.g. IntelliJ). For gentle-ai-supported IDEs, gentle-ai injects the protocol
-        globally and team-ai-kit skips it to avoid duplication.
+        Engram protocol is always included by default. Use SkipEngramProtocol to exclude.
     #>
     param(
         [Parameter(Mandatory)]
         [string]$Role,
         [string]$PackRulesContent = '',
         [string]$TeamRulesContent = '',
+        [string]$KitRoot = '',
         [switch]$SkipEngramProtocol
     )
 
@@ -1763,7 +1773,7 @@ function New-CopilotInstructions {
     $result = $header
 
     if (-not $SkipEngramProtocol) {
-        $memoryProtocol = Get-EngramProtocolContent
+        $memoryProtocol = Get-EngramProtocolContent -KitRoot $KitRoot
         $result += $memoryProtocol
     }
 


### PR DESCRIPTION
Closes #219

## PR Type
- [x] Bug fix

## Summary
- Fix `Join-Path` calls with 3+ arguments that break on PowerShell 5.1 (Windows corporate PCs)
- Add explicit `$KitRoot` parameter to `Get-EngramProtocolContent`, `New-CopilotInstructions`, and `Update-InstructionsEngramProtocol` for reliable template resolution

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | Nested `Join-Path` calls for PS 5.1 compatibility, added `$KitRoot` param to 3 functions |
| `bin/team-ai-kit.ps1` | Pass `-KitRoot $kitRoot` to `New-CopilotInstructions` and `Update-InstructionsEngramProtocol` |

## Test Plan
- [x] All 223 unit tests pass (`Invoke-Pester`)
- [x] Manually tested on Windows PowerShell 5.1

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
