### PR TITLE
chore(release): bump version to 2.7.2

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.7.1'
+KIT_VERSION='2.7.2'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -85,7 +85,7 @@ $ErrorActionPreference = 'Stop'
 
 # -- Kit version ---------------------------------------------------------------
 # Single source of truth. Bump this on every release.
-$KitVersion = '2.7.1'
+$KitVersion = '2.7.2'
 
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root


### PR DESCRIPTION
Closes #235

## Summary
- Bump version from 2.7.1 to 2.7.2 for MCP cwd fix + gitignore fix release