### PR TITLE
chore(scoop): update engram manifest to v1.14.4

### DIFF
--- a/scoop/engram.json
+++ b/scoop/engram.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.12.0",
+    "version": "1.14.4",
     "description": "Persistent memory for AI coding agents. Agent-agnostic Go binary with SQLite + FTS5.",
     "homepage": "https://github.com/Gentleman-Programming/engram",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Gentleman-Programming/engram/releases/download/v1.12.0/engram_1.12.0_windows_amd64.zip",
-            "hash": "2c14b300e9195e4b88b9730901f3e973be997cae84c38eaf82cd1c2905b767db",
+            "url": "https://github.com/Gentleman-Programming/engram/releases/download/v1.14.4/engram_1.14.4_windows_amd64.zip",
+            "hash": "7deb32a8d565609557fc1cc68c06bf9eacd49f44e81afc4579c9e89486263b04",
             "bin": [
                 "engram.exe"
             ]
         },
         "arm64": {
-            "url": "https://github.com/Gentleman-Programming/engram/releases/download/v1.12.0/engram_1.12.0_windows_arm64.zip",
-            "hash": "2be6efd1ca199c14ef9efc83ee93d33f66cdb18930a1df7d5ae28e9a4f92a60e",
+            "url": "https://github.com/Gentleman-Programming/engram/releases/download/v1.14.4/engram_1.14.4_windows_arm64.zip",
+            "hash": "2121471c3d23e07b531fedb1f7ea33c985ba7ea906425c3accad3ec45fbab021",
             "bin": [
                 "engram.exe"
             ]


### PR DESCRIPTION
﻿Closes #253

## PR Type
- [x] Maintenance/tooling

## Summary
- Update engram Scoop manifest from v1.12.0 to v1.14.4
- New SHA256 hashes for both amd64 and arm64 Windows ZIPs

## Changes

| File | Change |
|------|--------|
| `scoop/engram.json` | Version bump 1.12.0 -> 1.14.4, updated URLs and hashes |

## Test Plan
- [x] Downloaded both ZIPs and verified SHA256 hashes match
- [x] Manifest JSON is valid

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
