### PR TITLE
fix(release): clean temp dir before scoop PR step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           mkdir -p team-ai-kit
           cp -r bin lib packs skills templates setup.sh setup.ps1 LICENSE README.md team-ai-kit/
           zip -r "$ZIPNAME" team-ai-kit
+          rm -rf team-ai-kit
           echo "zipname=$ZIPNAME" >> "$GITHUB_ENV"
 
       - name: Compute SHA256 hash


### PR DESCRIPTION
Remove team-ai-kit/ temp dir after zipping to prevent create-pull-request from committing 17k lines of duplicated source. Also enabled Actions PR creation permission via API.