### PR TITLE
chore: bump version to v2.7.4

### DIFF
--- a/bin/team-ai-kit
+++ b/bin/team-ai-kit
@@ -42,7 +42,7 @@
 set -euo pipefail
 
 # -- Version -------------------------------------------------------------------
-KIT_VERSION='2.7.3'
+KIT_VERSION='2.7.4'
 
 # -- Resolve paths -------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/team-ai-kit.ps1
+++ b/bin/team-ai-kit.ps1
@@ -85,7 +85,7 @@ $ErrorActionPreference = 'Stop'
 
 # -- Kit version ---------------------------------------------------------------
 # Single source of truth. Bump this on every release.
-$KitVersion = '2.7.3'
+$KitVersion = '2.7.4'
 
 # -- Resolve paths -------------------------------------------------------------
 # bin/ is one level down from the kit root

--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -1,10 +1,10 @@
 {
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Team AI Kit - gentle-ai for teams. Standardizes AI usage across development teams with role-based skills, shared memory, and zero-friction onboarding.",
   "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
   "license": "MIT",
-  "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.7.3/team-ai-kit-v2.7.3.zip",
-  "hash": "47c101d805c49c417a3e86efc2e6a2bff39394fdd9c33305f56576120b78a036",
+  "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.7.4/team-ai-kit-v2.7.4.zip",
+  "hash": "",
   "extract_dir": "team-ai-kit",
   "bin": [
     [


### PR DESCRIPTION
﻿Closes #255

## PR Type
- [x] Maintenance/tooling

## Summary
- Bump team-ai-kit version from 2.7.3 to 2.7.4
- Includes engram Scoop manifest update to v1.14.4 (PR #254)

## Changes

| File | Change |
|------|--------|
| `bin/team-ai-kit.ps1` | KIT_VERSION 2.7.3 -> 2.7.4 |
| `bin/team-ai-kit` | KIT_VERSION 2.7.3 -> 2.7.4 |
| `scoop/team-ai-kit.json` | version + URL 2.7.3 -> 2.7.4, hash cleared for release |

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
