### PR TITLE
chore(scoop): update team-ai-kit manifest hash for v2.7.4

### DIFF
--- a/scoop/team-ai-kit.json
+++ b/scoop/team-ai-kit.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/lazarogadiel93/team-ai-kit",
   "license": "MIT",
   "url": "https://github.com/lazarogadiel93/team-ai-kit/releases/download/v2.7.4/team-ai-kit-v2.7.4.zip",
-  "hash": "",
+  "hash": "2722941e504b07679d2d8640fbe0f9b6d0b4516b65b4d8c369e7777ed9e4fd87",
   "extract_dir": "team-ai-kit",
   "bin": [
     [


### PR DESCRIPTION
﻿Closes #258

## PR Type
- [x] Maintenance/tooling

## Summary
- Update scoop/team-ai-kit.json hash to match v2.7.4 release asset (verified SHA256)

## Changes

| File | Change |
|------|--------|
| `scoop/team-ai-kit.json` | Hash updated for v2.7.4 release zip |

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
