### PR TITLE
fix(sync): normalize project name to lowercase for engram compatibility

### DIFF
--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -40,7 +40,7 @@ function ConvertTo-SafeProjectName {
         Allows only: a-z A-Z 0-9 . _ -
     #>
     param([string]$Name)
-    return ($Name -replace '[^a-zA-Z0-9._-]', '')
+    return ($Name -replace '[^a-zA-Z0-9._-]', '').ToLower()
 }
 
 function Get-TeamAiKitConfigDir {

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -28,7 +28,7 @@ _require_jq() {
 _sanitize_project_name() {
     # Strips unsafe characters from project name to prevent shell injection in git hooks.
     # Allows only: a-z A-Z 0-9 . _ -
-    echo "$1" | tr -cd 'a-zA-Z0-9._-'
+    echo "$1" | tr -cd 'a-zA-Z0-9._-' | tr '[:upper:]' '[:lower:]'
 }
 
 _resolve_team_repo() {

--- a/tests/functions-bash.sh
+++ b/tests/functions-bash.sh
@@ -80,14 +80,17 @@ assert_eq "strips shell metacharacters" \
 assert_eq "strips spaces" \
     "myproject" "$(_sanitize_project_name "my project")"
 
-assert_eq "strips dollar signs and backticks" \
-    "projHOMEcmd" "$(_sanitize_project_name 'proj$HOME`cmd`')"
+assert_eq "strips dollar signs and backticks and lowercases" \
+    "projhomecmd" "$(_sanitize_project_name 'proj$HOME`cmd`')"
 
 assert_eq "returns empty for all-unsafe input" \
     "rm-rf" "$(_sanitize_project_name '$(rm -rf /)')"
 
 assert_eq "handles empty string" \
     "" "$(_sanitize_project_name "")"
+
+assert_eq "normalizes uppercase to lowercase for engram compatibility" \
+    "fe-3pl-template-next" "$(_sanitize_project_name "fe-3pl-Template-next")"
 
 echo ""
 

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -57,20 +57,24 @@ Describe 'ConvertTo-SafeProjectName' {
         ConvertTo-SafeProjectName -Name 'my-project_v2.0' | Should -Be 'my-project_v2.0'
     }
 
-    It 'strips shell metacharacters' {
+    It 'strips shell metacharacters and lowercases' {
         ConvertTo-SafeProjectName -Name 'proj"; rm -rf /; echo "' | Should -Be 'projrm-rfecho'
     }
 
-    It 'strips spaces' {
+    It 'strips spaces and lowercases' {
         ConvertTo-SafeProjectName -Name 'my project' | Should -Be 'myproject'
     }
 
-    It 'strips dollar signs and backticks' {
-        ConvertTo-SafeProjectName -Name 'proj$HOME`cmd`' | Should -Be 'projHOMEcmd'
+    It 'strips dollar signs and backticks and lowercases' {
+        ConvertTo-SafeProjectName -Name 'proj$HOME`cmd`' | Should -Be 'projhomecmd'
     }
 
     It 'returns empty string for all-unsafe input' {
         ConvertTo-SafeProjectName -Name '$(rm -rf /)' | Should -Be 'rm-rf'
+    }
+
+    It 'normalizes uppercase to lowercase for engram compatibility' {
+        ConvertTo-SafeProjectName -Name 'fe-3pl-Template-next' | Should -Be 'fe-3pl-template-next'
     }
 
     It 'handles empty string' {


### PR DESCRIPTION
Closes #230

## Summary
- Normalize project names to lowercase in both PowerShell and Bash sanitizers to match engram MCP's internal normalization
- Fixes empty chunk exports when repo directories have uppercase letters (e.g. e-3pl-Template-next)

## Changes

| File | Change |
|------|--------|
| lib/functions.ps1 | Added .ToLower() to ConvertTo-SafeProjectName |
| lib/functions.sh | Added 	r '[:upper:]' '[:lower:]' to _sanitize_project_name |
| 	ests/functions.Tests.ps1 | Updated expectations + added engram compat test |
| 	ests/functions-bash.sh | Updated expectations + added engram compat test |

## Test Plan
- [x] PowerShell tests pass (223/223)
- [x] Manually verified e-3pl-Template-next normalizes to e-3pl-template-next

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one 	ype:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers