### PR TITLE
fix(mcp): create per-project .vscode/mcp.json instead of patching global config

### DIFF
--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -386,12 +386,6 @@ function Invoke-SetupCommand {
             & $gentleBin @installArgs
             if ($LASTEXITCODE -eq 0) {
                 Write-Ok "gentle-ai configured for $gentleAiAgentId"
-
-                # Patch global mcp.json to add cwd=${workspaceFolder} to engram
-                $patchResult = Add-McpEngramCwd -Ide $Ide
-                if ($patchResult.patched) {
-                    Write-Ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
-                }
             }
             else {
                 Write-Warn "gentle-ai install exited with code $LASTEXITCODE"
@@ -534,7 +528,7 @@ function Invoke-InitCommand {
     $projectRoot = (Get-Location).Path
 
     # -- Step 1: Check global config -------------------------------------------
-    Write-Host '  [1/4] Checking global configuration...' -ForegroundColor White
+    Write-Host '  [1/5] Checking global configuration...' -ForegroundColor White
     $globalConfig = Get-TeamAiKitConfig
     if (-not $globalConfig.ide) {
         Write-Err 'No global configuration found.'
@@ -545,7 +539,7 @@ function Invoke-InitCommand {
 
     # -- Step 2: Check if already initialized ----------------------------------
     Write-Host ''
-    Write-Host '  [2/4] Checking project state...' -ForegroundColor White
+    Write-Host '  [2/5] Checking project state...' -ForegroundColor White
 
     $existingConfig = $null
     if (Test-ProjectInitialized -ProjectRoot $projectRoot) {
@@ -585,7 +579,7 @@ function Invoke-InitCommand {
 
     # -- Step 3: Generate project files ----------------------------------------
     Write-Host ''
-    Write-Host '  [3/4] Generating project files...' -ForegroundColor White
+    Write-Host '  [3/5] Generating project files...' -ForegroundColor White
 
     # 3a. Instructions file
     $instructionsPath = Get-IdeInstructionsPath -Ide $effectiveIde -ProjectRoot $projectRoot
@@ -676,7 +670,34 @@ function Invoke-InitCommand {
 
     # -- Step 4: Setup engram sync + git hooks --------------------------------
     Write-Host ''
-    Write-Host '  [4/4] Setting up engram sync and git hooks...' -ForegroundColor White
+    Write-Host '  [4/5] Setting up project MCP config...' -ForegroundColor White
+
+    # 4a. Install .vscode/mcp.json (or IDE equivalent) with engram + context7
+    if ($DryRun) {
+        Write-Dry 'Would create/update .vscode/mcp.json with engram + context7'
+    }
+    else {
+        $engramPath = Get-EngramBinaryPath
+        if (-not $engramPath) { $engramPath = '(path-to-engram)' }
+
+        $mcpResult = Install-ProjectMcpConfig -ProjectRoot $projectRoot -EngramBinaryPath $engramPath
+        if ($mcpResult.created) {
+            Write-Ok 'Created .vscode/mcp.json with engram + context7'
+        }
+        elseif ($mcpResult.updated) {
+            Write-Ok 'Updated .vscode/mcp.json -- engram + context7 merged'
+        }
+        elseif ($mcpResult.unchanged) {
+            Write-Step '.vscode/mcp.json already up to date'
+        }
+        else {
+            Write-Warn "MCP config issue: $($mcpResult.error)"
+        }
+    }
+
+    # -- Step 5: Setup engram sync + git hooks --------------------------------
+    Write-Host ''
+    Write-Host '  [5/5] Setting up engram sync and git hooks...' -ForegroundColor White
 
     # Derive project name from directory
     $projectName = ConvertTo-SafeProjectName (Split-Path $projectRoot -Leaf)
@@ -1037,20 +1058,6 @@ function Invoke-UpdateCommand {
         }
         else {
             Write-Step '.gitignore already has .team-ai-kit.json'
-        }
-    }
-
-    # Step 4c: Ensure engram MCP has cwd=${workspaceFolder}
-    if ($DryRun) {
-        Write-Dry 'Would patch engram MCP config with cwd=${workspaceFolder}'
-    }
-    else {
-        $patchResult = Add-McpEngramCwd -Ide $config.ide
-        if ($patchResult.patched) {
-            Write-Ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
-        }
-        else {
-            Write-Step 'Engram MCP config already has cwd'
         }
     }
 

--- a/lib/functions.ps1
+++ b/lib/functions.ps1
@@ -1706,56 +1706,111 @@ function Get-GlobalMcpJsonPath {
     }
 }
 
-function Add-McpEngramCwd {
+function Install-ProjectMcpConfig {
     <#
     .SYNOPSIS
-        Patches the global mcp.json to add cwd=${workspaceFolder} to the engram server entry.
+        Creates or merges .vscode/mcp.json in the project with engram + context7 servers.
     .DESCRIPTION
-        Reads the global mcp.json, checks if engram server exists, and adds cwd if missing.
-        Idempotent: no-op if cwd is already present.
-        Returns hashtable with patched=$true/$false.
+        If the file exists, reads it and merges engram/context7 entries without touching
+        other servers. If it does not exist, creates it fresh.
+        Returns hashtable with created=$true/updated=$true/unchanged=$true.
     #>
     param(
         [Parameter(Mandatory)]
-        [string]$Ide
+        [string]$ProjectRoot,
+
+        [Parameter(Mandatory)]
+        [string]$EngramBinaryPath
     )
 
-    $mcpPath = Get-GlobalMcpJsonPath -Ide $Ide
-    if (-not $mcpPath -or -not (Test-Path $mcpPath)) {
-        return @{ patched = $false; reason = 'no-mcp-file' }
+    $vscodDir = Join-Path $ProjectRoot '.vscode'
+    $mcpPath = Join-Path $vscodDir 'mcp.json'
+
+    # Build the server entries we want
+    $engramEntry = [ordered]@{
+        command = $EngramBinaryPath
+        args    = @('mcp', '--tools=agent')
+    }
+    $context7Entry = [ordered]@{
+        type = 'sse'
+        url  = 'https://mcp.context7.com/mcp'
     }
 
-    try {
-        $raw = Get-Content $mcpPath -Raw -ErrorAction Stop
-        $config = $raw | ConvertFrom-Json
+    if (Test-Path $mcpPath) {
+        try {
+            $raw = Get-Content $mcpPath -Raw -ErrorAction Stop
+            $config = $raw | ConvertFrom-Json
 
-        # Find engram entry in servers or mcpServers
-        $serversKey = if ($config.PSObject.Properties['servers']) { 'servers' }
-                      elseif ($config.PSObject.Properties['mcpServers']) { 'mcpServers' }
-                      else { $null }
+            # Detect servers key (servers or mcpServers)
+            $serversKey = if ($config.PSObject.Properties['servers']) { 'servers' }
+                          elseif ($config.PSObject.Properties['mcpServers']) { 'mcpServers' }
+                          else { $null }
 
-        if (-not $serversKey) {
-            return @{ patched = $false; reason = 'no-servers-key' }
+            if (-not $serversKey) {
+                # File exists but no servers key — add one
+                $config | Add-Member -NotePropertyName 'servers' -NotePropertyValue ([PSCustomObject]@{})
+                $serversKey = 'servers'
+            }
+
+            $servers = $config.$serversKey
+            $changed = $false
+
+            # Merge engram
+            if ($servers.PSObject.Properties['engram']) {
+                $existing = $servers.engram
+                # Update command and args if different
+                $needsUpdate = ($existing.command -ne $EngramBinaryPath) -or
+                               (($existing.args -join ',') -ne ($engramEntry.args -join ','))
+                if ($needsUpdate) {
+                    $servers.engram.command = $EngramBinaryPath
+                    $servers.engram.args = $engramEntry.args
+                    # Remove cwd if present (project-level doesn't need it)
+                    if ($existing.PSObject.Properties['cwd']) {
+                        $servers.engram.PSObject.Properties.Remove('cwd')
+                    }
+                    $changed = $true
+                }
+            }
+            else {
+                $servers | Add-Member -NotePropertyName 'engram' -NotePropertyValue ([PSCustomObject]$engramEntry)
+                $changed = $true
+            }
+
+            # Merge context7
+            if (-not $servers.PSObject.Properties['context7']) {
+                $servers | Add-Member -NotePropertyName 'context7' -NotePropertyValue ([PSCustomObject]$context7Entry)
+                $changed = $true
+            }
+
+            if (-not $changed) {
+                return @{ unchanged = $true; path = $mcpPath }
+            }
+
+            $json = $config | ConvertTo-Json -Depth 10
+            $lfJson = $json -replace "`r`n", "`n"
+            [System.IO.File]::WriteAllText($mcpPath, $lfJson, [System.Text.UTF8Encoding]::new($false))
+            return @{ updated = $true; path = $mcpPath }
+        }
+        catch {
+            return @{ error = "Failed to merge: $_" }
+        }
+    }
+    else {
+        # Create fresh
+        if (-not (Test-Path $vscodDir)) {
+            New-Item -ItemType Directory -Path $vscodDir -Force | Out-Null
         }
 
-        $servers = $config.$serversKey
-        if (-not $servers.PSObject.Properties['engram']) {
-            return @{ patched = $false; reason = 'no-engram-entry' }
+        $config = [ordered]@{
+            servers = [ordered]@{
+                engram   = $engramEntry
+                context7 = $context7Entry
+            }
         }
-
-        $engram = $servers.engram
-        if ($engram.PSObject.Properties['cwd']) {
-            return @{ patched = $false; reason = 'already-has-cwd' }
-        }
-
-        $engram | Add-Member -NotePropertyName 'cwd' -NotePropertyValue '${workspaceFolder}'
-        $json = $config | ConvertTo-Json -Depth 10
+        $json = $config | ConvertTo-Json -Depth 5
         $lfJson = $json -replace "`r`n", "`n"
         [System.IO.File]::WriteAllText($mcpPath, $lfJson, [System.Text.UTF8Encoding]::new($false))
-        return @{ patched = $true; path = $mcpPath }
-    }
-    catch {
-        return @{ patched = $false; reason = "error: $_" }
+        return @{ created = $true; path = $mcpPath }
     }
 }
 
@@ -1773,7 +1828,6 @@ function New-VsCodeMcpConfig {
             engram = @{
                 command = $EngramBinaryPath
                 args    = @('mcp', '--tools=agent')
-                cwd     = '${workspaceFolder}'
             }
             context7 = @{
                 type = 'sse'

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -378,10 +378,10 @@ Describe 'New-VsCodeMcpConfig' {
         $config.servers.context7.url | Should -BeLike '*context7*'
     }
 
-    It 'includes cwd with workspaceFolder variable' {
+    It 'does not include cwd (global config does not support it)' {
         $json = New-VsCodeMcpConfig -EngramBinaryPath 'C:\engram.exe'
         $config = $json | ConvertFrom-Json
-        $config.servers.engram.cwd | Should -Be '${workspaceFolder}'
+        $config.servers.engram.PSObject.Properties['cwd'] | Should -BeNullOrEmpty
     }
 }
 
@@ -402,55 +402,78 @@ Describe 'Get-GlobalMcpJsonPath' {
     }
 }
 
-Describe 'Add-McpEngramCwd' {
+Describe 'Install-ProjectMcpConfig' {
     BeforeEach {
-        $script:mcpTestDir = Join-Path $TestDrive "mcp-test-$(Get-Random)"
-        New-Item -ItemType Directory -Path $script:mcpTestDir -Force | Out-Null
+        $script:projDir = Join-Path $TestDrive "proj-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:projDir -Force | Out-Null
     }
     AfterEach {
-        if (Test-Path $script:mcpTestDir) { Remove-Item $script:mcpTestDir -Recurse -Force }
+        if (Test-Path $script:projDir) { Remove-Item $script:projDir -Recurse -Force }
     }
 
-    It 'returns patched=$false when mcp.json does not exist' {
-        Mock Get-GlobalMcpJsonPath { return Join-Path $script:mcpTestDir 'nonexistent.json' }
-        $result = Add-McpEngramCwd -Ide 'vscode'
-        $result.patched | Should -BeFalse
-        $result.reason | Should -Be 'no-mcp-file'
+    It 'creates .vscode/mcp.json when it does not exist' {
+        $result = Install-ProjectMcpConfig -ProjectRoot $script:projDir -EngramBinaryPath 'C:\engram.exe'
+        $result.created | Should -BeTrue
+        $mcpPath = Join-Path $script:projDir '.vscode\mcp.json'
+        Test-Path $mcpPath | Should -BeTrue
+        $config = Get-Content $mcpPath -Raw | ConvertFrom-Json
+        $config.servers.engram.command | Should -Be 'C:\engram.exe'
+        $config.servers.context7.url | Should -BeLike '*context7*'
     }
 
-    It 'patches engram entry when cwd is missing' {
-        $mcpPath = Join-Path $script:mcpTestDir 'mcp.json'
-        $config = @{ servers = @{ engram = @{ command = 'engram'; args = @('mcp') } } }
-        $config | ConvertTo-Json -Depth 5 | Set-Content $mcpPath
-        Mock Get-GlobalMcpJsonPath { return $mcpPath }
+    It 'merges into existing mcp.json without removing other servers' {
+        $vscodeDir = Join-Path $script:projDir '.vscode'
+        New-Item -ItemType Directory -Path $vscodeDir -Force | Out-Null
+        $existing = @{ servers = @{ myserver = @{ command = 'my-tool' } } }
+        $existing | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $vscodeDir 'mcp.json')
 
-        $result = Add-McpEngramCwd -Ide 'vscode'
-        $result.patched | Should -BeTrue
+        $result = Install-ProjectMcpConfig -ProjectRoot $script:projDir -EngramBinaryPath 'C:\engram.exe'
+        $result.updated | Should -BeTrue
 
-        $patched = Get-Content $mcpPath -Raw | ConvertFrom-Json
-        $patched.servers.engram.cwd | Should -Be '${workspaceFolder}'
+        $config = Get-Content (Join-Path $vscodeDir 'mcp.json') -Raw | ConvertFrom-Json
+        $config.servers.myserver.command | Should -Be 'my-tool'
+        $config.servers.engram.command | Should -Be 'C:\engram.exe'
+        $config.servers.context7 | Should -Not -BeNullOrEmpty
     }
 
-    It 'is idempotent -- no-op when cwd already present' {
-        $mcpPath = Join-Path $script:mcpTestDir 'mcp.json'
-        $config = @{ servers = @{ engram = @{ command = 'engram'; args = @('mcp'); cwd = '${workspaceFolder}' } } }
-        $config | ConvertTo-Json -Depth 5 | Set-Content $mcpPath
-        Mock Get-GlobalMcpJsonPath { return $mcpPath }
+    It 'returns unchanged when engram and context7 already present' {
+        $vscodeDir = Join-Path $script:projDir '.vscode'
+        New-Item -ItemType Directory -Path $vscodeDir -Force | Out-Null
+        $existing = @{
+            servers = @{
+                engram   = @{ command = 'C:\engram.exe'; args = @('mcp', '--tools=agent') }
+                context7 = @{ type = 'sse'; url = 'https://mcp.context7.com/mcp' }
+            }
+        }
+        $existing | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $vscodeDir 'mcp.json')
 
-        $result = Add-McpEngramCwd -Ide 'vscode'
-        $result.patched | Should -BeFalse
-        $result.reason | Should -Be 'already-has-cwd'
+        $result = Install-ProjectMcpConfig -ProjectRoot $script:projDir -EngramBinaryPath 'C:\engram.exe'
+        $result.unchanged | Should -BeTrue
     }
 
-    It 'returns no-engram-entry when engram server is missing' {
-        $mcpPath = Join-Path $script:mcpTestDir 'mcp.json'
-        $config = @{ servers = @{ context7 = @{ url = 'https://example.com' } } }
-        $config | ConvertTo-Json -Depth 5 | Set-Content $mcpPath
-        Mock Get-GlobalMcpJsonPath { return $mcpPath }
+    It 'updates engram command when path differs' {
+        $vscodeDir = Join-Path $script:projDir '.vscode'
+        New-Item -ItemType Directory -Path $vscodeDir -Force | Out-Null
+        $existing = @{
+            servers = @{
+                engram   = @{ command = 'C:\old\engram.exe'; args = @('mcp', '--tools=agent') }
+                context7 = @{ type = 'sse'; url = 'https://mcp.context7.com/mcp' }
+            }
+        }
+        $existing | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $vscodeDir 'mcp.json')
 
-        $result = Add-McpEngramCwd -Ide 'vscode'
-        $result.patched | Should -BeFalse
-        $result.reason | Should -Be 'no-engram-entry'
+        $result = Install-ProjectMcpConfig -ProjectRoot $script:projDir -EngramBinaryPath 'C:\new\engram.exe'
+        $result.updated | Should -BeTrue
+
+        $config = Get-Content (Join-Path $vscodeDir 'mcp.json') -Raw | ConvertFrom-Json
+        $config.servers.engram.command | Should -Be 'C:\new\engram.exe'
+    }
+
+    It 'does not include cwd in the engram entry' {
+        $result = Install-ProjectMcpConfig -ProjectRoot $script:projDir -EngramBinaryPath 'C:\engram.exe'
+        $result.created | Should -BeTrue
+        $config = Get-Content (Join-Path $script:projDir '.vscode\mcp.json') -Raw | ConvertFrom-Json
+        $config.servers.engram.PSObject.Properties['cwd'] | Should -BeNullOrEmpty
     }
 }
 


### PR DESCRIPTION
﻿## Summary
- Replace `Add-McpEngramCwd` (broken: `$`{workspaceFolder} doesn't resolve in global mcp.json) with `Install-ProjectMcpConfig`
- `team-ai-kit init` now creates/merges `.vscode/mcp.json` with engram + context7 per project
- Remove `cwd` from `New-VsCodeMcpConfig` global template (not supported by VS Code)

Closes #240

## Changes

| File | Change |
|------|--------|
| `lib/functions.ps1` | Replace `Add-McpEngramCwd` with `Install-ProjectMcpConfig` (merge-safe); remove `cwd` from `New-VsCodeMcpConfig` |
| `bin/team-ai-kit.ps1` | Add step [4/5] in init calling `Install-ProjectMcpConfig`; remove `Add-McpEngramCwd` calls from setup/update |
| `tests/functions.Tests.ps1` | Replace 4 `Add-McpEngramCwd` tests with 5 `Install-ProjectMcpConfig` tests; update cwd assertion |

## Test Plan
- [x] 235 Pester tests pass, 0 failures
- [x] Manually verified `Install-ProjectMcpConfig` creates/merges correctly
