### PR TITLE
fix(mcp): add cwd to MCP config and gitignore .team-ai-kit.json during init

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -696,6 +696,20 @@ cmd_init() {
         else
             step ".gitattributes already configured"
         fi
+
+        # 4d. Ensure .team-ai-kit.json is gitignored
+        local gi_json gi_created gi_updated
+        gi_json=$(set_gitignore_rules "$project_root")
+        gi_created=$(echo "$gi_json" | jq -r '.created')
+        gi_updated=$(echo "$gi_json" | jq -r '.updated')
+
+        if [[ "$gi_created" == "true" ]]; then
+            ok ".gitignore created -- .team-ai-kit.json excluded from git"
+        elif [[ "$gi_updated" == "true" ]]; then
+            ok ".gitignore updated -- .team-ai-kit.json excluded from git"
+        else
+            step ".gitignore already has .team-ai-kit.json"
+        fi
     fi
 
     # -- Save project config ---------------------------------------------------
@@ -728,7 +742,7 @@ cmd_init() {
 
         echo ""
         echo -e "  ${C_YELLOW}Next steps:${C_RESET}"
-        echo -e "    ${C_WHITE}1. Commit .team-ai-kit.json and $rel_instructions_path to your repo${C_RESET}"
+        echo -e "    ${C_WHITE}1. Commit $rel_instructions_path to your repo${C_RESET}"
         if [[ -n "$effective_team_repo" ]]; then
             local rel_skills_dir
             rel_skills_dir="$(get_ide_project_skills_directory "$effective_ide" "$project_root")"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -720,6 +720,19 @@ function Invoke-InitCommand {
         else {
             Write-Step '.gitattributes already configured'
         }
+
+        # 4d. Ensure .team-ai-kit.json is gitignored
+        $giResult = Set-GitIgnoreRules -ProjectRoot $projectRoot
+
+        if ($giResult.created) {
+            Write-Ok '.gitignore created -- .team-ai-kit.json excluded from git'
+        }
+        elseif ($giResult.updated) {
+            Write-Ok '.gitignore updated -- .team-ai-kit.json excluded from git'
+        }
+        else {
+            Write-Step '.gitignore already has .team-ai-kit.json'
+        }
     }
 
     # -- Save project config ---------------------------------------------------
@@ -753,7 +766,7 @@ function Invoke-InitCommand {
 
         Write-Host ''
         Write-Host '  Next steps:' -ForegroundColor Yellow
-        Write-Host "    1. Commit .team-ai-kit.json and $relInstructionsPath to your repo" -ForegroundColor White
+        Write-Host "    1. Commit $relInstructionsPath to your repo" -ForegroundColor White
         if ($effectiveTeamRepo) {
             $relSkillsDir = (Get-IdeProjectSkillsDirectory -Ide $effectiveIde -ProjectRoot $projectRoot).Replace($projectRoot, '').TrimStart('\', '/')
             Write-Host "    2. Commit $relSkillsDir/ (team skills for this project)" -ForegroundColor White
@@ -1000,6 +1013,24 @@ function Invoke-UpdateCommand {
         }
         else {
             Write-Step '.gitattributes already configured'
+        }
+    }
+
+    # Step 4b: Ensure .team-ai-kit.json is gitignored
+    if ($DryRun) {
+        Write-Dry 'Would ensure .team-ai-kit.json is in .gitignore'
+    }
+    else {
+        $giResult = Set-GitIgnoreRules -ProjectRoot $projectRoot
+
+        if ($giResult.created) {
+            Write-Ok '.gitignore created -- .team-ai-kit.json excluded from git'
+        }
+        elseif ($giResult.updated) {
+            Write-Ok '.gitignore updated -- .team-ai-kit.json excluded from git'
+        }
+        else {
+            Write-Step '.gitignore already has .team-ai-kit.json'
         }
     }
 

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -239,6 +239,39 @@ function Set-GitAttributes {
     }
 }
 
+function Set-GitIgnoreRules {
+    <#
+    .SYNOPSIS
+        Ensures .team-ai-kit.json is listed in the project .gitignore.
+    .DESCRIPTION
+        Appends .team-ai-kit.json to .gitignore if not already present.
+        Creates .gitignore if it does not exist. Idempotent.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $giPath = Join-Path $ProjectRoot '.gitignore'
+    $entry = '.team-ai-kit.json'
+
+    if (Test-Path $giPath) {
+        $existing = Get-Content $giPath -Raw -ErrorAction SilentlyContinue
+        if ($existing -and $existing.Contains($entry)) {
+            return @{ created = $false; updated = $false; path = $giPath }
+        }
+        $newContent = $existing.TrimEnd() + "`n" + $entry + "`n"
+        $lfContent = $newContent -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($giPath, $lfContent, [System.Text.UTF8Encoding]::new($false))
+        return @{ created = $false; updated = $true; path = $giPath }
+    }
+    else {
+        $lfContent = ($entry + "`n") -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($giPath, $lfContent, [System.Text.UTF8Encoding]::new($false))
+        return @{ created = $true; updated = $false; path = $giPath }
+    }
+}
+
 function Remove-GitAttributesBlock {
     <#
     .SYNOPSIS
@@ -1671,6 +1704,7 @@ function New-VsCodeMcpConfig {
             engram = @{
                 command = $EngramBinaryPath
                 args    = @('mcp', '--tools=agent')
+                cwd     = '${workspaceFolder}'
             }
             context7 = @{
                 type = 'sse'

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -300,6 +300,28 @@ remove_gitattributes_block() {
     fi
 }
 
+set_gitignore_rules() {
+    # Ensures .team-ai-kit.json is listed in the project .gitignore.
+    # Creates .gitignore if it does not exist. Idempotent.
+    # Usage: set_gitignore_rules "/path/to/project"
+    # Outputs JSON: {"created":bool,"updated":bool,"path":"..."}
+    local project_root="$1"
+    local gi_path="$project_root/.gitignore"
+    local entry=".team-ai-kit.json"
+
+    if [[ -f "$gi_path" ]]; then
+        if grep -qF "$entry" "$gi_path" 2>/dev/null; then
+            printf '{"created":false,"updated":false,"path":"%s"}' "$gi_path"
+            return
+        fi
+        printf '\n%s\n' "$entry" >> "$gi_path"
+        printf '{"created":false,"updated":true,"path":"%s"}' "$gi_path"
+    else
+        printf '%s\n' "$entry" > "$gi_path"
+        printf '{"created":true,"updated":false,"path":"%s"}' "$gi_path"
+    fi
+}
+
 initialize_engram_sync() {
     # Runs initial engram sync to export project memories to .engram/.
     # Uses native 'engram sync --project <name>' for team knowledge sharing via git.
@@ -1181,7 +1203,8 @@ new_vscode_mcp_config() {
         servers: {
             engram: {
                 command: $engram,
-                args: ["mcp", "--tools=agent"]
+                args: ["mcp", "--tools=agent"],
+                cwd: "${workspaceFolder}"
             },
             context7: {
                 type: "sse",
@@ -1197,7 +1220,8 @@ new_cursor_mcp_config() {
         mcpServers: {
             engram: {
                 command: $engram,
-                args: ["mcp", "--tools=agent"]
+                args: ["mcp", "--tools=agent"],
+                cwd: "${workspaceFolder}"
             },
             context7: {
                 url: "https://mcp.context7.com/mcp"

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -377,6 +377,12 @@ Describe 'New-VsCodeMcpConfig' {
         $config.servers.context7 | Should -Not -BeNullOrEmpty
         $config.servers.context7.url | Should -BeLike '*context7*'
     }
+
+    It 'includes cwd with workspaceFolder variable' {
+        $json = New-VsCodeMcpConfig -EngramBinaryPath 'C:\engram.exe'
+        $config = $json | ConvertFrom-Json
+        $config.servers.engram.cwd | Should -Be '${workspaceFolder}'
+    }
 }
 
 # -- Instructions Generation ---------------------------------------------------
@@ -2147,6 +2153,45 @@ Describe 'Set-GitAttributes' {
         $existing = "# [team-ai-kit] engram diff rules`n.engram/** linguist-generated=true`n.engram/** -diff`n"
         Set-Content $gaPath -Value $existing -NoNewline
         $result = Set-GitAttributes -ProjectRoot $script:gaTestDir
+        $result.created | Should -BeFalse
+        $result.updated | Should -BeFalse
+    }
+}
+
+Describe 'Set-GitIgnoreRules' {
+    BeforeEach {
+        $script:giTestDir = Join-Path $TestDrive "gi-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:giTestDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $script:giTestDir) { Remove-Item $script:giTestDir -Recurse -Force }
+    }
+
+    It 'creates .gitignore when file does not exist' {
+        $result = Set-GitIgnoreRules -ProjectRoot $script:giTestDir
+        $result.created | Should -BeTrue
+        $result.updated | Should -BeFalse
+        $giPath = Join-Path $script:giTestDir '.gitignore'
+        Test-Path $giPath | Should -BeTrue
+        $content = Get-Content $giPath -Raw
+        $content | Should -BeLike '*.team-ai-kit.json*'
+    }
+
+    It 'appends entry to existing .gitignore without it' {
+        $giPath = Join-Path $script:giTestDir '.gitignore'
+        "node_modules/`n" | Set-Content $giPath -NoNewline
+        $result = Set-GitIgnoreRules -ProjectRoot $script:giTestDir
+        $result.created | Should -BeFalse
+        $result.updated | Should -BeTrue
+        $content = Get-Content $giPath -Raw
+        $content | Should -BeLike '*node_modules/*'
+        $content | Should -BeLike '*.team-ai-kit.json*'
+    }
+
+    It 'is idempotent -- no-op when entry already present' {
+        $giPath = Join-Path $script:giTestDir '.gitignore'
+        ".team-ai-kit.json`n" | Set-Content $giPath -NoNewline
+        $result = Set-GitIgnoreRules -ProjectRoot $script:giTestDir
         $result.created | Should -BeFalse
         $result.updated | Should -BeFalse
     }


### PR DESCRIPTION
Closes #235

## Summary
- Add `cwd: ${workspaceFolder}` to generated MCP config so engram detects the correct project name from the workspace instead of the user home directory
- Add `.team-ai-kit.json` to `.gitignore` during init and update to prevent personal config from traveling in git
- Fix Next steps message that incorrectly told users to commit `.team-ai-kit.json`

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | Added `cwd` to `New-VsCodeMcpConfig` + new `Set-GitIgnoreRules` function |
| `lib/functions.sh` | Added `cwd` to `new_vscode_mcp_config` and `new_cursor_mcp_config` + new `set_gitignore_rules` function |
| `bin/team-ai-kit.ps1` | Invoke `Set-GitIgnoreRules` in init and update + fix Next steps message |
| `bin/team-ai-kit` | Invoke `set_gitignore_rules` in init + fix Next steps message |
| `tests/functions.Tests.ps1` | 4 new tests: cwd in MCP config + 3 for gitignore rules |

## Test Plan
- [x] All 227 Pester tests pass (0 failures)
- [x] New tests cover cwd presence and gitignore create/update/idempotent scenarios
