### PR TITLE
fix(mcp): patch global mcp.json to add cwd after gentle-ai install

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -372,6 +372,14 @@ cmd_setup() {
 
         if [[ -n "$gentle_bin" ]] && "$gentle_bin" install --agent "$agent_id" --preset ecosystem-only --persona gentleman 2>/dev/null; then
             ok "gentle-ai configured for $agent_id"
+
+            # Patch global mcp.json to add cwd=${workspaceFolder} to engram
+            local patch_json patch_result
+            patch_json=$(add_mcp_engram_cwd "$OPT_IDE")
+            patch_result=$(echo "$patch_json" | jq -r '.patched')
+            if [[ "$patch_result" == "true" ]]; then
+                ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
+            fi
         else
             warn "gentle-ai install failed or exited with error"
             warn "Run gentle-ai manually after setup completes"
@@ -1026,6 +1034,20 @@ cmd_update() {
             ok ".gitattributes updated -- .engram/ diffs collapsed in PRs"
         else
             step ".gitattributes already configured"
+        fi
+    fi
+
+    # Step 4c: Ensure engram MCP has cwd=${workspaceFolder}
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry 'Would patch engram MCP config with cwd=${workspaceFolder}'
+    else
+        local patch_json patch_result
+        patch_json=$(add_mcp_engram_cwd "$ide")
+        patch_result=$(echo "$patch_json" | jq -r '.patched')
+        if [[ "$patch_result" == "true" ]]; then
+            ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
+        else
+            step 'Engram MCP config already has cwd'
         fi
     fi
 

--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -1042,7 +1042,7 @@ cmd_update() {
         dry 'Would patch engram MCP config with cwd=${workspaceFolder}'
     else
         local patch_json patch_result
-        patch_json=$(add_mcp_engram_cwd "$ide")
+        patch_json=$(add_mcp_engram_cwd "$config_ide")
         patch_result=$(echo "$patch_json" | jq -r '.patched')
         if [[ "$patch_result" == "true" ]]; then
             ok 'Patched engram MCP config: added cwd=${workspaceFolder}'

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -386,6 +386,12 @@ function Invoke-SetupCommand {
             & $gentleBin @installArgs
             if ($LASTEXITCODE -eq 0) {
                 Write-Ok "gentle-ai configured for $gentleAiAgentId"
+
+                # Patch global mcp.json to add cwd=${workspaceFolder} to engram
+                $patchResult = Add-McpEngramCwd -Ide $Ide
+                if ($patchResult.patched) {
+                    Write-Ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
+                }
             }
             else {
                 Write-Warn "gentle-ai install exited with code $LASTEXITCODE"
@@ -1031,6 +1037,20 @@ function Invoke-UpdateCommand {
         }
         else {
             Write-Step '.gitignore already has .team-ai-kit.json'
+        }
+    }
+
+    # Step 4c: Ensure engram MCP has cwd=${workspaceFolder}
+    if ($DryRun) {
+        Write-Dry 'Would patch engram MCP config with cwd=${workspaceFolder}'
+    }
+    else {
+        $patchResult = Add-McpEngramCwd -Ide $config.ide
+        if ($patchResult.patched) {
+            Write-Ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
+        }
+        else {
+            Write-Step 'Engram MCP config already has cwd'
         }
     }
 

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1690,6 +1690,75 @@ function Install-ProjectSkills {
 
 # ── MCP Config Generation ────────────────────────────────────────────────────
 
+function Get-GlobalMcpJsonPath {
+    <#
+    .SYNOPSIS
+        Returns the path to the global mcp.json for the given IDE.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Ide
+    )
+    switch ($Ide.ToLower()) {
+        'vscode'  { return Join-Path $env:APPDATA 'Code\User\mcp.json' }
+        'cursor'  { return Join-Path (Get-UserHome) '.cursor\mcp.json' }
+        default   { return $null }
+    }
+}
+
+function Add-McpEngramCwd {
+    <#
+    .SYNOPSIS
+        Patches the global mcp.json to add cwd=${workspaceFolder} to the engram server entry.
+    .DESCRIPTION
+        Reads the global mcp.json, checks if engram server exists, and adds cwd if missing.
+        Idempotent: no-op if cwd is already present.
+        Returns hashtable with patched=$true/$false.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Ide
+    )
+
+    $mcpPath = Get-GlobalMcpJsonPath -Ide $Ide
+    if (-not $mcpPath -or -not (Test-Path $mcpPath)) {
+        return @{ patched = $false; reason = 'no-mcp-file' }
+    }
+
+    try {
+        $raw = Get-Content $mcpPath -Raw -ErrorAction Stop
+        $config = $raw | ConvertFrom-Json
+
+        # Find engram entry in servers or mcpServers
+        $serversKey = if ($config.PSObject.Properties['servers']) { 'servers' }
+                      elseif ($config.PSObject.Properties['mcpServers']) { 'mcpServers' }
+                      else { $null }
+
+        if (-not $serversKey) {
+            return @{ patched = $false; reason = 'no-servers-key' }
+        }
+
+        $servers = $config.$serversKey
+        if (-not $servers.PSObject.Properties['engram']) {
+            return @{ patched = $false; reason = 'no-engram-entry' }
+        }
+
+        $engram = $servers.engram
+        if ($engram.PSObject.Properties['cwd']) {
+            return @{ patched = $false; reason = 'already-has-cwd' }
+        }
+
+        $engram | Add-Member -NotePropertyName 'cwd' -NotePropertyValue '${workspaceFolder}'
+        $json = $config | ConvertTo-Json -Depth 10
+        $lfJson = $json -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($mcpPath, $lfJson, [System.Text.UTF8Encoding]::new($false))
+        return @{ patched = $true; path = $mcpPath }
+    }
+    catch {
+        return @{ patched = $false; reason = "error: $_" }
+    }
+}
+
 function New-VsCodeMcpConfig {
     <#
     .SYNOPSIS

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1197,6 +1197,80 @@ install_project_skills() {
 
 # -- MCP Config Generation ----------------------------------------------------
 
+get_global_mcp_json_path() {
+    # Returns the path to the global mcp.json for the given IDE.
+    # Usage: get_global_mcp_json_path "vscode"
+    local ide="$1"
+    local home_dir
+    home_dir=$(get_user_home)
+
+    case "$ide" in
+        vscode)
+            if [[ "$OSTYPE" == darwin* ]]; then
+                echo "$home_dir/Library/Application Support/Code/User/mcp.json"
+            else
+                echo "${XDG_CONFIG_HOME:-$home_dir/.config}/Code/User/mcp.json"
+            fi
+            ;;
+        cursor)
+            echo "$home_dir/.cursor/mcp.json"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+add_mcp_engram_cwd() {
+    # Patches the global mcp.json to add cwd=${workspaceFolder} to engram.
+    # Usage: add_mcp_engram_cwd "vscode"
+    # Outputs JSON: {"patched":bool,"reason":"..."}
+    local ide="$1"
+    local mcp_path
+    mcp_path=$(get_global_mcp_json_path "$ide")
+
+    if [[ -z "$mcp_path" || ! -f "$mcp_path" ]]; then
+        printf '{"patched":false,"reason":"no-mcp-file"}'
+        return
+    fi
+
+    # Check if engram entry exists
+    local servers_key
+    servers_key=$(jq -r 'if .servers then "servers" elif .mcpServers then "mcpServers" else "" end' "$mcp_path" 2>/dev/null)
+
+    if [[ -z "$servers_key" ]]; then
+        printf '{"patched":false,"reason":"no-servers-key"}'
+        return
+    fi
+
+    local has_engram
+    has_engram=$(jq -r ".$servers_key | has(\"engram\")" "$mcp_path" 2>/dev/null)
+
+    if [[ "$has_engram" != "true" ]]; then
+        printf '{"patched":false,"reason":"no-engram-entry"}'
+        return
+    fi
+
+    local has_cwd
+    has_cwd=$(jq -r ".$servers_key.engram | has(\"cwd\")" "$mcp_path" 2>/dev/null)
+
+    if [[ "$has_cwd" == "true" ]]; then
+        printf '{"patched":false,"reason":"already-has-cwd"}'
+        return
+    fi
+
+    # Patch it
+    local tmp_file="${mcp_path}.tmp"
+    jq ".$servers_key.engram.cwd = \"\${workspaceFolder}\"" "$mcp_path" > "$tmp_file" 2>/dev/null
+    if [[ $? -eq 0 ]]; then
+        mv "$tmp_file" "$mcp_path"
+        printf '{"patched":true,"path":"%s"}' "$mcp_path"
+    else
+        rm -f "$tmp_file"
+        printf '{"patched":false,"reason":"jq-error"}'
+    fi
+}
+
 new_vscode_mcp_config() {
     local engram_path="$1"
     jq -n --arg engram "$engram_path" '{

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -385,6 +385,75 @@ Describe 'New-VsCodeMcpConfig' {
     }
 }
 
+Describe 'Get-GlobalMcpJsonPath' {
+    It 'returns a path for vscode' {
+        $path = Get-GlobalMcpJsonPath -Ide 'vscode'
+        $path | Should -BeLike '*Code*mcp.json'
+    }
+
+    It 'returns a path for cursor' {
+        $path = Get-GlobalMcpJsonPath -Ide 'cursor'
+        $path | Should -BeLike '*.cursor*mcp.json'
+    }
+
+    It 'returns $null for unsupported IDE' {
+        $path = Get-GlobalMcpJsonPath -Ide 'intellij'
+        $path | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Add-McpEngramCwd' {
+    BeforeEach {
+        $script:mcpTestDir = Join-Path $TestDrive "mcp-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:mcpTestDir -Force | Out-Null
+    }
+    AfterEach {
+        if (Test-Path $script:mcpTestDir) { Remove-Item $script:mcpTestDir -Recurse -Force }
+    }
+
+    It 'returns patched=$false when mcp.json does not exist' {
+        Mock Get-GlobalMcpJsonPath { return Join-Path $script:mcpTestDir 'nonexistent.json' }
+        $result = Add-McpEngramCwd -Ide 'vscode'
+        $result.patched | Should -BeFalse
+        $result.reason | Should -Be 'no-mcp-file'
+    }
+
+    It 'patches engram entry when cwd is missing' {
+        $mcpPath = Join-Path $script:mcpTestDir 'mcp.json'
+        $config = @{ servers = @{ engram = @{ command = 'engram'; args = @('mcp') } } }
+        $config | ConvertTo-Json -Depth 5 | Set-Content $mcpPath
+        Mock Get-GlobalMcpJsonPath { return $mcpPath }
+
+        $result = Add-McpEngramCwd -Ide 'vscode'
+        $result.patched | Should -BeTrue
+
+        $patched = Get-Content $mcpPath -Raw | ConvertFrom-Json
+        $patched.servers.engram.cwd | Should -Be '${workspaceFolder}'
+    }
+
+    It 'is idempotent -- no-op when cwd already present' {
+        $mcpPath = Join-Path $script:mcpTestDir 'mcp.json'
+        $config = @{ servers = @{ engram = @{ command = 'engram'; args = @('mcp'); cwd = '${workspaceFolder}' } } }
+        $config | ConvertTo-Json -Depth 5 | Set-Content $mcpPath
+        Mock Get-GlobalMcpJsonPath { return $mcpPath }
+
+        $result = Add-McpEngramCwd -Ide 'vscode'
+        $result.patched | Should -BeFalse
+        $result.reason | Should -Be 'already-has-cwd'
+    }
+
+    It 'returns no-engram-entry when engram server is missing' {
+        $mcpPath = Join-Path $script:mcpTestDir 'mcp.json'
+        $config = @{ servers = @{ context7 = @{ url = 'https://example.com' } } }
+        $config | ConvertTo-Json -Depth 5 | Set-Content $mcpPath
+        Mock Get-GlobalMcpJsonPath { return $mcpPath }
+
+        $result = Add-McpEngramCwd -Ide 'vscode'
+        $result.patched | Should -BeFalse
+        $result.reason | Should -Be 'no-engram-entry'
+    }
+}
+
 # -- Instructions Generation ---------------------------------------------------
 
 Describe 'Get-EngramProtocolContent' {


### PR DESCRIPTION
Closes #235

## Summary
- Add `Add-McpEngramCwd` / `add_mcp_engram_cwd` functions that patch the global `mcp.json` to add `cwd: ${workspaceFolder}` to the engram MCP server entry
- Patch runs automatically after `gentle-ai install` during setup and during `team-ai-kit update`
- Idempotent: no-op if cwd already present

## Context
The previous PR (#236) added `cwd` to the generated MCP JSON shown in manual setup, but for VS Code the MCP config is written by `gentle-ai install` globally without `cwd`. This PR patches that global file post-install.

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | New `Get-GlobalMcpJsonPath` + `Add-McpEngramCwd` functions |
| `lib/functions.sh` | New `get_global_mcp_json_path` + `add_mcp_engram_cwd` functions |
| `bin/team-ai-kit.ps1` | Invoke patch after gentle-ai install in setup + in update command |
| `bin/team-ai-kit` | Invoke patch after gentle-ai install in setup + in update command |
| `tests/functions.Tests.ps1` | 7 new tests: GlobalMcpJsonPath (3) + Add-McpEngramCwd (4) |

## Test Plan
- [x] All 234 Pester tests pass (0 failures)
- [x] New tests cover path resolution, patching, idempotency, and missing entries
