### PR TITLE
fix: sync bash script with PS1 changes (version + project MCP config)

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.7.2'
+KIT_VERSION='2.7.3'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -372,14 +372,6 @@ cmd_setup() {
 
         if [[ -n "$gentle_bin" ]] && "$gentle_bin" install --agent "$agent_id" --preset ecosystem-only --persona gentleman 2>/dev/null; then
             ok "gentle-ai configured for $agent_id"
-
-            # Patch global mcp.json to add cwd=${workspaceFolder} to engram
-            local patch_json patch_result
-            patch_json=$(add_mcp_engram_cwd "$OPT_IDE")
-            patch_result=$(echo "$patch_json" | jq -r '.patched')
-            if [[ "$patch_result" == "true" ]]; then
-                ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
-            fi
         else
             warn "gentle-ai install failed or exited with error"
             warn "Run gentle-ai manually after setup completes"
@@ -513,7 +505,7 @@ cmd_init() {
     project_root=$(pwd)
 
     # -- Step 1: Check global config -------------------------------------------
-    echo -e "  ${C_WHITE}[1/4] Checking global configuration...${C_RESET}"
+    echo -e "  ${C_WHITE}[1/5] Checking global configuration...${C_RESET}"
     local global_ide global_role
     global_ide=$(get_config_value "ide")
     global_role=$(get_config_value "role")
@@ -527,7 +519,7 @@ cmd_init() {
 
     # -- Step 2: Check if already initialized ----------------------------------
     echo ""
-    echo -e "  ${C_WHITE}[2/4] Checking project state...${C_RESET}"
+    echo -e "  ${C_WHITE}[2/5] Checking project state...${C_RESET}"
 
     if test_project_initialized "$project_root"; then
         local existing_role existing_ide existing_at
@@ -567,7 +559,7 @@ cmd_init() {
 
     # -- Step 3: Generate project files ----------------------------------------
     echo ""
-    echo -e "  ${C_WHITE}[3/4] Generating project files...${C_RESET}"
+    echo -e "  ${C_WHITE}[3/5] Generating project files...${C_RESET}"
 
     # 3a. Instructions file
     local instructions_path
@@ -649,9 +641,37 @@ cmd_init() {
         fi
     fi
 
-    # -- Step 4: Setup engram sync + git hooks --------------------------------
+    # -- Step 4: Setup project MCP config ----------------------------------------
     echo ""
-    echo -e "  ${C_WHITE}[4/4] Setting up engram sync and git hooks...${C_RESET}"
+    echo -e "  ${C_WHITE}[4/5] Setting up project MCP config...${C_RESET}"
+
+    if [[ "$OPT_DRY_RUN" == "true" ]]; then
+        dry "Would create/update .vscode/mcp.json with engram + context7"
+    else
+        local engram_path
+        engram_path=$(get_engram_binary_path 2>/dev/null) || true
+        if [[ -z "$engram_path" ]]; then engram_path="(path-to-engram)"; fi
+
+        local mcp_result mcp_created mcp_updated mcp_unchanged
+        mcp_result=$(install_project_mcp_config "$project_root" "$engram_path")
+        mcp_created=$(echo "$mcp_result" | jq -r '.created // empty')
+        mcp_updated=$(echo "$mcp_result" | jq -r '.updated // empty')
+        mcp_unchanged=$(echo "$mcp_result" | jq -r '.unchanged // empty')
+
+        if [[ "$mcp_created" == "true" ]]; then
+            ok "Created .vscode/mcp.json with engram + context7"
+        elif [[ "$mcp_updated" == "true" ]]; then
+            ok "Updated .vscode/mcp.json -- engram + context7 merged"
+        elif [[ "$mcp_unchanged" == "true" ]]; then
+            step ".vscode/mcp.json already up to date"
+        else
+            warn "MCP config issue: $mcp_result"
+        fi
+    fi
+
+    # -- Step 5: Setup engram sync + git hooks --------------------------------
+    echo ""
+    echo -e "  ${C_WHITE}[5/5] Setting up engram sync and git hooks...${C_RESET}"
 
     local project_name
     project_name=$(_sanitize_project_name "$(basename "$project_root")")
@@ -1034,20 +1054,6 @@ cmd_update() {
             ok ".gitattributes updated -- .engram/ diffs collapsed in PRs"
         else
             step ".gitattributes already configured"
-        fi
-    fi
-
-    # Step 4c: Ensure engram MCP has cwd=${workspaceFolder}
-    if [[ "$OPT_DRY_RUN" == "true" ]]; then
-        dry 'Would patch engram MCP config with cwd=${workspaceFolder}'
-    else
-        local patch_json patch_result
-        patch_json=$(add_mcp_engram_cwd "$config_ide")
-        patch_result=$(echo "$patch_json" | jq -r '.patched')
-        if [[ "$patch_result" == "true" ]]; then
-            ok 'Patched engram MCP config: added cwd=${workspaceFolder}'
-        else
-            step 'Engram MCP config already has cwd'
         fi
     fi
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1221,53 +1221,74 @@ get_global_mcp_json_path() {
     esac
 }
 
-add_mcp_engram_cwd() {
-    # Patches the global mcp.json to add cwd=${workspaceFolder} to engram.
-    # Usage: add_mcp_engram_cwd "vscode"
-    # Outputs JSON: {"patched":bool,"reason":"..."}
-    local ide="$1"
-    local mcp_path
-    mcp_path=$(get_global_mcp_json_path "$ide")
+install_project_mcp_config() {
+    # Creates or merges .vscode/mcp.json in the project with engram + context7.
+    # Usage: install_project_mcp_config "/path/to/project" "/path/to/engram"
+    # Outputs JSON: {"created":bool,"updated":bool,"unchanged":bool,"path":"..."}
+    local project_root="$1"
+    local engram_path="$2"
+    local vscode_dir="${project_root}/.vscode"
+    local mcp_path="${vscode_dir}/mcp.json"
 
-    if [[ -z "$mcp_path" || ! -f "$mcp_path" ]]; then
-        printf '{"patched":false,"reason":"no-mcp-file"}'
-        return
-    fi
+    if [[ -f "$mcp_path" ]]; then
+        # Merge into existing
+        local servers_key
+        servers_key=$(jq -r 'if .servers then "servers" elif .mcpServers then "mcpServers" else "" end' "$mcp_path" 2>/dev/null)
 
-    # Check if engram entry exists
-    local servers_key
-    servers_key=$(jq -r 'if .servers then "servers" elif .mcpServers then "mcpServers" else "" end' "$mcp_path" 2>/dev/null)
+        if [[ -z "$servers_key" ]]; then
+            servers_key="servers"
+        fi
 
-    if [[ -z "$servers_key" ]]; then
-        printf '{"patched":false,"reason":"no-servers-key"}'
-        return
-    fi
+        local has_engram has_context7 needs_update="false"
+        has_engram=$(jq -r ".$servers_key | has(\"engram\")" "$mcp_path" 2>/dev/null)
+        has_context7=$(jq -r ".$servers_key | has(\"context7\")" "$mcp_path" 2>/dev/null)
 
-    local has_engram
-    has_engram=$(jq -r ".$servers_key | has(\"engram\")" "$mcp_path" 2>/dev/null)
+        local tmp_file="${mcp_path}.tmp"
+        cp "$mcp_path" "$tmp_file"
 
-    if [[ "$has_engram" != "true" ]]; then
-        printf '{"patched":false,"reason":"no-engram-entry"}'
-        return
-    fi
+        if [[ "$has_engram" == "true" ]]; then
+            local current_cmd
+            current_cmd=$(jq -r ".$servers_key.engram.command" "$mcp_path" 2>/dev/null)
+            if [[ "$current_cmd" != "$engram_path" ]]; then
+                jq ".$servers_key.engram.command = \$cmd | .$servers_key.engram.args = [\"mcp\", \"--tools=agent\"] | del(.$servers_key.engram.cwd)" \
+                    --arg cmd "$engram_path" "$tmp_file" > "${tmp_file}.2" && mv "${tmp_file}.2" "$tmp_file"
+                needs_update="true"
+            fi
+        else
+            jq ".$servers_key.engram = {command: \$cmd, args: [\"mcp\", \"--tools=agent\"]}" \
+                --arg cmd "$engram_path" "$tmp_file" > "${tmp_file}.2" && mv "${tmp_file}.2" "$tmp_file"
+            needs_update="true"
+        fi
 
-    local has_cwd
-    has_cwd=$(jq -r ".$servers_key.engram | has(\"cwd\")" "$mcp_path" 2>/dev/null)
+        if [[ "$has_context7" != "true" ]]; then
+            jq ".$servers_key.context7 = {type: \"sse\", url: \"https://mcp.context7.com/mcp\"}" \
+                "$tmp_file" > "${tmp_file}.2" && mv "${tmp_file}.2" "$tmp_file"
+            needs_update="true"
+        fi
 
-    if [[ "$has_cwd" == "true" ]]; then
-        printf '{"patched":false,"reason":"already-has-cwd"}'
-        return
-    fi
-
-    # Patch it
-    local tmp_file="${mcp_path}.tmp"
-    jq ".$servers_key.engram.cwd = \"\${workspaceFolder}\"" "$mcp_path" > "$tmp_file" 2>/dev/null
-    if [[ $? -eq 0 ]]; then
-        mv "$tmp_file" "$mcp_path"
-        printf '{"patched":true,"path":"%s"}' "$mcp_path"
+        if [[ "$needs_update" == "true" ]]; then
+            mv "$tmp_file" "$mcp_path"
+            printf '{"updated":true,"path":"%s"}' "$mcp_path"
+        else
+            rm -f "$tmp_file"
+            printf '{"unchanged":true,"path":"%s"}' "$mcp_path"
+        fi
     else
-        rm -f "$tmp_file"
-        printf '{"patched":false,"reason":"jq-error"}'
+        # Create fresh
+        mkdir -p "$vscode_dir"
+        jq -n --arg engram "$engram_path" '{
+            servers: {
+                engram: {
+                    command: $engram,
+                    args: ["mcp", "--tools=agent"]
+                },
+                context7: {
+                    type: "sse",
+                    url: "https://mcp.context7.com/mcp"
+                }
+            }
+        }' > "$mcp_path"
+        printf '{"created":true,"path":"%s"}' "$mcp_path"
     fi
 }
 
@@ -1277,8 +1298,7 @@ new_vscode_mcp_config() {
         servers: {
             engram: {
                 command: $engram,
-                args: ["mcp", "--tools=agent"],
-                cwd: "${workspaceFolder}"
+                args: ["mcp", "--tools=agent"]
             },
             context7: {
                 type: "sse",
@@ -1294,8 +1314,7 @@ new_cursor_mcp_config() {
         mcpServers: {
             engram: {
                 command: $engram,
-                args: ["mcp", "--tools=agent"],
-                cwd: "${workspaceFolder}"
+                args: ["mcp", "--tools=agent"]
             },
             context7: {
                 url: "https://mcp.context7.com/mcp"


### PR DESCRIPTION
﻿## Summary
- Sync bash script with PS1 changes from PR #241
- Bump bash KIT_VERSION to 2.7.3
- Replace `add_mcp_engram_cwd` with `install_project_mcp_config` in bash
- Remove `cwd` from `new_vscode_mcp_config` and `new_cursor_mcp_config`

Closes #246

## Changes

| File | Change |
|------|--------|
| `bin/team-ai-kit` | Version bump + add step [4/5] for project MCP config + remove cwd patch calls |
| `lib/functions.sh` | Replace `add_mcp_engram_cwd` with `install_project_mcp_config` + remove cwd from templates |

## Test Plan
- [x] 235 Pester tests pass
- [x] Version sync check should now pass (both scripts at 2.7.3)
