### PR TITLE
chore: update scoop manifest hash for v2.7.3 re-release

### DIFF
--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
   "license": "MIT",
   "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.7.3/team-ai-kit-v2.7.3.zip",
-  "hash": "d9e53e82d86f6c4f6d16dd2b87af48e76cb56e7be47640d702d9e2db463330a5",
+  "hash": "338c4e6b26490c0336d055f365b8a0aae6c16a775679980ec728ca7d6ce1ffcd",
   "extract_dir": "team-ai-kit",
   "bin": [
     [


### PR DESCRIPTION
﻿## Summary
- Update scoop hash after v2.7.3 re-release (includes bash sync fix from #247)

Closes #246

## Changes

| File | Change |
|------|--------|
| `scoop/team-ai-kit.json` | Updated SHA256 hash |
