### PR TITLE
chore(release): bump version to 2.7.1

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.7.0'
+KIT_VERSION='2.7.1'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -85,7 +85,7 @@ $ErrorActionPreference = 'Stop'
 
 # -- Kit version ---------------------------------------------------------------
 # Single source of truth. Bump this on every release.
-$KitVersion = '2.7.0'
+$KitVersion = '2.7.1'
 
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root


### PR DESCRIPTION
Closes #232

## Summary
- Bump KitVersion to 2.7.1 in both PS and Bash CLIs
- After merge, tag v2.7.1 to trigger release workflow

## Changes

| File | Change |
|------|--------|
| `bin/team-ai-kit.ps1` | KitVersion 2.7.0 → 2.7.1 |
| `bin/team-ai-kit` | KIT_VERSION 2.7.0 → 2.7.1 |

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format